### PR TITLE
Provide a method of creating Scatter from ndarray

### DIFF
--- a/plotly/Cargo.toml
+++ b/plotly/Cargo.toml
@@ -19,6 +19,7 @@ exclude = [
 [features]
 # Adds plot save functionality to the following formats: png, jpeg, webp, svg, pdf and eps.
 orca = ["plotly_orca"]
+ndarray_scatter = ["ndarray"]
 
 [dependencies]
 plotly_orca = { version = "0.2.1", path = "../plotly_orca", optional = true }
@@ -28,6 +29,7 @@ askama = "0.9.0"
 rand = "0.7.3"
 rand_distr = "0.2.2"
 num = "0.2.1"
+ndarray = { version = "0.13.0", optional = true }
 
 [dev-dependencies]
 plotly_orca = { version = "0.2.1", path = "../plotly_orca" }

--- a/plotly/src/scatter.rs
+++ b/plotly/src/scatter.rs
@@ -10,11 +10,7 @@ use crate::Trace;
 use serde::Serialize;
 
 #[derive(Serialize, Debug)]
-pub struct Scatter<X, Y>
-where
-    X: Serialize,
-    Y: num::Num + Serialize,
-{
+pub struct Scatter<X, Y> {
     r#type: PlotType,
     x: Vec<X>,
     y: Vec<Y>,
@@ -317,5 +313,20 @@ where
 {
     fn serialize(&self) -> String {
         serde_json::to_string(&self).unwrap()
+    }
+}
+
+impl<'a, N> Scatter<N, N>
+where
+    N: num::Num + Clone + Serialize + 'a,
+{
+    #[cfg(feature = "ndarray_scatter")]
+    pub fn from_ndarray<A>(arr: A) -> Box<Self>
+    where
+        N: ,
+        A: ndarray::AsArray<'a, N, ndarray::Ix2>,
+    {
+        let v = arr.into();
+        Scatter::new(v.row(0).to_vec(), v.row(1).to_vec())
     }
 }


### PR DESCRIPTION
Partially closes #1

I am not confident to say that it was meant in the issue :(. And I saw that @igiagkiozis you was going to implement it on your own, but it's marked as a good first one so I decided to put my hand on :)

Firstly I was willing to create a new type which implements `Trace` but after I came to that solution.
It's not ideal since it causes a ton of copies might creating a new type would be better. In which case the scatter settings may be better extracted out of the `Scatter`.

The first example in README.md using `ndarray`

```rust
extern crate plotly;
use ndarray::prelude::*;
use plotly::common::Mode;
use plotly::{Plot, Scatter};

fn line_and_scatter_plot() {
    let trace1 = Scatter::from_ndarray(&array![[1, 2, 3, 4], [10, 15, 13, 17],])
        .name("trace1")
        .mode(Mode::Markers);
    let trace2 = Scatter::from_ndarray(&array![[2, 3, 4, 5], [16, 5, 11, 9],])
        .name("trace2")
        .mode(Mode::Lines);
    let trace3 = Scatter::from_ndarray(&array![[1, 2, 3, 4], [12, 9, 15, 12],]).name("trace3");

    let mut plot = Plot::new();
    plot.add_trace(trace1);
    plot.add_trace(trace2);
    plot.add_trace(trace3);
    plot.show();
}

fn main() -> std::io::Result<()> {
    line_and_scatter_plot();

    Ok(())
}

```