### PR TITLE
Removed calls to unwrap() and expect()

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.7.0] - 2020-12-31
+### Changed
+- Removed calls to `.unwrap()` and `.expect()` in favor of returning `Result<T, Error>`
+
 
 ## [0.6.0] - 2020-07-25
 ### Added

--- a/docs/book/src/fundamentals/ndarray_support.md
+++ b/docs/book/src/fundamentals/ndarray_support.md
@@ -36,9 +36,9 @@ fn single_ndarray_trace(show: bool) {
     let mut plot = Plot::new();
     plot.add_trace(trace);
     if show {
-        plot.show();
+        plot.show().unwrap();
     }
-    println!("{}", plot.to_inline_html(Some("single_ndarray_trace")));
+    println!("{}", plot.to_inline_html(Some("single_ndarray_trace")).unwrap());
 }
 ```
 <div id="single_ndarray_trace" class="plotly-graph-div" style="height:100%; width:100%;"></div>
@@ -79,9 +79,9 @@ fn multiple_ndarray_traces_over_columns(show: bool) {
     let mut plot = Plot::new();
     plot.add_traces(traces);
     if show {
-        plot.show();
+        plot.show().unwrap();
     }
-    println!("{}", plot.to_inline_html(Some("multiple_ndarray_traces_over_columns")));
+    println!("{}", plot.to_inline_html(Some("multiple_ndarray_traces_over_columns")).unwrap());
 }
 ```
 <div id="multiple_ndarray_traces_over_columns" class="plotly-graph-div" style="height:100%; width:100%;"></div>

--- a/docs/book/src/fundamentals/shapes.md
+++ b/docs/book/src/fundamentals/shapes.md
@@ -29,9 +29,9 @@ fn filled_area_chart(show: bool) {
     plot.add_trace(trace1);
     plot.add_trace(trace2);
     if show {
-        plot.show();
+        plot.show().unwrap();
     }
-    println!("{}", plot.to_inline_html(Some("filled_area_chart")));
+    println!("{}", plot.to_inline_html(Some("filled_area_chart")).unwrap());
 }
 ```
 <div id="filled_area_chart" class="plotly-graph-div" style="height:100%; width:100%;"></div>
@@ -106,13 +106,13 @@ fn vertical_and_horizontal_lines_positioned_relative_to_axes(show: bool) {
 
     plot.set_layout(layout);
     if show {
-        plot.show();
+        plot.show().unwrap();
     }
     println!(
         "{}",
         plot.to_inline_html(Some(
             "vertical_and_horizontal_lines_positioned_relative_to_axes"
-        ))
+        )).unwrap()
     );
 }
 ```
@@ -171,13 +171,13 @@ fn lines_positioned_relative_to_the_plot_and_to_the_axes(show: bool) {
 
     plot.set_layout(layout);
     if show {
-        plot.show();
+        plot.show().unwrap();
     }
     println!(
         "{}",
         plot.to_inline_html(Some(
             "lines_positioned_relative_to_the_plot_and_to_the_axes"
-        ))
+        )).unwrap()
     );
 }
 ```
@@ -247,11 +247,11 @@ fn creating_tangent_lines_with_shapes(show: bool) {
 
     plot.set_layout(layout);
     if show {
-        plot.show();
+        plot.show().unwrap();
     }
     println!(
         "{}",
-        plot.to_inline_html(Some("creating_tangent_lines_with_shapes"))
+        plot.to_inline_html(Some("creating_tangent_lines_with_shapes")).unwrap()
     );
 }
 ```
@@ -308,11 +308,11 @@ fn rectangles_positioned_relative_to_the_axes(show: bool) {
 
     plot.set_layout(layout);
     if show {
-        plot.show();
+        plot.show().unwrap();
     }
     println!(
         "{}",
-        plot.to_inline_html(Some("rectangles_positioned_relative_to_the_axes"))
+        plot.to_inline_html(Some("rectangles_positioned_relative_to_the_axes")).unwrap()
     );
 }
 ```
@@ -373,13 +373,13 @@ fn rectangle_positioned_relative_to_the_plot_and_to_the_axes(show: bool) {
 
     plot.set_layout(layout);
     if show {
-        plot.show();
+        plot.show().unwrap();
     }
     println!(
         "{}",
         plot.to_inline_html(Some(
             "rectangle_positioned_relative_to_the_plot_and_to_the_axes"
-        ))
+        )).unwrap()
     );
 }
 ```
@@ -471,13 +471,13 @@ fn highlighting_time_series_regions_with_rectangle_shapes(show: bool) {
 
     plot.set_layout(layout);
     if show {
-        plot.show();
+        plot.show().unwrap();
     }
     println!(
         "{}",
         plot.to_inline_html(Some(
             "highlighting_time_series_regions_with_rectangle_shapes"
-        ))
+        )).unwrap()
     );
 }
 ```
@@ -536,11 +536,11 @@ fn circles_positioned_relative_to_the_axes(show: bool) {
 
     plot.set_layout(layout);
     if show {
-        plot.show();
+        plot.show().unwrap();
     }
     println!(
         "{}",
-        plot.to_inline_html(Some("circles_positioned_relative_to_the_axes"))
+        plot.to_inline_html(Some("circles_positioned_relative_to_the_axes")).unwrap()
     );
 }
 ```
@@ -669,13 +669,13 @@ fn highlighting_clusters_of_scatter_points_with_circle_shapes(show: bool) {
 
     plot.set_layout(layout);
     if show {
-        plot.show();
+        plot.show().unwrap();
     }
     println!(
         "{}",
         plot.to_inline_html(Some(
             "highlighting_clusters_of_scatter_points_with_circle_shapes"
-        ))
+        )).unwrap()
     );
 }
 ```
@@ -761,11 +761,11 @@ fn venn_diagram_with_circle_shapes(show: bool) {
 
     plot.set_layout(layout);
     if show {
-        plot.show();
+        plot.show().unwrap();
     }
     println!(
         "{}",
-        plot.to_inline_html(Some("venn_diagram_with_circle_shapes"))
+        plot.to_inline_html(Some("venn_diagram_with_circle_shapes")).unwrap()
     );
 }
 ```
@@ -868,9 +868,9 @@ fn adding_shapes_to_subplots(show: bool) {
 
     plot.set_layout(layout);
     if show {
-        plot.show();
+        plot.show().unwrap();
     }
-    println!("{}", plot.to_inline_html(Some("adding_shapes_to_subplots")));
+    println!("{}", plot.to_inline_html(Some("adding_shapes_to_subplots")).unwrap());
 }
 ```
 <div id="adding_shapes_to_subplots" class="plotly-graph-div" style="height:100%; width:100%;"></div>
@@ -947,9 +947,9 @@ fn svg_paths(show: bool) {
 
     plot.set_layout(layout);
     if show {
-        plot.show();
+        plot.show().unwrap();
     }
-    println!("{}", plot.to_inline_html(Some("svg_paths")));
+    println!("{}", plot.to_inline_html(Some("svg_paths")).unwrap());
 }
 ```
 <div id="svg_paths" class="plotly-graph-div" style="height:100%; width:100%;"></div>

--- a/docs/book/src/getting_started.md
+++ b/docs/book/src/getting_started.md
@@ -66,7 +66,7 @@ fn line_and_scatter_plot() {
     plot.add_trace(trace1);
     plot.add_trace(trace2);
     plot.add_trace(trace3);
-    plot.show();
+    plot.show().unwrap();
 }
 
 fn main() -> std::io::Result<()> {

--- a/docs/book/src/recipes/basic_charts/bar_charts.md
+++ b/docs/book/src/recipes/basic_charts/bar_charts.md
@@ -16,16 +16,16 @@ The `to_inline_html` method is used to produce the html plot displayed in this p
 
 
 ## Basic Bar Chart
-```rust 
+```rust
 fn basic_bar_chart(show: bool) {
     let animals = vec!["giraffes", "orangutans", "monkeys"];
     let t = Bar::new(animals, vec![20, 14, 23]);
     let mut plot = Plot::new();
     plot.add_trace(t);
     if show {
-        plot.show();
+        plot.show().unwrap();
     }
-    println!("{}", plot.to_inline_html(Some("basic_bar_chart")));
+    println!("{}", plot.to_inline_html(Some("basic_bar_chart")).unwrap());
 }
 
 ```
@@ -43,7 +43,7 @@ var layout = {};
 </script>
 
 ## Grouped Bar Chart
-```rust 
+```rust
 fn grouped_bar_chart(show: bool) {
     let animals1 = vec!["giraffes", "orangutans", "monkeys"];
     let trace1 = Bar::new(animals1, vec![20, 14, 23]).name("SF Zoo");
@@ -58,9 +58,9 @@ fn grouped_bar_chart(show: bool) {
     plot.add_trace(trace2);
     plot.set_layout(layout);
     if show {
-        plot.show();
+        plot.show().unwrap();
     }
-    println!("{}", plot.to_inline_html(Some("grouped_bar_chart")));
+    println!("{}", plot.to_inline_html(Some("grouped_bar_chart")).unwrap());
 }
 ```
 <div id="grouped_bar_chart" class="plotly-graph-div" style="height:100%; width:100%;"></div>
@@ -79,7 +79,7 @@ var layout = {"barmode":"group"};
 
 
 ## Stacked Bar Chart
-```rust 
+```rust
 fn stacked_bar_chart(show: bool) {
     let animals1 = vec!["giraffes", "orangutans", "monkeys"];
     let trace1 = Bar::new(animals1, vec![20, 14, 23]).name("SF Zoo");
@@ -94,9 +94,9 @@ fn stacked_bar_chart(show: bool) {
     plot.add_trace(trace2);
     plot.set_layout(layout);
     if show {
-        plot.show();
+        plot.show().unwrap();
     }
-    println!("{}", plot.to_inline_html(Some("stacked_bar_chart")));
+    println!("{}", plot.to_inline_html(Some("stacked_bar_chart")).unwrap());
 }
 ```
 <div id="stacked_bar_chart" class="plotly-graph-div" style="height:100%; width:100%;"></div>

--- a/docs/book/src/recipes/basic_charts/line_charts.md
+++ b/docs/book/src/recipes/basic_charts/line_charts.md
@@ -35,9 +35,9 @@ fn adding_names_to_line_and_scatter_plot(show: bool) {
     plot.add_trace(trace3);
     plot.set_layout(layout);
     if show {
-        plot.show();
+        plot.show().unwrap();
     }
-    println!("{}", plot.to_inline_html(Some("adding_names_to_line_and_scatter_plot")));
+    println!("{}", plot.to_inline_html(Some("adding_names_to_line_and_scatter_plot")).unwrap());
 }
 
 ```
@@ -81,9 +81,9 @@ fn line_and_scatter_styling(show: bool) {
     plot.add_trace(trace3);
     plot.set_layout(layout);
     if show {
-        plot.show();
+        plot.show().unwrap();
     }
-    println!("{}", plot.to_inline_html(Some("line_and_scatter_styling")));
+    println!("{}", plot.to_inline_html(Some("line_and_scatter_styling")).unwrap());
 }
 ```
 <div id="line_and_scatter_styling" class="plotly-graph-div" style="height:100%; width:100%;"></div>
@@ -122,9 +122,9 @@ fn styling_line_plot(show: bool) {
     plot.add_trace(trace2);
     plot.set_layout(layout);
     if show {
-        plot.show();
+        plot.show().unwrap();
     }
-    println!("{}", plot.to_inline_html(Some("styling_line_plot")));
+    println!("{}", plot.to_inline_html(Some("styling_line_plot")).unwrap());
 }
 ```
 <div id="styling_line_plot" class="plotly-graph-div" style="height:100%; width:100%;"></div>
@@ -185,9 +185,9 @@ fn line_shape_options_for_interpolation(show: bool) {
     plot.add_trace(trace6);
     plot.show_png(1024, 680);
     if show {
-        plot.show();
+        plot.show().unwrap();
     }
-    println!("{}", plot.to_inline_html(Some("line_shape_options_for_interpolation")));
+    println!("{}", plot.to_inline_html(Some("line_shape_options_for_interpolation")).unwrap());
 }
 ```
 <div id="line_shape_options_for_interpolation" class="plotly-graph-div" style="height:100%; width:100%;"></div>
@@ -254,9 +254,9 @@ fn line_dash(show: bool) {
     plot.add_trace(trace5);
     plot.add_trace(trace6);
     if show {
-        plot.show();
+        plot.show().unwrap();
     }
-    println!("{}", plot.to_inline_html(Some("line_dash")));
+    println!("{}", plot.to_inline_html(Some("line_dash")).unwrap());
 }
 ```
 <div id="line_dash" class="plotly-graph-div" style="height:100%; width:100%;"></div>
@@ -375,9 +375,9 @@ fn filled_lines(show: bool) {
     plot.add_trace(trace5);
     plot.add_trace(trace6);
     if show {
-        plot.show();
+        plot.show().unwrap();
     }
-    println!("{}", plot.to_inline_html(Some("filled_lines")));
+    println!("{}", plot.to_inline_html(Some("filled_lines")).unwrap());
 }
 ```
 <div id="filled_lines" class="plotly-graph-div" style="height:100%; width:100%;"></div>

--- a/docs/book/src/recipes/financial_charts/candlestick_charts.md
+++ b/docs/book/src/recipes/financial_charts/candlestick_charts.md
@@ -78,11 +78,11 @@ fn simple_candlestick_chart(show: bool) {
     let mut plot = Plot::new();
     plot.add_trace(trace1);
     if show {
-        plot.show();
+        plot.show().unwrap();
     }
     println!(
         "{}",
-        plot.to_inline_html(Some("simple_candlestick_chart"))
+        plot.to_inline_html(Some("simple_candlestick_chart")).unwrap()
     );
 }
 ```

--- a/docs/book/src/recipes/financial_charts/ohlc_charts.md
+++ b/docs/book/src/recipes/financial_charts/ohlc_charts.md
@@ -78,11 +78,11 @@ fn simple_ohlc_chart(show: bool) {
     let mut plot = Plot::new();
     plot.add_trace(trace1);
     if show {
-        plot.show();
+        plot.show().unwrap();
     }
     println!(
         "{}",
-        plot.to_inline_html(Some("simple_ohlc_chart"))
+        plot.to_inline_html(Some("simple_ohlc_chart")).unwrap()
     );
 }
 ```

--- a/docs/book/src/recipes/financial_charts/time_series_and_date_axes.md
+++ b/docs/book/src/recipes/financial_charts/time_series_and_date_axes.md
@@ -31,11 +31,11 @@ fn time_series_plot_with_custom_date_range(show: bool) {
     plot.set_layout(layout);
 
     if show {
-        plot.show();
+        plot.show().unwrap();
     }
     println!(
         "{}",
-        plot.to_inline_html(Some("time_series_plot_with_custom_date_range"))
+        plot.to_inline_html(Some("time_series_plot_with_custom_date_range")).unwrap()
     );
 }
 
@@ -72,11 +72,11 @@ fn time_series_with_range_slider(show: bool) {
     plot.set_layout(layout);
 
     if show {
-        plot.show();
+        plot.show().unwrap();
     }
     println!(
         "{}",
-        plot.to_inline_html(Some("time_series_with_range_slider"))
+        plot.to_inline_html(Some("time_series_with_range_slider")).unwrap()
     );
 }
 ```
@@ -136,11 +136,11 @@ fn time_series_with_range_selector_buttons(show: bool) {
     plot.set_layout(layout);
 
     if show {
-        plot.show();
+        plot.show().unwrap();
     }
     println!(
         "{}",
-        plot.to_inline_html(Some("time_series_with_range_selector_buttons"))
+        plot.to_inline_html(Some("time_series_with_range_selector_buttons")).unwrap()
     );
 }
 ```
@@ -197,11 +197,11 @@ fn customizing_tick_label_formatting_by_zoom_level(show: bool) {
     plot.set_layout(layout);
 
     if show {
-        plot.show();
+        plot.show().unwrap();
     }
     println!(
         "{}",
-        plot.to_inline_html(Some("customizing_tick_label_formatting_by_zoom_level"))
+        plot.to_inline_html(Some("customizing_tick_label_formatting_by_zoom_level")).unwrap()
     );
 }
 ```

--- a/docs/book/src/recipes/scientific_charts/contour_plots.md
+++ b/docs/book/src/recipes/scientific_charts/contour_plots.md
@@ -41,9 +41,9 @@ fn simple_contour_plot(show: bool) {
 
     plot.add_trace(trace);
     if show {
-        plot.show();
+        plot.show().unwrap();
     }
-    println!("{}", plot.to_inline_html(Some("simple_contour_plot")));
+    println!("{}", plot.to_inline_html(Some("simple_contour_plot")).unwrap());
 }
 ```
 <div id="simple_contour_plot" class="plotly-graph-div" style="height:100%; width:100%;"></div>
@@ -77,11 +77,11 @@ fn colorscale_for_contour_plot(show: bool) {
     plot.set_layout(layout);
     plot.add_trace(trace);
     if show {
-        plot.show();
+        plot.show().unwrap();
     }
     println!(
         "{}",
-        plot.to_inline_html(Some("colorscale_for_contour_plot"))
+        plot.to_inline_html(Some("colorscale_for_contour_plot")).unwrap()
     );
 }
 
@@ -120,13 +120,13 @@ fn customizing_size_and_range_of_a_contour_plots_contours(show: bool) {
     plot.set_layout(layout);
     plot.add_trace(trace);
     if show {
-        plot.show();
+        plot.show().unwrap();
     }
     println!(
         "{}",
         plot.to_inline_html(Some(
             "customizing_size_and_range_of_a_contour_plots_contours"
-        ))
+        )).unwrap()
     );
 }
 ```
@@ -166,11 +166,11 @@ fn customizing_spacing_between_x_and_y_ticks(show: bool) {
     plot.set_layout(layout);
     plot.add_trace(trace);
     if show {
-        plot.show();
+        plot.show().unwrap();
     }
     println!(
         "{}",
-        plot.to_inline_html(Some("customizing_spacing_between_x_and_y_ticks"))
+        plot.to_inline_html(Some("customizing_spacing_between_x_and_y_ticks")).unwrap()
     );
 }
 ```

--- a/docs/book/src/recipes/scientific_charts/heatmaps.md
+++ b/docs/book/src/recipes/scientific_charts/heatmaps.md
@@ -19,9 +19,9 @@ fn basic_heat_map(show: bool) {
     let mut plot = Plot::new();
     plot.add_trace(trace);
     if show {
-        plot.show();
+        plot.show().unwrap();
     }
-    println!("{}", plot.to_inline_html(Some("basic_heat_map")));
+    println!("{}", plot.to_inline_html(Some("basic_heat_map")).unwrap());
 }
 ```
 <div id="basic_heat_map" class="plotly-graph-div" style="height:100%; width:100%;"></div>

--- a/docs/book/src/recipes/statistical_charts/box_plots.md
+++ b/docs/book/src/recipes/statistical_charts/box_plots.md
@@ -38,11 +38,11 @@ fn basic_box_plot(show: bool) {
     plot.add_trace(trace1);
     plot.add_trace(trace2);
     if show {
-        plot.show();
+        plot.show().unwrap();
     }
     println!(
         "{}",
-        plot.to_inline_html(Some("basic_box_plot"))
+        plot.to_inline_html(Some("basic_box_plot")).unwrap()
     );
 }
 ```
@@ -71,11 +71,11 @@ fn box_plot_that_displays_the_underlying_data(show: bool) {
     let mut plot = Plot::new();
     plot.add_trace(trace1);
     if show {
-        plot.show();
+        plot.show().unwrap();
     }
     println!(
         "{}",
-        plot.to_inline_html(Some("box_plot_that_displays_the_underlying_data"))
+        plot.to_inline_html(Some("box_plot_that_displays_the_underlying_data")).unwrap()
     );
 }
 
@@ -104,11 +104,11 @@ fn horizontal_box_plot(show: bool) {
     plot.add_trace(trace1);
     plot.add_trace(trace2);
     if show {
-        plot.show();
+        plot.show().unwrap();
     }
     println!(
         "{}",
-        plot.to_inline_html(Some("horizontal_box_plot"))
+        plot.to_inline_html(Some("horizontal_box_plot")).unwrap()
     );
 }
 ```
@@ -163,11 +163,11 @@ fn grouped_box_plot(show: bool) {
 
     plot.set_layout(layout);
     if show {
-        plot.show();
+        plot.show().unwrap();
     }
     println!(
         "{}",
-        plot.to_inline_html(Some("grouped_box_plot"))
+        plot.to_inline_html(Some("grouped_box_plot")).unwrap()
     );
 }
 ```
@@ -231,11 +231,11 @@ fn box_plot_styling_outliers(show: bool) {
     plot.add_trace(trace3);
     plot.add_trace(trace4);
     if show {
-        plot.show();
+        plot.show().unwrap();
     }
     println!(
         "{}",
-        plot.to_inline_html(Some("box_plot_styling_outliers"))
+        plot.to_inline_html(Some("box_plot_styling_outliers")).unwrap()
     );
 }
 ```
@@ -279,11 +279,11 @@ fn box_plot_styling_mean_and_standard_deviation(show: bool) {
     plot.add_trace(trace1);
     plot.add_trace(trace2);
     if show {
-        plot.show();
+        plot.show().unwrap();
     }
     println!(
         "{}",
-        plot.to_inline_html(Some("box_plot_styling_mean_and_standard_deviation"))
+        plot.to_inline_html(Some("box_plot_styling_mean_and_standard_deviation")).unwrap()
     );
 }
 ```
@@ -351,11 +351,11 @@ fn grouped_horizontal_box_plot(show: bool) {
 
     plot.set_layout(layout);
     if show {
-        plot.show();
+        plot.show().unwrap();
     }
     println!(
         "{}",
-        plot.to_inline_html(Some("grouped_horizontal_box_plot"))
+        plot.to_inline_html(Some("grouped_horizontal_box_plot")).unwrap()
     );
 }
 ```
@@ -445,11 +445,11 @@ fn fully_styled_box_plot(show: bool) {
         plot.add_trace(trace);
     }
     if show {
-        plot.show();
+        plot.show().unwrap();
     }
     println!(
         "{}",
-        plot.to_inline_html(Some("fully_styled_box_plot"))
+        plot.to_inline_html(Some("fully_styled_box_plot")).unwrap()
     );
 }
 ```

--- a/docs/book/src/recipes/statistical_charts/error_bars.md
+++ b/docs/book/src/recipes/statistical_charts/error_bars.md
@@ -25,11 +25,11 @@ fn basic_symmetric_error_bars(show: bool) {
     let mut plot = Plot::new();
     plot.add_trace(trace1);
     if show {
-        plot.show();
+        plot.show().unwrap();
     }
     println!(
         "{}",
-        plot.to_inline_html(Some("basic_symmetric_error_bars"))
+        plot.to_inline_html(Some("basic_symmetric_error_bars")).unwrap()
     );
 }
 ```
@@ -60,9 +60,9 @@ fn asymmetric_error_bars(show: bool) {
     let mut plot = Plot::new();
     plot.add_trace(trace1);
     if show {
-        plot.show();
+        plot.show().unwrap();
     }
-    println!("{}", plot.to_inline_html(Some("asymmetric_error_bars")));
+    println!("{}", plot.to_inline_html(Some("asymmetric_error_bars")).unwrap());
 }
 ```
 <div id="asymmetric_error_bars" class="plotly-graph-div" style="height:100%; width:100%;"></div>
@@ -89,11 +89,11 @@ fn error_bars_as_a_percentage_of_the_y_value(show: bool) {
     let mut plot = Plot::new();
     plot.add_trace(trace1);
     if show {
-        plot.show();
+        plot.show().unwrap();
     }
     println!(
         "{}",
-        plot.to_inline_html(Some("error_bars_as_a_percentage_of_the_y_value"))
+        plot.to_inline_html(Some("error_bars_as_a_percentage_of_the_y_value")).unwrap()
     );
 }
 ```
@@ -126,11 +126,11 @@ fn asymmetric_error_bars_with_a_constant_offset(show: bool) {
     let mut plot = Plot::new();
     plot.add_trace(trace1);
     if show {
-        plot.show();
+        plot.show().unwrap();
     }
     println!(
         "{}",
-        plot.to_inline_html(Some("asymmetric_error_bars_with_a_constant_offset"))
+        plot.to_inline_html(Some("asymmetric_error_bars_with_a_constant_offset")).unwrap()
     );
 }
 
@@ -159,9 +159,9 @@ fn horizontal_error_bars(show: bool) {
     let mut plot = Plot::new();
     plot.add_trace(trace1);
     if show {
-        plot.show();
+        plot.show().unwrap();
     }
-    println!("{}", plot.to_inline_html(Some("horizontal_error_bars")));
+    println!("{}", plot.to_inline_html(Some("horizontal_error_bars")).unwrap());
 }
 ```
 <div id="horizontal_error_bars" class="plotly-graph-div" style="height:100%; width:100%;"></div>
@@ -194,9 +194,9 @@ fn bar_chart_with_error_bars(show: bool) {
     plot.set_layout(layout);
 
     if show {
-        plot.show();
+        plot.show().unwrap();
     }
-    println!("{}", plot.to_inline_html(Some("bar_chart_with_error_bars")));
+    println!("{}", plot.to_inline_html(Some("bar_chart_with_error_bars")).unwrap());
 }
 ```
 <div id="bar_chart_with_error_bars" class="plotly-graph-div" style="height:100%; width:100%;"></div>
@@ -254,11 +254,11 @@ fn colored_and_styled_error_bars(show: bool) {
     plot.add_trace(trace2);
 
     if show {
-        plot.show();
+        plot.show().unwrap();
     }
     println!(
         "{}",
-        plot.to_inline_html(Some("colored_and_styled_error_bars"))
+        plot.to_inline_html(Some("colored_and_styled_error_bars")).unwrap()
     );
 }
 ```

--- a/docs/book/src/recipes/statistical_charts/histograms.md
+++ b/docs/book/src/recipes/statistical_charts/histograms.md
@@ -24,11 +24,11 @@ fn basic_histogram(show: bool) {
     let mut plot = Plot::new();
     plot.add_trace(trace);
     if show {
-        plot.show();
+        plot.show().unwrap();
     }
     println!(
         "{}",
-        plot.to_inline_html(Some("basic_histogram"))
+        plot.to_inline_html(Some("basic_histogram")).unwrap()
     );
 }
 ```
@@ -57,11 +57,11 @@ fn horizontal_histogram(show: bool) {
 
     plot.add_trace(trace);
     if show {
-        plot.show();
+        plot.show().unwrap();
     }
     println!(
         "{}",
-        plot.to_inline_html(Some("horizontal_histogram"))
+        plot.to_inline_html(Some("horizontal_histogram")).unwrap()
     );
 }
 ```
@@ -101,11 +101,11 @@ fn overlaid_histogram(show: bool) {
     let layout = Layout::new().bar_mode(BarMode::Overlay);
     plot.set_layout(layout);
     if show {
-        plot.show();
+        plot.show().unwrap();
     }
     println!(
         "{}",
-        plot.to_inline_html(Some("overlaid_histogram"))
+        plot.to_inline_html(Some("overlaid_histogram")).unwrap()
     );
 }
 ```
@@ -146,11 +146,11 @@ fn stacked_histograms(show: bool) {
     let layout = Layout::new().bar_mode(BarMode::Stack);
     plot.set_layout(layout);
     if show {
-        plot.show();
+        plot.show().unwrap();
     }
     println!(
         "{}",
-        plot.to_inline_html(Some("stacked_histograms"))
+        plot.to_inline_html(Some("stacked_histograms")).unwrap()
     );
 }
 ```
@@ -213,11 +213,11 @@ fn colored_and_styled_histograms(show: bool) {
     plot.add_trace(trace1);
     plot.add_trace(trace2);
     if show {
-        plot.show();
+        plot.show().unwrap();
     }
     println!(
         "{}",
-        plot.to_inline_html(Some("colored_and_styled_histograms"))
+        plot.to_inline_html(Some("colored_and_styled_histograms")).unwrap()
     );
 }
 ```
@@ -247,11 +247,11 @@ fn cumulative_histogram(show: bool) {
     let mut plot = Plot::new();
     plot.add_trace(trace);
     if show {
-        plot.show();
+        plot.show().unwrap();
     }
     println!(
         "{}",
-        plot.to_inline_html(Some("cumulative_histogram"))
+        plot.to_inline_html(Some("cumulative_histogram")).unwrap()
     );
 }
 ```
@@ -280,11 +280,11 @@ fn normalized_histogram(show: bool) {
     let mut plot = Plot::new();
     plot.add_trace(trace);
     if show {
-        plot.show();
+        plot.show().unwrap();
     }
     println!(
         "{}",
-        plot.to_inline_html(Some("normalized_histogram"))
+        plot.to_inline_html(Some("normalized_histogram")).unwrap()
     );
 }
 ```
@@ -319,11 +319,11 @@ fn specify_binning_function(show: bool) {
     plot.add_trace(trace1);
     plot.add_trace(trace2);
     if show {
-        plot.show();
+        plot.show().unwrap();
     }
     println!(
         "{}",
-        plot.to_inline_html(Some("specify_binning_function"))
+        plot.to_inline_html(Some("specify_binning_function")).unwrap()
     );
 }
 

--- a/docs/book/src/recipes/subplots/multiple_axes.md
+++ b/docs/book/src/recipes/subplots/multiple_axes.md
@@ -34,9 +34,9 @@ fn two_y_axes(show: bool) {
         );
     plot.set_layout(layout);
     if show {
-        plot.show();
+        plot.show().unwrap();
     }
-    println!("{}", plot.to_inline_html(Some("two_y_axes")));
+    println!("{}", plot.to_inline_html(Some("two_y_axes")).unwrap());
 }
 ```
 <div id="two_y_axes" class="plotly-graph-div" style="height:100%; width:100%;"></div>
@@ -107,9 +107,9 @@ fn multiple_axes(show: bool) {
         );
     plot.set_layout(layout);
     if show {
-        plot.show();
+        plot.show().unwrap();
     }
-    println!("{}", plot.to_inline_html(Some("multiple_axes")));
+    println!("{}", plot.to_inline_html(Some("multiple_axes")).unwrap());
 }
 ```
 <div id="multiple_axes" class="plotly-graph-div" style="height:100%; width:100%;"></div>

--- a/docs/book/src/recipes/subplots/subplots.md
+++ b/docs/book/src/recipes/subplots/subplots.md
@@ -36,7 +36,7 @@ fn simple_subplot(show: bool) {
     }
     println!(
         "{}",
-        plot.to_inline_html(Some("simple_subplot"))
+        plot.to_inline_html(Some("simple_subplot")).unwrap()
     );
 }
 ```
@@ -78,7 +78,7 @@ fn custom_sized_subplot(show: bool) {
     }
     println!(
         "{}",
-        plot.to_inline_html(Some("custom_sized_subplot"))
+        plot.to_inline_html(Some("custom_sized_subplot")).unwrap()
     );
 }
 ```
@@ -130,7 +130,7 @@ fn multiple_subplots(show: bool) {
     }
     println!(
         "{}",
-        plot.to_inline_html(Some("multiple_subplots"))
+        plot.to_inline_html(Some("multiple_subplots")).unwrap()
     );
 }
 ```
@@ -181,7 +181,7 @@ fn stacked_subplots(show: bool) {
     }
     println!(
         "{}",
-        plot.to_inline_html(Some("stacked_subplots"))
+        plot.to_inline_html(Some("stacked_subplots")).unwrap()
     );
 }
 ```
@@ -226,7 +226,7 @@ fn stacked_subplots_with_shared_x_axis(show: bool) {
     }
     println!(
         "{}",
-        plot.to_inline_html(Some("stacked_subplots_with_shared_x_axis"))
+        plot.to_inline_html(Some("stacked_subplots_with_shared_x_axis")).unwrap()
     );
 }
 ```
@@ -281,11 +281,11 @@ fn multiple_custom_sized_subplots(show: bool) {
         .y_axis4(Axis::new().domain(&[0., 0.45]).anchor("x4"));
     plot.set_layout(layout);
         if show {
-        plot.show();
+        plot.show().unwrap();
     }
     println!(
         "{}",
-        plot.to_inline_html(Some("multiple_custom_sized_subplots"))
+        plot.to_inline_html(Some("multiple_custom_sized_subplots")).unwrap()
     );
 }
 ```

--- a/plotly/Cargo.toml
+++ b/plotly/Cargo.toml
@@ -29,6 +29,7 @@ serde_json = "1.0"
 askama = "0.9.0"
 rand = "0.7.3"
 rand_distr = "0.2.2"
+thiserror = "1.0.23"
 
 
 [dev-dependencies]

--- a/plotly/examples/basic_charts.rs
+++ b/plotly/examples/basic_charts.rs
@@ -16,9 +16,12 @@ fn simple_scatter_plot(show: bool) {
     let mut plot = Plot::new();
     plot.add_trace(trace);
     if show {
-        plot.show();
+        plot.show().unwrap();
     }
-    println!("{}", plot.to_inline_html(Some("simple_scatter_plot")));
+    println!(
+        "{}",
+        plot.to_inline_html(Some("simple_scatter_plot")).unwrap()
+    );
 }
 
 fn line_and_scatter_plots(show: bool) {
@@ -56,9 +59,12 @@ fn line_and_scatter_plots(show: bool) {
     plot.add_trace(trace2);
     plot.add_trace(trace3);
     if show {
-        plot.show();
+        plot.show().unwrap();
     }
-    println!("{}", plot.to_inline_html(Some("line_and_scatter_plots")));
+    println!(
+        "{}",
+        plot.to_inline_html(Some("line_and_scatter_plots")).unwrap()
+    );
 }
 
 fn bubble_scatter_plots(show: bool) {
@@ -77,9 +83,12 @@ fn bubble_scatter_plots(show: bool) {
     let mut plot = Plot::new();
     plot.add_trace(trace1);
     if show {
-        plot.show();
+        plot.show().unwrap();
     }
-    println!("{}", plot.to_inline_html(Some("bubble_scatter_plots")));
+    println!(
+        "{}",
+        plot.to_inline_html(Some("bubble_scatter_plots")).unwrap()
+    );
 }
 
 fn data_labels_hover(show: bool) {
@@ -102,9 +111,12 @@ fn data_labels_hover(show: bool) {
         .y_axis(Axis::new().title("y".into()).range(vec![0., 8.]));
     plot.set_layout(layout);
     if show {
-        plot.show();
+        plot.show().unwrap();
     }
-    println!("{}", plot.to_inline_html(Some("data_labels_hover")));
+    println!(
+        "{}",
+        plot.to_inline_html(Some("data_labels_hover")).unwrap()
+    );
 }
 
 fn data_labels_on_the_plot(show: bool) {
@@ -129,9 +141,13 @@ fn data_labels_on_the_plot(show: bool) {
         .y_axis(Axis::new().range(vec![0., 8.]));
     plot.set_layout(layout);
     if show {
-        plot.show();
+        plot.show().unwrap();
     }
-    println!("{}", plot.to_inline_html(Some("data_labels_on_the_plot")));
+    println!(
+        "{}",
+        plot.to_inline_html(Some("data_labels_on_the_plot"))
+            .unwrap()
+    );
 }
 
 fn colored_and_styled_scatter_plot(show: bool) {
@@ -214,11 +230,12 @@ fn colored_and_styled_scatter_plot(show: bool) {
     plot.add_trace(trace4);
     plot.set_layout(layout);
     if show {
-        plot.show();
+        plot.show().unwrap();
     }
     println!(
         "{}",
         plot.to_inline_html(Some("colored_and_styled_scatter_plot"))
+            .unwrap()
     );
 }
 
@@ -260,9 +277,9 @@ fn large_data_sets(show: bool) {
     plot.add_trace(trace);
 
     if show {
-        plot.show();
+        plot.show().unwrap();
     }
-    println!("{}", plot.to_inline_html(Some("large_data_sets")));
+    println!("{}", plot.to_inline_html(Some("large_data_sets")).unwrap());
 }
 
 // Line Charts
@@ -284,11 +301,12 @@ fn adding_names_to_line_and_scatter_plot(show: bool) {
     plot.add_trace(trace3);
     plot.set_layout(layout);
     if show {
-        plot.show();
+        plot.show().unwrap();
     }
     println!(
         "{}",
         plot.to_inline_html(Some("adding_names_to_line_and_scatter_plot"))
+            .unwrap()
     );
 }
 
@@ -314,9 +332,13 @@ fn line_and_scatter_styling(show: bool) {
     plot.add_trace(trace3);
     plot.set_layout(layout);
     if show {
-        plot.show();
+        plot.show().unwrap();
     }
-    println!("{}", plot.to_inline_html(Some("line_and_scatter_styling")));
+    println!(
+        "{}",
+        plot.to_inline_html(Some("line_and_scatter_styling"))
+            .unwrap()
+    );
 }
 
 fn styling_line_plot(show: bool) {
@@ -338,9 +360,12 @@ fn styling_line_plot(show: bool) {
     plot.add_trace(trace2);
     plot.set_layout(layout);
     if show {
-        plot.show();
+        plot.show().unwrap();
     }
-    println!("{}", plot.to_inline_html(Some("styling_line_plot")));
+    println!(
+        "{}",
+        plot.to_inline_html(Some("styling_line_plot")).unwrap()
+    );
 }
 
 fn line_shape_options_for_interpolation(show: bool) {
@@ -383,13 +408,14 @@ fn line_shape_options_for_interpolation(show: bool) {
     plot.add_trace(trace4);
     plot.add_trace(trace5);
     plot.add_trace(trace6);
-    plot.show_png(1024, 680);
+    plot.show_png(1024, 680).unwrap();
     if show {
-        plot.show();
+        plot.show().unwrap();
     }
     println!(
         "{}",
         plot.to_inline_html(Some("line_shape_options_for_interpolation"))
+            .unwrap()
     );
 }
 
@@ -437,9 +463,9 @@ fn line_dash(show: bool) {
     plot.add_trace(trace5);
     plot.add_trace(trace6);
     if show {
-        plot.show();
+        plot.show().unwrap();
     }
-    println!("{}", plot.to_inline_html(Some("line_dash")));
+    println!("{}", plot.to_inline_html(Some("line_dash")).unwrap());
 }
 
 fn filled_lines(show: bool) {
@@ -534,9 +560,9 @@ fn filled_lines(show: bool) {
     plot.add_trace(trace5);
     plot.add_trace(trace6);
     if show {
-        plot.show();
+        plot.show().unwrap();
     }
-    println!("{}", plot.to_inline_html(Some("filled_lines")));
+    println!("{}", plot.to_inline_html(Some("filled_lines")).unwrap());
 }
 
 // Bar Charts
@@ -546,9 +572,9 @@ fn basic_bar_chart(show: bool) {
     let mut plot = Plot::new();
     plot.add_trace(t);
     if show {
-        plot.show();
+        plot.show().unwrap();
     }
-    println!("{}", plot.to_inline_html(Some("basic_bar_chart")));
+    println!("{}", plot.to_inline_html(Some("basic_bar_chart")).unwrap());
 }
 
 fn grouped_bar_chart(show: bool) {
@@ -565,9 +591,12 @@ fn grouped_bar_chart(show: bool) {
     plot.add_trace(trace2);
     plot.set_layout(layout);
     if show {
-        plot.show();
+        plot.show().unwrap();
     }
-    println!("{}", plot.to_inline_html(Some("grouped_bar_chart")));
+    println!(
+        "{}",
+        plot.to_inline_html(Some("grouped_bar_chart")).unwrap()
+    );
 }
 
 fn stacked_bar_chart(show: bool) {
@@ -584,9 +613,12 @@ fn stacked_bar_chart(show: bool) {
     plot.add_trace(trace2);
     plot.set_layout(layout);
     if show {
-        plot.show();
+        plot.show().unwrap();
     }
-    println!("{}", plot.to_inline_html(Some("stacked_bar_chart")));
+    println!(
+        "{}",
+        plot.to_inline_html(Some("stacked_bar_chart")).unwrap()
+    );
 }
 
 fn main() -> std::io::Result<()> {

--- a/plotly/examples/financial_charts.rs
+++ b/plotly/examples/financial_charts.rs
@@ -52,11 +52,12 @@ fn time_series_plot_with_custom_date_range(show: bool) {
     plot.set_layout(layout);
 
     if show {
-        plot.show();
+        plot.show().unwrap();
     }
     println!(
         "{}",
         plot.to_inline_html(Some("time_series_plot_with_custom_date_range"))
+            .unwrap()
     );
 }
 
@@ -76,11 +77,12 @@ fn time_series_with_range_slider(show: bool) {
     plot.set_layout(layout);
 
     if show {
-        plot.show();
+        plot.show().unwrap();
     }
     println!(
         "{}",
         plot.to_inline_html(Some("time_series_with_range_slider"))
+            .unwrap()
     );
 }
 
@@ -124,11 +126,12 @@ fn time_series_with_range_selector_buttons(show: bool) {
     plot.set_layout(layout);
 
     if show {
-        plot.show();
+        plot.show().unwrap();
     }
     println!(
         "{}",
         plot.to_inline_html(Some("time_series_with_range_selector_buttons"))
+            .unwrap()
     );
 }
 
@@ -169,11 +172,12 @@ fn customizing_tick_label_formatting_by_zoom_level(show: bool) {
     plot.set_layout(layout);
 
     if show {
-        plot.show();
+        plot.show().unwrap();
     }
     println!(
         "{}",
         plot.to_inline_html(Some("customizing_tick_label_formatting_by_zoom_level"))
+            .unwrap()
     );
 }
 
@@ -241,9 +245,13 @@ fn simple_candlestick_chart(show: bool) {
     let mut plot = Plot::new();
     plot.add_trace(trace1);
     if show {
-        plot.show();
+        plot.show().unwrap();
     }
-    println!("{}", plot.to_inline_html(Some("simple_candlestick_chart")));
+    println!(
+        "{}",
+        plot.to_inline_html(Some("simple_candlestick_chart"))
+            .unwrap()
+    );
 }
 
 // OHLC Charts
@@ -310,9 +318,12 @@ fn simple_ohlc_chart(show: bool) {
     let mut plot = Plot::new();
     plot.add_trace(trace1);
     if show {
-        plot.show();
+        plot.show().unwrap();
     }
-    println!("{}", plot.to_inline_html(Some("simple_ohlc_chart")));
+    println!(
+        "{}",
+        plot.to_inline_html(Some("simple_ohlc_chart")).unwrap()
+    );
 }
 
 fn main() -> std::io::Result<()> {

--- a/plotly/examples/fundamentals.rs
+++ b/plotly/examples/fundamentals.rs
@@ -16,9 +16,12 @@ fn filled_area_chart(show: bool) {
     plot.add_trace(trace1);
     plot.add_trace(trace2);
     if show {
-        plot.show();
+        plot.show().unwrap();
     }
-    println!("{}", plot.to_inline_html(Some("filled_area_chart")));
+    println!(
+        "{}",
+        plot.to_inline_html(Some("filled_area_chart")).unwrap()
+    );
 }
 
 fn vertical_and_horizontal_lines_positioned_relative_to_axes(show: bool) {
@@ -76,13 +79,14 @@ fn vertical_and_horizontal_lines_positioned_relative_to_axes(show: bool) {
 
     plot.set_layout(layout);
     if show {
-        plot.show();
+        plot.show().unwrap();
     }
     println!(
         "{}",
         plot.to_inline_html(Some(
             "vertical_and_horizontal_lines_positioned_relative_to_axes"
         ))
+        .unwrap()
     );
 }
 
@@ -125,13 +129,14 @@ fn lines_positioned_relative_to_the_plot_and_to_the_axes(show: bool) {
 
     plot.set_layout(layout);
     if show {
-        plot.show();
+        plot.show().unwrap();
     }
     println!(
         "{}",
         plot.to_inline_html(Some(
             "lines_positioned_relative_to_the_plot_and_to_the_axes"
         ))
+        .unwrap()
     );
 }
 
@@ -185,11 +190,12 @@ fn creating_tangent_lines_with_shapes(show: bool) {
 
     plot.set_layout(layout);
     if show {
-        plot.show();
+        plot.show().unwrap();
     }
     println!(
         "{}",
         plot.to_inline_html(Some("creating_tangent_lines_with_shapes"))
+            .unwrap()
     );
 }
 
@@ -230,11 +236,12 @@ fn rectangles_positioned_relative_to_the_axes(show: bool) {
 
     plot.set_layout(layout);
     if show {
-        plot.show();
+        plot.show().unwrap();
     }
     println!(
         "{}",
         plot.to_inline_html(Some("rectangles_positioned_relative_to_the_axes"))
+            .unwrap()
     );
 }
 
@@ -279,13 +286,14 @@ fn rectangle_positioned_relative_to_the_plot_and_to_the_axes(show: bool) {
 
     plot.set_layout(layout);
     if show {
-        plot.show();
+        plot.show().unwrap();
     }
     println!(
         "{}",
         plot.to_inline_html(Some(
             "rectangle_positioned_relative_to_the_plot_and_to_the_axes"
         ))
+        .unwrap()
     );
 }
 
@@ -361,13 +369,14 @@ fn highlighting_time_series_regions_with_rectangle_shapes(show: bool) {
 
     plot.set_layout(layout);
     if show {
-        plot.show();
+        plot.show().unwrap();
     }
     println!(
         "{}",
         plot.to_inline_html(Some(
             "highlighting_time_series_regions_with_rectangle_shapes"
         ))
+        .unwrap()
     );
 }
 
@@ -410,11 +419,12 @@ fn circles_positioned_relative_to_the_axes(show: bool) {
 
     plot.set_layout(layout);
     if show {
-        plot.show();
+        plot.show().unwrap();
     }
     println!(
         "{}",
         plot.to_inline_html(Some("circles_positioned_relative_to_the_axes"))
+            .unwrap()
     );
 }
 
@@ -527,13 +537,14 @@ fn highlighting_clusters_of_scatter_points_with_circle_shapes(show: bool) {
 
     plot.set_layout(layout);
     if show {
-        plot.show();
+        plot.show().unwrap();
     }
     println!(
         "{}",
         plot.to_inline_html(Some(
             "highlighting_clusters_of_scatter_points_with_circle_shapes"
         ))
+        .unwrap()
     );
 }
 
@@ -600,11 +611,12 @@ fn venn_diagram_with_circle_shapes(show: bool) {
 
     plot.set_layout(layout);
     if show {
-        plot.show();
+        plot.show().unwrap();
     }
     println!(
         "{}",
         plot.to_inline_html(Some("venn_diagram_with_circle_shapes"))
+            .unwrap()
     );
 }
 
@@ -691,9 +703,13 @@ fn adding_shapes_to_subplots(show: bool) {
 
     plot.set_layout(layout);
     if show {
-        plot.show();
+        plot.show().unwrap();
     }
-    println!("{}", plot.to_inline_html(Some("adding_shapes_to_subplots")));
+    println!(
+        "{}",
+        plot.to_inline_html(Some("adding_shapes_to_subplots"))
+            .unwrap()
+    );
 }
 
 fn svg_paths(show: bool) {
@@ -751,9 +767,9 @@ fn svg_paths(show: bool) {
 
     plot.set_layout(layout);
     if show {
-        plot.show();
+        plot.show().unwrap();
     }
-    println!("{}", plot.to_inline_html(Some("svg_paths")));
+    println!("{}", plot.to_inline_html(Some("svg_paths")).unwrap());
 }
 
 fn main() -> std::io::Result<()> {

--- a/plotly/examples/jupyter_notebook_examples.ipynb
+++ b/plotly/examples/jupyter_notebook_examples.ipynb
@@ -24,7 +24,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 6,
+   "execution_count": 4,
    "metadata": {
     "scrolled": true
    },
@@ -41,7 +41,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 9,
+   "execution_count": 7,
    "metadata": {
     "scrolled": true
    },
@@ -50,22 +50,22 @@
      "data": {
       "text/html": [
        "<div>\n",
-       "    <div id=\"LbkgUVmz2gqtoB3MWoay\" class=\"plotly-graph-div\" style=\"height:100%; width:100%;\"></div>\n",
+       "    <div id=\"Q3JtVbLDAPgE11vgP9gI\" class=\"plotly-graph-div\" style=\"height:100%; width:100%;\"></div>\n",
        "    <script type=\"text/javascript\">\n",
        "        require(['https://cdn.plot.ly/plotly-1.54.6.min.js'], function(Plotly) {\n",
        "            window.PLOTLYENV=window.PLOTLYENV || {};\n",
        "\n",
-       "            if (document.getElementById(\"LbkgUVmz2gqtoB3MWoay\")) {\n",
+       "            if (document.getElementById(\"Q3JtVbLDAPgE11vgP9gI\")) {\n",
        "                var trace_0 = {\"type\":\"scatter\",\"mode\":\"markers\",\"x\":[1,2,3,4,5,6,7,8,9,10],\"y\":[1.0,4.0,9.0,16.0,25.0,36.0,49.0,64.0,81.0,100.0]};\n",
        "var data = [trace_0];\n",
        "var layout = {\"height\":525};\n",
        "                Plotly.newPlot(\n",
-       "                    'LbkgUVmz2gqtoB3MWoay',\n",
+       "                    'Q3JtVbLDAPgE11vgP9gI',\n",
        "                    data,\n",
        "                    layout,\n",
        "                    {\"responsive\": true}\n",
        "                ).then(function(){\n",
-       "                    var gd = document.getElementById('LbkgUVmz2gqtoB3MWoay');\n",
+       "                    var gd = document.getElementById('Q3JtVbLDAPgE11vgP9gI');\n",
        "                    var x = new MutationObserver(function (mutations, observer) { {\n",
        "                            var display = window.getComputedStyle(gd).display;\n",
        "                            if (!display || display === 'none') { {\n",
@@ -92,7 +92,7 @@
        "</div>"
       ]
      },
-     "execution_count": 9,
+     "execution_count": 7,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -108,6 +108,60 @@
     "plot.set_layout(layout);\n",
     "plot.notebook_display();"
    ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 9,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "thread '<unnamed>' panicked at 'Foo', src/lib.rs:154:1\n",
+      "stack backtrace:\n",
+      "   0: std::panicking::begin_panic\n",
+      "   1: run_user_code_7\n",
+      "   2: evcxr::runtime::Runtime::run_loop\n",
+      "   3: evcxr::runtime::runtime_hook\n",
+      "   4: evcxr_jupyter::main\n",
+      "note: Some details are omitted, run with `RUST_BACKTRACE=full` for a verbose backtrace.\n",
+      "Segmentation fault.\n",
+      "   0: evcxr::runtime::Runtime::install_crash_handlers::segfault_handler\n",
+      "   1: <unknown>\n",
+      "   2: core::ptr::drop_in_place\n",
+      "             at /rustc/7eac88abb2e57e752f3302f02be5f3ce3d7adfb4/library/core/src/ptr/mod.rs:175:1\n",
+      "      core::ptr::drop_in_place\n",
+      "             at /rustc/7eac88abb2e57e752f3302f02be5f3ce3d7adfb4/library/core/src/ptr/mod.rs:175:1\n",
+      "      core::result::Result<T,E>::unwrap_or\n",
+      "             at /rustc/7eac88abb2e57e752f3302f02be5f3ce3d7adfb4/library/core/src/result.rs:805:5\n",
+      "      std::rt::lang_start_internal\n",
+      "             at /rustc/7eac88abb2e57e752f3302f02be5f3ce3d7adfb4/library/std/src/rt.rs:54:9\n",
+      "   3: main\n",
+      "   4: __libc_start_main\n",
+      "   5: _start\n",
+      "\n"
+     ]
+    },
+    {
+     "ename": "Error",
+     "evalue": "Child process terminated with status: signal: 6",
+     "output_type": "error",
+     "traceback": [
+      "Child process terminated with status: signal: 6"
+     ]
+    }
+   ],
+   "source": [
+    "panic! (\"Foo\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": []
   }
  ],
  "metadata": {

--- a/plotly/examples/ndarray_support.rs
+++ b/plotly/examples/ndarray_support.rs
@@ -1,8 +1,7 @@
-use plotly::common::{Mode};
-use plotly::{Plot, Scatter};
 use ndarray::{Array, Ix1, Ix2};
+use plotly::common::Mode;
 use plotly::ndarray::ArrayTraces;
-
+use plotly::{Plot, Scatter};
 
 fn single_ndarray_trace(show: bool) {
     let n: usize = 11;
@@ -14,9 +13,12 @@ fn single_ndarray_trace(show: bool) {
     let mut plot = Plot::new();
     plot.add_trace(trace);
     if show {
-        plot.show();
+        plot.show().unwrap();
     }
-    println!("{}", plot.to_inline_html(Some("single_ndarray_trace")));
+    println!(
+        "{}",
+        plot.to_inline_html(Some("single_ndarray_trace")).unwrap()
+    );
 }
 
 fn multiple_ndarray_traces_over_columns(show: bool) {
@@ -39,9 +41,13 @@ fn multiple_ndarray_traces_over_columns(show: bool) {
     let mut plot = Plot::new();
     plot.add_traces(traces);
     if show {
-        plot.show();
+        plot.show().unwrap();
     }
-    println!("{}", plot.to_inline_html(Some("multiple_ndarray_traces_over_columns")));
+    println!(
+        "{}",
+        plot.to_inline_html(Some("multiple_ndarray_traces_over_columns"))
+            .unwrap()
+    );
 }
 
 fn multiple_ndarray_traces_over_rows(show: bool) {
@@ -64,9 +70,13 @@ fn multiple_ndarray_traces_over_rows(show: bool) {
     let mut plot = Plot::new();
     plot.add_traces(traces);
     if show {
-        plot.show();
+        plot.show().unwrap();
     }
-    println!("{}", plot.to_inline_html(Some("multiple_ndarray_traces_over_rows")));
+    println!(
+        "{}",
+        plot.to_inline_html(Some("multiple_ndarray_traces_over_rows"))
+            .unwrap()
+    );
 }
 
 fn main() -> std::io::Result<()> {

--- a/plotly/examples/scientific_charts.rs
+++ b/plotly/examples/scientific_charts.rs
@@ -32,9 +32,12 @@ fn simple_contour_plot(show: bool) {
 
     plot.add_trace(trace);
     if show {
-        plot.show();
+        plot.show().unwrap();
     }
-    println!("{}", plot.to_inline_html(Some("simple_contour_plot")));
+    println!(
+        "{}",
+        plot.to_inline_html(Some("simple_contour_plot")).unwrap()
+    );
 }
 
 fn colorscale_for_contour_plot(show: bool) {
@@ -52,11 +55,12 @@ fn colorscale_for_contour_plot(show: bool) {
     plot.set_layout(layout);
     plot.add_trace(trace);
     if show {
-        plot.show();
+        plot.show().unwrap();
     }
     println!(
         "{}",
         plot.to_inline_html(Some("colorscale_for_contour_plot"))
+            .unwrap()
     );
 }
 
@@ -78,13 +82,14 @@ fn customizing_size_and_range_of_a_contour_plots_contours(show: bool) {
     plot.set_layout(layout);
     plot.add_trace(trace);
     if show {
-        plot.show();
+        plot.show().unwrap();
     }
     println!(
         "{}",
         plot.to_inline_html(Some(
             "customizing_size_and_range_of_a_contour_plots_contours"
         ))
+        .unwrap()
     );
 }
 
@@ -108,11 +113,12 @@ fn customizing_spacing_between_x_and_y_ticks(show: bool) {
     plot.set_layout(layout);
     plot.add_trace(trace);
     if show {
-        plot.show();
+        plot.show().unwrap();
     }
     println!(
         "{}",
         plot.to_inline_html(Some("customizing_spacing_between_x_and_y_ticks"))
+            .unwrap()
     );
 }
 
@@ -123,9 +129,9 @@ fn basic_heat_map(show: bool) {
     let mut plot = Plot::new();
     plot.add_trace(trace);
     if show {
-        plot.show();
+        plot.show().unwrap();
     }
-    println!("{}", plot.to_inline_html(Some("basic_heat_map")));
+    println!("{}", plot.to_inline_html(Some("basic_heat_map")).unwrap());
 }
 
 fn main() -> std::io::Result<()> {

--- a/plotly/examples/statistical_charts.rs
+++ b/plotly/examples/statistical_charts.rs
@@ -15,11 +15,12 @@ fn basic_symmetric_error_bars(show: bool) {
     let mut plot = Plot::new();
     plot.add_trace(trace1);
     if show {
-        plot.show();
+        plot.show().unwrap();
     }
     println!(
         "{}",
         plot.to_inline_html(Some("basic_symmetric_error_bars"))
+            .unwrap()
     );
 }
 
@@ -35,9 +36,12 @@ fn asymmetric_error_bars(show: bool) {
     let mut plot = Plot::new();
     plot.add_trace(trace1);
     if show {
-        plot.show();
+        plot.show().unwrap();
     }
-    println!("{}", plot.to_inline_html(Some("asymmetric_error_bars")));
+    println!(
+        "{}",
+        plot.to_inline_html(Some("asymmetric_error_bars")).unwrap()
+    );
 }
 
 fn error_bars_as_a_percentage_of_the_y_value(show: bool) {
@@ -48,11 +52,12 @@ fn error_bars_as_a_percentage_of_the_y_value(show: bool) {
     let mut plot = Plot::new();
     plot.add_trace(trace1);
     if show {
-        plot.show();
+        plot.show().unwrap();
     }
     println!(
         "{}",
         plot.to_inline_html(Some("error_bars_as_a_percentage_of_the_y_value"))
+            .unwrap()
     );
 }
 
@@ -69,11 +74,12 @@ fn asymmetric_error_bars_with_a_constant_offset(show: bool) {
     let mut plot = Plot::new();
     plot.add_trace(trace1);
     if show {
-        plot.show();
+        plot.show().unwrap();
     }
     println!(
         "{}",
         plot.to_inline_html(Some("asymmetric_error_bars_with_a_constant_offset"))
+            .unwrap()
     );
 }
 
@@ -85,9 +91,12 @@ fn horizontal_error_bars(show: bool) {
     let mut plot = Plot::new();
     plot.add_trace(trace1);
     if show {
-        plot.show();
+        plot.show().unwrap();
     }
-    println!("{}", plot.to_inline_html(Some("horizontal_error_bars")));
+    println!(
+        "{}",
+        plot.to_inline_html(Some("horizontal_error_bars")).unwrap()
+    );
 }
 
 fn bar_chart_with_error_bars(show: bool) {
@@ -104,9 +113,13 @@ fn bar_chart_with_error_bars(show: bool) {
     plot.set_layout(layout);
 
     if show {
-        plot.show();
+        plot.show().unwrap();
     }
-    println!("{}", plot.to_inline_html(Some("bar_chart_with_error_bars")));
+    println!(
+        "{}",
+        plot.to_inline_html(Some("bar_chart_with_error_bars"))
+            .unwrap()
+    );
 }
 
 fn colored_and_styled_error_bars(show: bool) {
@@ -147,11 +160,12 @@ fn colored_and_styled_error_bars(show: bool) {
     plot.add_trace(trace2);
 
     if show {
-        plot.show();
+        plot.show().unwrap();
     }
     println!(
         "{}",
         plot.to_inline_html(Some("colored_and_styled_error_bars"))
+            .unwrap()
     );
 }
 
@@ -176,9 +190,9 @@ fn basic_box_plot(show: bool) {
     plot.add_trace(trace1);
     plot.add_trace(trace2);
     if show {
-        plot.show();
+        plot.show().unwrap();
     }
-    println!("{}", plot.to_inline_html(Some("basic_box_plot")));
+    println!("{}", plot.to_inline_html(Some("basic_box_plot")).unwrap());
 }
 
 fn box_plot_that_displays_the_underlying_data(show: bool) {
@@ -189,11 +203,12 @@ fn box_plot_that_displays_the_underlying_data(show: bool) {
     let mut plot = Plot::new();
     plot.add_trace(trace1);
     if show {
-        plot.show();
+        plot.show().unwrap();
     }
     println!(
         "{}",
         plot.to_inline_html(Some("box_plot_that_displays_the_underlying_data"))
+            .unwrap()
     );
 }
 
@@ -205,9 +220,12 @@ fn horizontal_box_plot(show: bool) {
     plot.add_trace(trace1);
     plot.add_trace(trace2);
     if show {
-        plot.show();
+        plot.show().unwrap();
     }
-    println!("{}", plot.to_inline_html(Some("horizontal_box_plot")));
+    println!(
+        "{}",
+        plot.to_inline_html(Some("horizontal_box_plot")).unwrap()
+    );
 }
 
 fn grouped_box_plot(show: bool) {
@@ -244,9 +262,9 @@ fn grouped_box_plot(show: bool) {
 
     plot.set_layout(layout);
     if show {
-        plot.show();
+        plot.show().unwrap();
     }
-    println!("{}", plot.to_inline_html(Some("grouped_box_plot")));
+    println!("{}", plot.to_inline_html(Some("grouped_box_plot")).unwrap());
 }
 
 fn box_plot_styling_outliers(show: bool) {
@@ -291,9 +309,13 @@ fn box_plot_styling_outliers(show: bool) {
     plot.add_trace(trace3);
     plot.add_trace(trace4);
     if show {
-        plot.show();
+        plot.show().unwrap();
     }
-    println!("{}", plot.to_inline_html(Some("box_plot_styling_outliers")));
+    println!(
+        "{}",
+        plot.to_inline_html(Some("box_plot_styling_outliers"))
+            .unwrap()
+    );
 }
 
 fn box_plot_styling_mean_and_standard_deviation(show: bool) {
@@ -317,11 +339,12 @@ fn box_plot_styling_mean_and_standard_deviation(show: bool) {
     plot.add_trace(trace1);
     plot.add_trace(trace2);
     if show {
-        plot.show();
+        plot.show().unwrap();
     }
     println!(
         "{}",
         plot.to_inline_html(Some("box_plot_styling_mean_and_standard_deviation"))
+            .unwrap()
     );
 }
 
@@ -372,11 +395,12 @@ fn grouped_horizontal_box_plot(show: bool) {
 
     plot.set_layout(layout);
     if show {
-        plot.show();
+        plot.show().unwrap();
     }
     println!(
         "{}",
         plot.to_inline_html(Some("grouped_horizontal_box_plot"))
+            .unwrap()
     );
 }
 
@@ -447,9 +471,12 @@ fn fully_styled_box_plot(show: bool) {
         plot.add_trace(trace);
     }
     if show {
-        plot.show();
+        plot.show().unwrap();
     }
-    println!("{}", plot.to_inline_html(Some("fully_styled_box_plot")));
+    println!(
+        "{}",
+        plot.to_inline_html(Some("fully_styled_box_plot")).unwrap()
+    );
 }
 
 // Histograms
@@ -479,9 +506,9 @@ fn basic_histogram(show: bool) {
     let mut plot = Plot::new();
     plot.add_trace(trace);
     if show {
-        plot.show();
+        plot.show().unwrap();
     }
-    println!("{}", plot.to_inline_html(Some("basic_histogram")));
+    println!("{}", plot.to_inline_html(Some("basic_histogram")).unwrap());
 }
 
 fn horizontal_histogram(show: bool) {
@@ -493,9 +520,12 @@ fn horizontal_histogram(show: bool) {
 
     plot.add_trace(trace);
     if show {
-        plot.show();
+        plot.show().unwrap();
     }
-    println!("{}", plot.to_inline_html(Some("horizontal_histogram")));
+    println!(
+        "{}",
+        plot.to_inline_html(Some("horizontal_histogram")).unwrap()
+    );
 }
 
 fn overlaid_histogram(show: bool) {
@@ -518,9 +548,12 @@ fn overlaid_histogram(show: bool) {
     let layout = Layout::new().bar_mode(BarMode::Overlay);
     plot.set_layout(layout);
     if show {
-        plot.show();
+        plot.show().unwrap();
     }
-    println!("{}", plot.to_inline_html(Some("overlaid_histogram")));
+    println!(
+        "{}",
+        plot.to_inline_html(Some("overlaid_histogram")).unwrap()
+    );
 }
 
 fn stacked_histograms(show: bool) {
@@ -543,9 +576,12 @@ fn stacked_histograms(show: bool) {
     let layout = Layout::new().bar_mode(BarMode::Stack);
     plot.set_layout(layout);
     if show {
-        plot.show();
+        plot.show().unwrap();
     }
-    println!("{}", plot.to_inline_html(Some("stacked_histograms")));
+    println!(
+        "{}",
+        plot.to_inline_html(Some("stacked_histograms")).unwrap()
+    );
 }
 
 fn colored_and_styled_histograms(show: bool) {
@@ -590,11 +626,12 @@ fn colored_and_styled_histograms(show: bool) {
     plot.add_trace(trace1);
     plot.add_trace(trace2);
     if show {
-        plot.show();
+        plot.show().unwrap();
     }
     println!(
         "{}",
         plot.to_inline_html(Some("colored_and_styled_histograms"))
+            .unwrap()
     );
 }
 
@@ -607,9 +644,12 @@ fn cumulative_histogram(show: bool) {
     let mut plot = Plot::new();
     plot.add_trace(trace);
     if show {
-        plot.show();
+        plot.show().unwrap();
     }
-    println!("{}", plot.to_inline_html(Some("cumulative_histogram")));
+    println!(
+        "{}",
+        plot.to_inline_html(Some("cumulative_histogram")).unwrap()
+    );
 }
 
 fn normalized_histogram(show: bool) {
@@ -621,9 +661,12 @@ fn normalized_histogram(show: bool) {
     let mut plot = Plot::new();
     plot.add_trace(trace);
     if show {
-        plot.show();
+        plot.show().unwrap();
     }
-    println!("{}", plot.to_inline_html(Some("normalized_histogram")));
+    println!(
+        "{}",
+        plot.to_inline_html(Some("normalized_histogram")).unwrap()
+    );
 }
 
 fn specify_binning_function(show: bool) {
@@ -641,9 +684,13 @@ fn specify_binning_function(show: bool) {
     plot.add_trace(trace1);
     plot.add_trace(trace2);
     if show {
-        plot.show();
+        plot.show().unwrap();
     }
-    println!("{}", plot.to_inline_html(Some("specify_binning_function")));
+    println!(
+        "{}",
+        plot.to_inline_html(Some("specify_binning_function"))
+            .unwrap()
+    );
 }
 
 fn main() -> std::io::Result<()> {

--- a/plotly/examples/subplots.rs
+++ b/plotly/examples/subplots.rs
@@ -22,9 +22,9 @@ fn simple_subplot(show: bool) {
     );
     plot.set_layout(layout);
     if show {
-        plot.show();
+        plot.show().unwrap();
     }
-    println!("{}", plot.to_inline_html(Some("simple_subplot")));
+    println!("{}", plot.to_inline_html(Some("simple_subplot")).unwrap());
 }
 
 fn custom_sized_subplot(show: bool) {
@@ -44,9 +44,12 @@ fn custom_sized_subplot(show: bool) {
         .x_axis2(Axis::new().domain(&[0.8, 1.]));
     plot.set_layout(layout);
     if show {
-        plot.show();
+        plot.show().unwrap();
     }
-    println!("{}", plot.to_inline_html(Some("custom_sized_subplot")));
+    println!(
+        "{}",
+        plot.to_inline_html(Some("custom_sized_subplot")).unwrap()
+    );
 }
 
 fn multiple_subplots(show: bool) {
@@ -76,9 +79,12 @@ fn multiple_subplots(show: bool) {
     );
     plot.set_layout(layout);
     if show {
-        plot.show();
+        plot.show().unwrap();
     }
-    println!("{}", plot.to_inline_html(Some("multiple_subplots")));
+    println!(
+        "{}",
+        plot.to_inline_html(Some("multiple_subplots")).unwrap()
+    );
 }
 
 fn stacked_subplots(show: bool) {
@@ -105,9 +111,9 @@ fn stacked_subplots(show: bool) {
     );
     plot.set_layout(layout);
     if show {
-        plot.show();
+        plot.show().unwrap();
     }
-    println!("{}", plot.to_inline_html(Some("stacked_subplots")));
+    println!("{}", plot.to_inline_html(Some("stacked_subplots")).unwrap());
 }
 
 fn stacked_subplots_with_shared_x_axis(show: bool) {
@@ -129,11 +135,12 @@ fn stacked_subplots_with_shared_x_axis(show: bool) {
         .y_axis3(Axis::new().domain(&[0.66, 1.]));
     plot.set_layout(layout);
     if show {
-        plot.show();
+        plot.show().unwrap();
     }
     println!(
         "{}",
         plot.to_inline_html(Some("stacked_subplots_with_shared_x_axis"))
+            .unwrap()
     );
 }
 
@@ -170,11 +177,12 @@ fn multiple_custom_sized_subplots(show: bool) {
         .y_axis4(Axis::new().domain(&[0., 0.45]).anchor("x4"));
     plot.set_layout(layout);
     if show {
-        plot.show();
+        plot.show().unwrap();
     }
     println!(
         "{}",
         plot.to_inline_html(Some("multiple_custom_sized_subplots"))
+            .unwrap()
     );
 }
 
@@ -201,9 +209,9 @@ fn two_y_axes(show: bool) {
         );
     plot.set_layout(layout);
     if show {
-        plot.show();
+        plot.show().unwrap();
     }
-    println!("{}", plot.to_inline_html(Some("two_y_axes")));
+    println!("{}", plot.to_inline_html(Some("two_y_axes")).unwrap());
 }
 
 fn multiple_axes(show: bool) {
@@ -257,9 +265,9 @@ fn multiple_axes(show: bool) {
         );
     plot.set_layout(layout);
     if show {
-        plot.show();
+        plot.show().unwrap();
     }
-    println!("{}", plot.to_inline_html(Some("multiple_axes")));
+    println!("{}", plot.to_inline_html(Some("multiple_axes")).unwrap());
 }
 
 fn main() -> std::io::Result<()> {

--- a/plotly/src/bar.rs
+++ b/plotly/src/bar.rs
@@ -7,6 +7,7 @@ use crate::common::{
 use crate::Trace;
 use serde::Serialize;
 
+use crate::error::TraceError;
 use crate::private;
 
 #[derive(Serialize, Debug, Default)]
@@ -299,7 +300,7 @@ where
     X: Serialize + Default,
     Y: Serialize + Default,
 {
-    fn serialize(&self) -> String {
-        serde_json::to_string(&self).unwrap()
+    fn serialize(&self) -> Result<String, TraceError> {
+        Ok(serde_json::to_string(self)?)
     }
 }

--- a/plotly/src/box_plot.rs
+++ b/plotly/src/box_plot.rs
@@ -2,6 +2,7 @@
 
 use crate::common::color::{Color, ColorWrapper};
 use crate::common::{Calendar, Dim, HoverInfo, Label, Line, Marker, Orientation, PlotType};
+use crate::error::TraceError;
 use crate::private;
 use crate::Trace;
 use serde::Serialize;
@@ -382,7 +383,7 @@ where
     X: Serialize + Default,
     Y: Serialize + Default,
 {
-    fn serialize(&self) -> String {
-        serde_json::to_string(&self).unwrap()
+    fn serialize(&self) -> Result<String, TraceError> {
+        Ok(serde_json::to_string(self)?)
     }
 }

--- a/plotly/src/candlestick.rs
+++ b/plotly/src/candlestick.rs
@@ -2,6 +2,7 @@
 
 use crate::common::color::NamedColor;
 use crate::common::{Calendar, Dim, Direction, HoverInfo, Label, Line, PlotType};
+use crate::error::TraceError;
 use crate::private;
 use crate::Trace;
 use serde::Serialize;
@@ -177,7 +178,7 @@ where
     X: Serialize + Default,
     Y: Serialize + Default,
 {
-    fn serialize(&self) -> String {
-        serde_json::to_string(&self).unwrap()
+    fn serialize(&self) -> Result<String, TraceError> {
+        Ok(serde_json::to_string(self)?)
     }
 }

--- a/plotly/src/contour.rs
+++ b/plotly/src/contour.rs
@@ -2,6 +2,7 @@
 
 use crate::common::color::{Color, ColorWrapper};
 use crate::common::{Calendar, ColorBar, ColorScale, Dim, Font, HoverInfo, Label, Line, PlotType};
+use crate::error::TraceError;
 use crate::private;
 use crate::Trace;
 use serde::Serialize;
@@ -443,7 +444,7 @@ where
     Y: Serialize + Default,
     Z: Serialize + Default,
 {
-    fn serialize(&self) -> String {
-        serde_json::to_string(&self).unwrap()
+    fn serialize(&self) -> Result<String, TraceError> {
+        Ok(serde_json::to_string(self)?)
     }
 }

--- a/plotly/src/error/mod.rs
+++ b/plotly/src/error/mod.rs
@@ -1,0 +1,89 @@
+use thiserror::Error;
+
+const DEFAULT_HTML_APP_NOT_FOUND: &str = r#"Could not find default application for HTML files.
+Consider using the `to_html` method to save the plot instead. If using the `kaleido` feature the
+`save` method can be used to produce a static image in one of the following formats:
+- ImageFormat::PNG
+- ImageFormat::JPEG
+- ImageFormat::WEBP
+- ImageFormat::SVG
+- ImageFormat::PDF
+- ImageFormat::EPS
+
+used as follows:
+let plot = Plot::new();
+...
+let width = 1024;
+let height = 680;
+let scale = 1.0;
+plot.save("filename", ImageFormat::PNG, width, height, scale);
+
+See https://igiagkiozis.github.io/plotly/content/getting_started.html for further details.
+"#;
+
+#[derive(Error, Debug)]
+pub enum Error {
+    #[error("...")]
+    IOError {
+        #[from]
+        source: std::io::Error,
+    },
+
+    #[error("Failed to convert path to string: {0}")]
+    PathSerializationError(std::path::PathBuf),
+
+    #[cfg(feature = "kaleido")]
+    #[error(transparent)]
+    PlotlyKaleidoError {
+        #[from]
+        source: plotly_kaleido::error::Error,
+    },
+
+    #[error(transparent)]
+    VarError {
+        #[from]
+        source: std::env::VarError,
+    },
+
+    #[error("{msg}")]
+    NoDefaultAppError { msg: String, source: std::io::Error },
+
+    #[error(transparent)]
+    AskamaError {
+        #[from]
+        source: askama::Error,
+    },
+
+    #[error(transparent)]
+    SerdeError {
+        #[from]
+        source: serde_json::Error,
+    },
+
+    #[error(transparent)]
+    TraceError {
+        #[from]
+        source: TraceError,
+    },
+}
+
+impl Error {
+    pub fn new_default_app_error(source: std::io::Error) -> Self {
+        Error::NoDefaultAppError {
+            msg: DEFAULT_HTML_APP_NOT_FOUND.into(),
+            source,
+        }
+    }
+}
+
+#[derive(Error, Debug)]
+pub enum TraceError {
+    #[error("{0}")]
+    CustomError(String),
+
+    #[error(transparent)]
+    SerdeError {
+        #[from]
+        source: serde_json::Error,
+    },
+}

--- a/plotly/src/heat_map.rs
+++ b/plotly/src/heat_map.rs
@@ -1,6 +1,7 @@
 //! Heat-map plot
 
 use crate::common::{Calendar, ColorBar, ColorScale, Dim, HoverInfo, Label, PlotType};
+use crate::error::TraceError;
 use crate::private;
 use crate::Trace;
 use serde::Serialize;
@@ -261,7 +262,7 @@ where
     Y: Serialize + Default,
     Z: Serialize + Default,
 {
-    fn serialize(&self) -> String {
-        serde_json::to_string(&self).unwrap()
+    fn serialize(&self) -> Result<String, TraceError> {
+        Ok(serde_json::to_string(self)?)
     }
 }

--- a/plotly/src/histogram.rs
+++ b/plotly/src/histogram.rs
@@ -7,11 +7,11 @@ use serde::Serialize;
 use crate::private;
 use crate::private::copy_iterable_to_vec;
 
-#[cfg(feature = "plotly_ndarray")]
-use ndarray::{Array, Ix1, Ix2};
+use crate::error::TraceError;
 #[cfg(feature = "plotly_ndarray")]
 use crate::ndarray::ArrayTraces;
-
+#[cfg(feature = "plotly_ndarray")]
+use ndarray::{Array, Ix1, Ix2};
 
 #[derive(Serialize, Clone, Debug)]
 pub struct Bins {
@@ -517,7 +517,7 @@ impl<H> Trace for Histogram<H>
 where
     H: Serialize + Clone + Default + 'static,
 {
-    fn serialize(&self) -> String {
-        serde_json::to_string(&self).unwrap()
+    fn serialize(&self) -> Result<String, TraceError> {
+        Ok(serde_json::to_string(self)?)
     }
 }

--- a/plotly/src/layout.rs
+++ b/plotly/src/layout.rs
@@ -3,6 +3,7 @@ use crate::common::{
     Anchor, Calendar, ColorBar, ColorScale, DashType, Font, Label, Orientation, Side,
     TickFormatStop, TickMode, Title,
 };
+use crate::error::TraceError;
 use crate::plot::Trace;
 use crate::private;
 use crate::private::{to_num_or_string_wrapper, NumOrString, NumOrStringWrapper, TruthyEnum};
@@ -2745,7 +2746,7 @@ impl Layout {
 }
 
 impl Trace for Layout {
-    fn serialize(&self) -> String {
-        serde_json::to_string(&self).unwrap()
+    fn serialize(&self) -> Result<String, TraceError> {
+        Ok(serde_json::to_string(self)?)
     }
 }

--- a/plotly/src/lib.rs
+++ b/plotly/src/lib.rs
@@ -7,6 +7,8 @@ extern crate askama;
 extern crate rand;
 extern crate serde;
 
+pub mod error;
+
 pub mod ndarray;
 
 pub mod layout;

--- a/plotly/src/ohlc.rs
+++ b/plotly/src/ohlc.rs
@@ -2,6 +2,7 @@
 
 use crate::common::color::NamedColor;
 use crate::common::{Calendar, Dim, Direction, HoverInfo, Label, Line, PlotType};
+use crate::error::TraceError;
 use crate::private;
 use crate::Trace;
 use serde::Serialize;
@@ -163,7 +164,7 @@ where
     X: Serialize + Default,
     Y: Serialize + Default,
 {
-    fn serialize(&self) -> String {
-        serde_json::to_string(&self).unwrap()
+    fn serialize(&self) -> Result<String, TraceError> {
+        Ok(serde_json::to_string(self)?)
     }
 }

--- a/plotly/src/private/mod.rs
+++ b/plotly/src/private/mod.rs
@@ -1,10 +1,10 @@
 use crate::common::color::{Color, ColorWrapper};
-use serde::{Serialize, Serializer};
+use serde::{ser::Error, Serialize, Serializer};
 
 #[cfg(feature = "plotly_ndarray")]
-use ndarray::{Array, Ix2};
-#[cfg(feature = "plotly_ndarray")]
 use crate::ndarray::ArrayTraces;
+#[cfg(feature = "plotly_ndarray")]
+use ndarray::{Array, Ix2};
 
 pub trait NumOrString {
     fn to_num_or_string(&self) -> NumOrStringWrapper;
@@ -116,7 +116,7 @@ where
         S: Serializer,
     {
         let s = serde_json::to_string(&self.e)
-            .unwrap()
+            .map_err(|_| S::Error::custom("Could not deserialize JSON"))?
             .chars()
             .filter(|c| *c != '"')
             .collect::<String>();

--- a/plotly/src/scatter.rs
+++ b/plotly/src/scatter.rs
@@ -9,13 +9,14 @@ use crate::private;
 use crate::Trace;
 use serde::Serialize;
 
+use crate::error::TraceError;
+#[cfg(feature = "plotly_ndarray")]
+use crate::ndarray::ArrayTraces;
 use crate::private::{
     copy_iterable_to_vec, to_num_or_string_wrapper, NumOrString, NumOrStringWrapper, TruthyEnum,
 };
 #[cfg(feature = "plotly_ndarray")]
 use ndarray::{Array, Ix1, Ix2};
-#[cfg(feature = "plotly_ndarray")]
-use crate::ndarray::ArrayTraces;
 
 #[derive(Serialize, Clone, Debug)]
 pub struct Scatter<X, Y>
@@ -654,7 +655,7 @@ where
     X: Serialize + Clone + 'static,
     Y: Serialize + Clone + 'static,
 {
-    fn serialize(&self) -> String {
-        serde_json::to_string(&self).unwrap()
+    fn serialize(&self) -> Result<String, TraceError> {
+        Ok(serde_json::to_string(self)?)
     }
 }

--- a/plotly/src/surface.rs
+++ b/plotly/src/surface.rs
@@ -2,6 +2,7 @@
 
 use crate::common::color::{Color, ColorWrapper};
 use crate::common::{Calendar, ColorBar, ColorScale, Dim, HoverInfo, Label, PlotType};
+use crate::error::TraceError;
 use crate::private;
 use crate::Trace;
 use serde::Serialize;
@@ -477,7 +478,7 @@ where
     Y: Serialize,
     Z: Serialize,
 {
-    fn serialize(&self) -> String {
-        serde_json::to_string(&self).unwrap()
+    fn serialize(&self) -> Result<String, TraceError> {
+        Ok(serde_json::to_string(self)?)
     }
 }

--- a/plotly_kaleido/Cargo.toml
+++ b/plotly_kaleido/Cargo.toml
@@ -22,6 +22,7 @@ exclude = [
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 base64 = "0.12.3"
+thiserror = "1.0.23"
 
 [dev-dependencies]
 zip = "0.5.6"

--- a/plotly_kaleido/README.md
+++ b/plotly_kaleido/README.md
@@ -26,8 +26,8 @@ fn line_and_scatter_plot() {
     plot.add_trace(trace3);
 
     // The following will save the plot in all available formats and show the plot.
-    plot.save("scatter", ImageFormat::PNG,  1024, 680, 1.0);
-    plot.show();
+    plot.save("scatter", ImageFormat::PNG,  1024, 680, 1.0).unwrap();
+    plot.show().unwrap();
 }
 
 fn main() -> std::io::Result<()> {

--- a/plotly_kaleido/kaleido/placeholder.md
+++ b/plotly_kaleido/kaleido/placeholder.md
@@ -1,1 +1,0 @@
-placeholder for plotly/Kaleido

--- a/plotly_kaleido/src/error.rs
+++ b/plotly_kaleido/src/error.rs
@@ -1,0 +1,40 @@
+use thiserror::Error;
+
+#[derive(Error, Debug)]
+pub enum Error {
+    #[error("Could not find kaleido executable in path: {0}")]
+    ExecutableNotFound(std::path::PathBuf),
+
+    #[error("Failed to convert path to string: {0}")]
+    PathSerializationError(std::path::PathBuf),
+
+    #[error(transparent)]
+    IOError {
+        #[from]
+        source: std::io::Error,
+    },
+
+    #[error("Could not connect to kaleido stdin")]
+    StdinError,
+
+    #[error("Failed to get parent directory for process")]
+    ParentDirectoryFailed,
+
+    #[error(transparent)]
+    Base64DecodeError {
+        #[from]
+        source: base64::DecodeError,
+    },
+
+    #[error(transparent)]
+    SerdeError {
+        #[from]
+        source: serde_json::Error,
+    },
+
+    #[error(transparent)]
+    VarError {
+        #[from]
+        source: std::env::VarError,
+    },
+}


### PR DESCRIPTION
For issue #33 
This removes most calls to `.unwrap()` and `.expect()` except in example and test code as well as a handful of cases where we're guaranteed not to fail. Methods that were affected have had their signatures changed to return `Result<T, Error>`.

I implemented error types with [thiserror](https://github.com/dtolnay/thiserror) so it's easy to wrangle together the different kinds of sub-errors that can occur under a common type. A downside here is it's more difficult to annotate certain common failures (like std::io::Error) with custom messages in certain places. It might be worth investigating using [snafu](https://github.com/shepmaster/snafu) in the future to assign contexts to errors, but for now there should be enough information in the errors themselves to describe the different points of failure.