### PR TITLE
Fixed spelling from 'CirleOpen' to 'CircleOpen' in plotly/src/common/…

### DIFF
--- a/plotly/src/common/mod.rs
+++ b/plotly/src/common/mod.rs
@@ -243,7 +243,7 @@ pub enum MarkerSymbol {
     #[serde(rename = "circle")]
     Circle,
     #[serde(rename = "circle-open")]
-    CirleOpen,
+    CircleOpen,
     #[serde(rename = "circle-dot")]
     CircleDot,
     #[serde(rename = "circle-open-dot")]


### PR DESCRIPTION
…mod.rs line 246

Resolves issue 51 https://github.com/igiagkiozis/plotly/issues/51