### PR TITLE
Fix variable interpolation in HTML template

### DIFF
--- a/plotly/templates/plot.html
+++ b/plotly/templates/plot.html
@@ -14,7 +14,7 @@
         {% if remote_plotly_js -%}
         <script src="https://cdn.plot.ly/plotly-2.8.3.min.js"></script>
         {% else -%}
-        <script type="text/javascript">{ { plotly_javascript } }</script>
+        <script type="text/javascript">{{ plotly_javascript }}</script>
         {% endif -%}
         {% if export_image -%}
         <div id="plotly-html-element" class="plotly-graph-div" style="height:100%; width:100%;" hidden></div>


### PR DESCRIPTION
A previous PR broke one of the templates due to auto-formatting. This PR fixes that.