### PR TITLE
Refactor `color` module 

### DIFF
--- a/plotly/examples/basic_charts.rs
+++ b/plotly/examples/basic_charts.rs
@@ -5,7 +5,10 @@ use plotly::common::{
 };
 use plotly::layout::{Axis, BarMode, Layout, Legend, TicksDirection, TraceOrder};
 use plotly::sankey::{Line as SankeyLine, Link, Node};
-use plotly::{Bar, NamedColor, Plot, Rgb, Rgba, Sankey, Scatter, ScatterPolar};
+use plotly::{
+    color::{NamedColor, Rgb, Rgba},
+    Bar, Plot, Sankey, Scatter, ScatterPolar,
+};
 use rand_distr::{Distribution, Normal, Uniform};
 
 // Scatter Plots
@@ -254,11 +257,6 @@ fn large_data_sets(show: bool) {
         .sample_iter(&mut rng)
         .take(n)
         .collect();
-    let colors: Vec<f64> = Normal::new(0., 1.)
-        .unwrap()
-        .sample_iter(&mut rng)
-        .take(n)
-        .collect();
 
     let x: Vec<f64> = r
         .iter()
@@ -276,7 +274,6 @@ fn large_data_sets(show: bool) {
         .marker(
             Marker::new()
                 .color_scale(ColorScale::Palette(ColorScalePalette::Viridis))
-                .color_array(colors)
                 .line(Line::new().width(1.)),
         );
     let mut plot = Plot::new();
@@ -406,7 +403,6 @@ fn line_shape_options_for_interpolation(show: bool) {
     plot.add_trace(trace4);
     plot.add_trace(trace5);
     plot.add_trace(trace6);
-    plot.show_png(1024, 680);
     if show {
         plot.show();
     }

--- a/plotly/examples/fundamentals.rs
+++ b/plotly/examples/fundamentals.rs
@@ -3,7 +3,7 @@ use plotly::common::{DashType, Fill, Font, Mode};
 use plotly::layout::{
     Axis, GridPattern, Layout, LayoutGrid, Margin, Shape, ShapeLayer, ShapeLine, ShapeType,
 };
-use plotly::{Bar, NamedColor, Plot, Scatter};
+use plotly::{color::NamedColor, Bar, Plot, Scatter};
 use rand::thread_rng;
 use rand_distr::{Distribution, Normal};
 

--- a/plotly/examples/statistical_charts.rs
+++ b/plotly/examples/statistical_charts.rs
@@ -3,7 +3,10 @@ use plotly::box_plot::{BoxMean, BoxPoints};
 use plotly::common::{ErrorData, ErrorType, Line, Marker, Mode, Orientation, Title};
 use plotly::histogram::{Bins, Cumulative, HistFunc, HistNorm};
 use plotly::layout::{Axis, BarMode, BoxMode, Layout, Margin};
-use plotly::{Bar, BoxPlot, Histogram, NamedColor, Plot, Rgb, Rgba, Scatter};
+use plotly::{
+    color::{NamedColor, Rgb, Rgba},
+    Bar, BoxPlot, Histogram, Plot, Scatter,
+};
 use rand_distr::{Distribution, Normal, Uniform};
 
 // Error Bars

--- a/plotly/examples/subplots.rs
+++ b/plotly/examples/subplots.rs
@@ -1,6 +1,6 @@
 use plotly::common::{AxisSide, Font, Title};
 use plotly::layout::{Axis, GridPattern, Layout, LayoutGrid, Legend, RowOrder, TraceOrder};
-use plotly::{Plot, Rgb, Scatter};
+use plotly::{color::Rgb, Plot, Scatter};
 
 // Subplots
 fn simple_subplot(show: bool) {

--- a/plotly/src/common/color.rs
+++ b/plotly/src/common/color.rs
@@ -1,30 +1,49 @@
+//! This module provides several user interfaces for describing a color to be used throughout the rest of the library.
+//! The easiest way of describing a colour is to use a `&str` or `String`, which is simply serialized as-is and
+//! passed on to the underlying `plotly.js` library. `plotly.js` supports [`CSS color formats`], and will fallback
+//! to some default color if the color string is malformed.
+//!
+//! For a more type-safe approach, the `RGB` or `RGBA` structs can be used to construct a valid color, which will then
+//! get serialized to an appropriate string representation. Cross-browser compatible [`predefined colors`] are
+//! supported via the `NamedColor` enum.
+//!
+//! The `Color` trait is public, and so can be implemented for custom colour types. The user can then implement
+//! a valid serialization function according to their own requirements. On the whole, that should be largely
+//! unnecessary given the functionality already provided within this module.
+//!
+//! [`CSS color formats`]: https://www.w3schools.com/cssref/css_colors_legal.asp
+//! [`predefined colors`]: https://www.w3schools.com/cssref/css_colors.asp
+
+use dyn_clone::DynClone;
+use erased_serde::Serialize as ErasedSerialize;
 use serde::Serialize;
 
-#[derive(Serialize, Clone, Debug)]
-#[serde(untagged)]
-pub enum ColorWrapper {
-    S(String),
-    F(f64),
-}
+/// A marker trait allowing several ways to describe a color.
+pub trait Color: DynClone + ErasedSerialize + Send + Sync + std::fmt::Debug + 'static {}
 
-impl PartialEq for ColorWrapper {
-    fn eq(&self, other: &Self) -> bool {
-        let lhs = match self {
-            ColorWrapper::S(v) => v.to_owned(),
-            ColorWrapper::F(v) => format!("{}", v),
-        };
-        let rhs = match other {
-            ColorWrapper::S(v) => v.to_owned(),
-            ColorWrapper::F(v) => format!("{}", v),
-        };
-        lhs == rhs
+dyn_clone::clone_trait_object!(Color);
+erased_serde::serialize_trait_object!(Color);
+
+impl Color for NamedColor {}
+impl Color for &'static str {}
+impl Color for String {}
+impl Color for Rgb {}
+impl Color for Rgba {}
+
+/// ColorArray is only used internally to provide a helper method for converting Vec<impl Color2> to
+/// Vec<Box<dyn Color2>>, as we would otherwise fall foul of the orphan rules.
+pub(crate) struct ColorArray<C: Color>(pub(crate) Vec<C>);
+
+impl<C: Color> Into<Vec<Box<dyn Color>>> for ColorArray<C> {
+    fn into(self) -> Vec<Box<dyn Color>> {
+        self.0
+            .into_iter()
+            .map(|c| Box::new(c) as Box<dyn Color>)
+            .collect()
     }
 }
 
-pub trait Color {
-    fn to_color(&self) -> ColorWrapper;
-}
-
+/// A type-safe way of constructing a valid RGB color from constituent R, G and B channels.
 #[derive(Debug, Clone, Copy)]
 pub struct Rgb {
     r: u8,
@@ -33,17 +52,22 @@ pub struct Rgb {
 }
 
 impl Rgb {
+    /// Create a new Rgb instance.
     pub fn new(r: u8, g: u8, b: u8) -> Rgb {
         Rgb { r, g, b }
     }
 }
 
-impl Color for Rgb {
-    fn to_color(&self) -> ColorWrapper {
-        ColorWrapper::S(format!("rgb({}, {}, {})", self.r, self.g, self.b))
+impl Serialize for Rgb {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        serializer.serialize_str(&format!("rgb({}, {}, {})", self.r, self.g, self.b))
     }
 }
 
+/// A type-safe way of constructing a valid RGBA color from constituent R, G, B and A channels.
 #[derive(Debug, Clone, Copy)]
 pub struct Rgba {
     r: u8,
@@ -53,22 +77,29 @@ pub struct Rgba {
 }
 
 impl Rgba {
+    /// Create a new Rgba instance.
     pub fn new(r: u8, g: u8, b: u8, a: f64) -> Rgba {
         Rgba { r, g, b, a }
     }
 }
 
-impl Color for Rgba {
-    fn to_color(&self) -> ColorWrapper {
-        ColorWrapper::S(format!(
+impl Serialize for Rgba {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        serializer.serialize_str(&format!(
             "rgba({}, {}, {}, {})",
             self.r, self.g, self.b, self.a
         ))
     }
 }
 
-// https://www.w3.org/TR/css-color-3/#svg-color
-#[derive(Debug, Clone, Copy)]
+/// Cross-browser compatible [`predefined colors`].
+///
+/// [`predefined colors`]: https://www.w3schools.com/cssref/css_colors.asp
+#[derive(Debug, Clone, Copy, Serialize)]
+#[serde(rename_all = "lowercase")]
 pub enum NamedColor {
     AliceBlue,
     AntiqueWhite,
@@ -78,7 +109,7 @@ pub enum NamedColor {
     Beige,
     Bisque,
     Black,
-    BlancheDalmond,
+    BlanchedAlmond,
     Blue,
     BlueViolet,
     Brown,
@@ -87,7 +118,7 @@ pub enum NamedColor {
     Chartreuse,
     Chocolate,
     Coral,
-    CornFlowerBlue,
+    CornflowerBlue,
     CornSilk,
     Crimson,
     Cyan,
@@ -189,6 +220,7 @@ pub enum NamedColor {
     Plum,
     PowderBlue,
     Purple,
+    RebeccaPurple,
     Red,
     RosyBrown,
     RoyalBlue,
@@ -220,304 +252,184 @@ pub enum NamedColor {
     Transparent,
 }
 
-impl Color for NamedColor {
-    fn to_color(&self) -> ColorWrapper {
-        match self {
-            NamedColor::AliceBlue => ColorWrapper::S("aliceblue".to_owned()),
-            NamedColor::AntiqueWhite => ColorWrapper::S("antiquewhite".to_owned()),
-            NamedColor::Aqua => ColorWrapper::S("aqua".to_owned()),
-            NamedColor::Aquamarine => ColorWrapper::S("aquamarine".to_owned()),
-            NamedColor::Azure => ColorWrapper::S("azure".to_owned()),
-            NamedColor::Beige => ColorWrapper::S("beige".to_owned()),
-            NamedColor::Bisque => ColorWrapper::S("bisque".to_owned()),
-            NamedColor::Black => ColorWrapper::S("black".to_owned()),
-            NamedColor::BlancheDalmond => ColorWrapper::S("blanchedalmond".to_owned()),
-            NamedColor::Blue => ColorWrapper::S("blue".to_owned()),
-            NamedColor::BlueViolet => ColorWrapper::S("blueviolet".to_owned()),
-            NamedColor::Brown => ColorWrapper::S("brown".to_owned()),
-            NamedColor::BurlyWood => ColorWrapper::S("burlywood".to_owned()),
-            NamedColor::CadetBlue => ColorWrapper::S("cadetblue".to_owned()),
-            NamedColor::Chartreuse => ColorWrapper::S("chartreuse".to_owned()),
-            NamedColor::Chocolate => ColorWrapper::S("chocolate".to_owned()),
-            NamedColor::Coral => ColorWrapper::S("coral".to_owned()),
-            NamedColor::CornFlowerBlue => ColorWrapper::S("cornflowerblue".to_owned()),
-            NamedColor::CornSilk => ColorWrapper::S("cornsilk".to_owned()),
-            NamedColor::Crimson => ColorWrapper::S("crimson".to_owned()),
-            NamedColor::Cyan => ColorWrapper::S("cyan".to_owned()),
-            NamedColor::DarkBlue => ColorWrapper::S("darkblue".to_owned()),
-            NamedColor::DarkCyan => ColorWrapper::S("darkcyan".to_owned()),
-            NamedColor::DarkGoldenrod => ColorWrapper::S("darkgoldenrod".to_owned()),
-            NamedColor::DarkGray => ColorWrapper::S("darkgray".to_owned()),
-            NamedColor::DarkGreen => ColorWrapper::S("darkgreen".to_owned()),
-            NamedColor::DarkGrey => ColorWrapper::S("darkgrey".to_owned()),
-            NamedColor::DarkKhaki => ColorWrapper::S("darkkhaki".to_owned()),
-            NamedColor::DarkMagenta => ColorWrapper::S("darkmagenta".to_owned()),
-            NamedColor::DarkOliveGreen => ColorWrapper::S("darkolivegreen".to_owned()),
-            NamedColor::DarkOrange => ColorWrapper::S("darkorange".to_owned()),
-            NamedColor::DarkOrchid => ColorWrapper::S("darkorchid".to_owned()),
-            NamedColor::DarkRed => ColorWrapper::S("darkred".to_owned()),
-            NamedColor::DarkSalmon => ColorWrapper::S("darksalmon".to_owned()),
-            NamedColor::DarkSeaGreen => ColorWrapper::S("darkseagreen".to_owned()),
-            NamedColor::DarkSlateBlue => ColorWrapper::S("darkslateblue".to_owned()),
-            NamedColor::DarkSlateGray => ColorWrapper::S("darkslategray".to_owned()),
-            NamedColor::DarkSlateGrey => ColorWrapper::S("darkslategrey".to_owned()),
-            NamedColor::DarkTurquoise => ColorWrapper::S("darkturquoise".to_owned()),
-            NamedColor::DarkViolet => ColorWrapper::S("darkviolet".to_owned()),
-            NamedColor::DeepPink => ColorWrapper::S("deeppink".to_owned()),
-            NamedColor::DeepSkyBlue => ColorWrapper::S("deepskyblue".to_owned()),
-            NamedColor::DimGray => ColorWrapper::S("dimgray".to_owned()),
-            NamedColor::DimGrey => ColorWrapper::S("dimgrey".to_owned()),
-            NamedColor::DodgerBlue => ColorWrapper::S("dodgerblue".to_owned()),
-            NamedColor::FireBrick => ColorWrapper::S("firebrick".to_owned()),
-            NamedColor::FloralWhite => ColorWrapper::S("floralwhite".to_owned()),
-            NamedColor::ForestGreen => ColorWrapper::S("forestgreen".to_owned()),
-            NamedColor::Fuchsia => ColorWrapper::S("fuchsia".to_owned()),
-            NamedColor::Gainsboro => ColorWrapper::S("gainsboro".to_owned()),
-            NamedColor::GhostWhite => ColorWrapper::S("ghostwhite".to_owned()),
-            NamedColor::Gold => ColorWrapper::S("gold".to_owned()),
-            NamedColor::Goldenrod => ColorWrapper::S("goldenrod".to_owned()),
-            NamedColor::Gray => ColorWrapper::S("gray".to_owned()),
-            NamedColor::Green => ColorWrapper::S("green".to_owned()),
-            NamedColor::GreenYellow => ColorWrapper::S("greenyellow".to_owned()),
-            NamedColor::Grey => ColorWrapper::S("grey".to_owned()),
-            NamedColor::Honeydew => ColorWrapper::S("honeydew".to_owned()),
-            NamedColor::HotPink => ColorWrapper::S("hotpink".to_owned()),
-            NamedColor::IndianRed => ColorWrapper::S("indianred".to_owned()),
-            NamedColor::Indigo => ColorWrapper::S("indigo".to_owned()),
-            NamedColor::Ivory => ColorWrapper::S("ivory".to_owned()),
-            NamedColor::Khaki => ColorWrapper::S("khaki".to_owned()),
-            NamedColor::Lavender => ColorWrapper::S("lavender".to_owned()),
-            NamedColor::LavenderBlush => ColorWrapper::S("lavenderblush".to_owned()),
-            NamedColor::LawnGreen => ColorWrapper::S("lawngreen".to_owned()),
-            NamedColor::LemonChiffon => ColorWrapper::S("lemonchiffon".to_owned()),
-            NamedColor::LightBlue => ColorWrapper::S("lightblue".to_owned()),
-            NamedColor::LightCoral => ColorWrapper::S("lightcoral".to_owned()),
-            NamedColor::LightCyan => ColorWrapper::S("lightcyan".to_owned()),
-            NamedColor::LightGoldenrodYellow => ColorWrapper::S("lightgoldenrodyellow".to_owned()),
-            NamedColor::LightGray => ColorWrapper::S("lightgray".to_owned()),
-            NamedColor::LightGreen => ColorWrapper::S("lightgreen".to_owned()),
-            NamedColor::LightGrey => ColorWrapper::S("lightgrey".to_owned()),
-            NamedColor::LightPink => ColorWrapper::S("lightpink".to_owned()),
-            NamedColor::LightSalmon => ColorWrapper::S("lightsalmon".to_owned()),
-            NamedColor::LightSeaGreen => ColorWrapper::S("lightseagreen".to_owned()),
-            NamedColor::LightSkyBlue => ColorWrapper::S("lightskyblue".to_owned()),
-            NamedColor::LightSlateGray => ColorWrapper::S("lightslategray".to_owned()),
-            NamedColor::LightSlateGrey => ColorWrapper::S("lightslategrey".to_owned()),
-            NamedColor::LightSteelBlue => ColorWrapper::S("lightsteelblue".to_owned()),
-            NamedColor::LightYellow => ColorWrapper::S("lightyellow".to_owned()),
-            NamedColor::Lime => ColorWrapper::S("lime".to_owned()),
-            NamedColor::LimeGreen => ColorWrapper::S("limegreen".to_owned()),
-            NamedColor::Linen => ColorWrapper::S("linen".to_owned()),
-            NamedColor::Magenta => ColorWrapper::S("magenta".to_owned()),
-            NamedColor::Maroon => ColorWrapper::S("maroon".to_owned()),
-            NamedColor::MediumAquamarine => ColorWrapper::S("mediumaquamarine".to_owned()),
-            NamedColor::MediumBlue => ColorWrapper::S("mediumblue".to_owned()),
-            NamedColor::MediumOrchid => ColorWrapper::S("mediumorchid".to_owned()),
-            NamedColor::MediumPurple => ColorWrapper::S("mediumpurple".to_owned()),
-            NamedColor::MediumSeaGreen => ColorWrapper::S("mediumseagreen".to_owned()),
-            NamedColor::MediumSlateBlue => ColorWrapper::S("mediumslateblue".to_owned()),
-            NamedColor::MediumSpringGreen => ColorWrapper::S("mediumspringgreen".to_owned()),
-            NamedColor::MediumTurquoise => ColorWrapper::S("mediumturquoise".to_owned()),
-            NamedColor::MediumVioletRed => ColorWrapper::S("mediumvioletred".to_owned()),
-            NamedColor::MidnightBlue => ColorWrapper::S("midnightblue".to_owned()),
-            NamedColor::MintCream => ColorWrapper::S("mintcream".to_owned()),
-            NamedColor::MistyRose => ColorWrapper::S("mistyrose".to_owned()),
-            NamedColor::Moccasin => ColorWrapper::S("moccasin".to_owned()),
-            NamedColor::NavajoWhite => ColorWrapper::S("navajowhite".to_owned()),
-            NamedColor::Navy => ColorWrapper::S("navy".to_owned()),
-            NamedColor::OldLace => ColorWrapper::S("oldlace".to_owned()),
-            NamedColor::Olive => ColorWrapper::S("olive".to_owned()),
-            NamedColor::OliveDrab => ColorWrapper::S("olivedrab".to_owned()),
-            NamedColor::Orange => ColorWrapper::S("orange".to_owned()),
-            NamedColor::OrangeRed => ColorWrapper::S("orangered".to_owned()),
-            NamedColor::Orchid => ColorWrapper::S("orchid".to_owned()),
-            NamedColor::PaleGoldenrod => ColorWrapper::S("palegoldenrod".to_owned()),
-            NamedColor::PaleGreen => ColorWrapper::S("palegreen".to_owned()),
-            NamedColor::PaleTurquoise => ColorWrapper::S("paleturquoise".to_owned()),
-            NamedColor::PaleVioletRed => ColorWrapper::S("palevioletred".to_owned()),
-            NamedColor::PapayaWhip => ColorWrapper::S("papayawhip".to_owned()),
-            NamedColor::PeachPuff => ColorWrapper::S("peachpuff".to_owned()),
-            NamedColor::Peru => ColorWrapper::S("peru".to_owned()),
-            NamedColor::Pink => ColorWrapper::S("pink".to_owned()),
-            NamedColor::Plum => ColorWrapper::S("plum".to_owned()),
-            NamedColor::PowderBlue => ColorWrapper::S("powderblue".to_owned()),
-            NamedColor::Purple => ColorWrapper::S("purple".to_owned()),
-            NamedColor::Red => ColorWrapper::S("red".to_owned()),
-            NamedColor::RosyBrown => ColorWrapper::S("rosybrown".to_owned()),
-            NamedColor::RoyalBlue => ColorWrapper::S("royalblue".to_owned()),
-            NamedColor::SaddleBrown => ColorWrapper::S("saddlebrown".to_owned()),
-            NamedColor::Salmon => ColorWrapper::S("salmon".to_owned()),
-            NamedColor::SandyBrown => ColorWrapper::S("sandybrown".to_owned()),
-            NamedColor::SeaGreen => ColorWrapper::S("seagreen".to_owned()),
-            NamedColor::Seashell => ColorWrapper::S("seashell".to_owned()),
-            NamedColor::Sienna => ColorWrapper::S("sienna".to_owned()),
-            NamedColor::Silver => ColorWrapper::S("silver".to_owned()),
-            NamedColor::SkyBlue => ColorWrapper::S("skyblue".to_owned()),
-            NamedColor::SlateBlue => ColorWrapper::S("slateblue".to_owned()),
-            NamedColor::SlateGray => ColorWrapper::S("slategray".to_owned()),
-            NamedColor::SlateGrey => ColorWrapper::S("slategrey".to_owned()),
-            NamedColor::Snow => ColorWrapper::S("snow".to_owned()),
-            NamedColor::SpringGreen => ColorWrapper::S("springgreen".to_owned()),
-            NamedColor::SteelBlue => ColorWrapper::S("steelblue".to_owned()),
-            NamedColor::Tan => ColorWrapper::S("tan".to_owned()),
-            NamedColor::Teal => ColorWrapper::S("teal".to_owned()),
-            NamedColor::Thistle => ColorWrapper::S("thistle".to_owned()),
-            NamedColor::Tomato => ColorWrapper::S("tomato".to_owned()),
-            NamedColor::Turquoise => ColorWrapper::S("turquoise".to_owned()),
-            NamedColor::Violet => ColorWrapper::S("violet".to_owned()),
-            NamedColor::Wheat => ColorWrapper::S("wheat".to_owned()),
-            NamedColor::White => ColorWrapper::S("white".to_owned()),
-            NamedColor::WhiteSmoke => ColorWrapper::S("whitesmoke".to_owned()),
-            NamedColor::Yellow => ColorWrapper::S("yellow".to_owned()),
-            NamedColor::YellowGreen => ColorWrapper::S("yellowgreen".to_owned()),
-            NamedColor::Transparent => ColorWrapper::S("transparent".to_owned()),
-        }
-    }
-}
-
-impl Color for f64 {
-    fn to_color(&self) -> ColorWrapper {
-        ColorWrapper::F(*self)
-    }
-}
-
-fn string_types_to_color_wrapper<S: AsRef<str> + std::fmt::Display + Sized>(v: S) -> ColorWrapper {
-    if v.as_ref().len() < 6 || v.as_ref().len() > 7 {
-        panic!("{} is not a valid hex color!", v);
-    }
-    if v.as_ref().len() == 6 && v.as_ref().starts_with('#') {
-        panic!("{} is not a valid hex color!", v);
-    }
-    if v.as_ref().len() == 7 && !v.as_ref().starts_with('#') {
-        panic!("{} is not a valid hex color!", v);
-    }
-    let valid_characters = "#ABCDEF0123456789";
-    let mut s = v.as_ref().to_uppercase();
-    if s.len() == 6 {
-        s = format!("#{}", s);
-    }
-    for c in s.chars() {
-        if !valid_characters.contains(c) {
-            panic!("{} is not a valid hex color!", v);
-        }
-    }
-
-    ColorWrapper::S(s)
-}
-
-// Implementations split intentionally; otherwise there is a conflict with the f64 implementation
-// as it `may` implement AsRef<str> in the future.
-impl Color for str {
-    fn to_color(&self) -> ColorWrapper {
-        string_types_to_color_wrapper(self)
-    }
-}
-
-// Implementations split intentionally; otherwise there is a conflict with the f64 implementation
-// as it `may` implement AsRef<str> in the future.
-impl Color for &str {
-    fn to_color(&self) -> ColorWrapper {
-        string_types_to_color_wrapper(self)
-    }
-}
-
-// Implementations split intentionally; otherwise there is a conflict with the f64 implementation
-// as it `may` implement AsRef<str> in the future.
-impl Color for String {
-    fn to_color(&self) -> ColorWrapper {
-        string_types_to_color_wrapper(self)
-    }
-}
-
-// Implementations split intentionally; otherwise there is a conflict with the f64 implementation
-// as it `may` implement AsRef<str> in the future.
-impl Color for &String {
-    fn to_color(&self) -> ColorWrapper {
-        string_types_to_color_wrapper(self)
-    }
-}
-
 #[cfg(test)]
 mod tests {
+    use serde_json::{json, to_value};
+
     use super::*;
 
     #[test]
-    fn hex_color_normalization_str() {
-        assert_eq!("#aabbcc".to_color(), ColorWrapper::S("#AABBCC".to_owned()));
-        assert_eq!("aabbcc".to_color(), ColorWrapper::S("#AABBCC".to_owned()));
-        assert_eq!("aaBBcc".to_color(), ColorWrapper::S("#AABBCC".to_owned()));
-        assert_eq!("FABCDe".to_color(), ColorWrapper::S("#FABCDE".to_owned()));
-        assert_eq!("123456".to_color(), ColorWrapper::S("#123456".to_owned()));
-        assert_eq!("7890EE".to_color(), ColorWrapper::S("#7890EE".to_owned()));
+    fn test_serialize_rgb() {
+        let rgb = Rgb::new(80, 90, 100);
+        assert_eq!(to_value(rgb).unwrap(), json!("rgb(80, 90, 100)"));
     }
 
     #[test]
-    fn hex_color_normalization_string() {
-        assert_eq!(
-            String::from("#aabbcc").to_color(),
-            ColorWrapper::S("#AABBCC".to_owned())
-        );
-        assert_eq!(
-            String::from("aabbcc").to_color(),
-            ColorWrapper::S("#AABBCC".to_owned())
-        );
-        assert_eq!(
-            String::from("aaBBcc").to_color(),
-            ColorWrapper::S("#AABBCC".to_owned())
-        );
-        assert_eq!(
-            String::from("FABCDe").to_color(),
-            ColorWrapper::S("#FABCDE".to_owned())
-        );
-        assert_eq!(
-            String::from("123456").to_color(),
-            ColorWrapper::S("#123456".to_owned())
-        );
-        assert_eq!(
-            String::from("7890EE").to_color(),
-            ColorWrapper::S("#7890EE".to_owned())
-        );
+    fn test_serialize_rgba() {
+        let rgb = Rgba::new(80, 90, 100, 0.2);
+        assert_eq!(to_value(rgb).unwrap(), json!("rgba(80, 90, 100, 0.2)"));
     }
 
     #[test]
-    fn color_from_f64() {
-        assert_eq!(1.54.to_color(), ColorWrapper::F(1.54));
-        assert_eq!(0.1.to_color(), ColorWrapper::F(0.1));
+    fn test_serialize_str() {
+        let color = "any_arbitrary_string";
+        assert_eq!(to_value(color).unwrap(), json!("any_arbitrary_string"));
     }
 
     #[test]
-    #[should_panic]
-    fn too_short_str() {
-        "abc".to_color();
+    fn test_serialize_string() {
+        let color = "any_arbitrary_string".to_string();
+        assert_eq!(to_value(color).unwrap(), json!("any_arbitrary_string"));
     }
 
     #[test]
-    #[should_panic]
-    fn too_short_string() {
-        String::from("abc").to_color();
-    }
-
-    #[test]
-    #[should_panic]
-    fn too_long_str() {
-        "abcdef0".to_color();
-    }
-
-    #[test]
-    #[should_panic]
-    fn too_long_string() {
-        String::from("abcdef0").to_color();
-    }
-
-    #[test]
-    #[should_panic]
-    fn invalid_characters_str() {
-        "abdefg".to_color();
-    }
-
-    #[test]
-    #[should_panic]
-    fn invalid_characters_string() {
-        String::from("abdefg").to_color();
+    #[rustfmt::skip]
+    fn test_serialize_named_color() {
+        assert_eq!(to_value(NamedColor::AliceBlue).unwrap(), json!("aliceblue"));
+        assert_eq!(to_value(NamedColor::AntiqueWhite).unwrap(), json!("antiquewhite"));
+        assert_eq!(to_value(NamedColor::Aqua).unwrap(), json!("aqua"));
+        assert_eq!(to_value(NamedColor::Aquamarine).unwrap(), json!("aquamarine"));
+        assert_eq!(to_value(NamedColor::Azure).unwrap(), json!("azure"));
+        assert_eq!(to_value(NamedColor::Beige).unwrap(), json!("beige"));
+        assert_eq!(to_value(NamedColor::Bisque).unwrap(), json!("bisque"));
+        assert_eq!(to_value(NamedColor::Black).unwrap(), json!("black"));
+        assert_eq!(to_value(NamedColor::BlanchedAlmond).unwrap(), json!("blanchedalmond"));
+        assert_eq!(to_value(NamedColor::Blue).unwrap(), json!("blue"));
+        assert_eq!(to_value(NamedColor::BlueViolet).unwrap(), json!("blueviolet"));
+        assert_eq!(to_value(NamedColor::Brown).unwrap(), json!("brown"));
+        assert_eq!(to_value(NamedColor::BurlyWood).unwrap(), json!("burlywood"));
+        assert_eq!(to_value(NamedColor::CadetBlue).unwrap(), json!("cadetblue"));
+        assert_eq!(to_value(NamedColor::Chartreuse).unwrap(), json!("chartreuse"));
+        assert_eq!(to_value(NamedColor::Chocolate).unwrap(), json!("chocolate"));
+        assert_eq!(to_value(NamedColor::Coral).unwrap(), json!("coral"));
+        assert_eq!(to_value(NamedColor::CornflowerBlue).unwrap(), json!("cornflowerblue"));
+        assert_eq!(to_value(NamedColor::CornSilk).unwrap(), json!("cornsilk"));
+        assert_eq!(to_value(NamedColor::Crimson).unwrap(), json!("crimson"));
+        assert_eq!(to_value(NamedColor::Cyan).unwrap(), json!("cyan"));
+        assert_eq!(to_value(NamedColor::DarkBlue).unwrap(), json!("darkblue"));
+        assert_eq!(to_value(NamedColor::DarkCyan).unwrap(), json!("darkcyan"));
+        assert_eq!(to_value(NamedColor::DarkGoldenrod).unwrap(), json!("darkgoldenrod"));
+        assert_eq!(to_value(NamedColor::DarkGray).unwrap(), json!("darkgray"));
+        assert_eq!(to_value(NamedColor::DarkGrey).unwrap(), json!("darkgrey"));
+        assert_eq!(to_value(NamedColor::DarkGreen).unwrap(), json!("darkgreen"));
+        assert_eq!(to_value(NamedColor::DarkOrange).unwrap(), json!("darkorange"));
+        assert_eq!(to_value(NamedColor::DarkOrchid).unwrap(), json!("darkorchid"));
+        assert_eq!(to_value(NamedColor::DarkRed).unwrap(), json!("darkred"));
+        assert_eq!(to_value(NamedColor::DarkSalmon).unwrap(), json!("darksalmon"));
+        assert_eq!(to_value(NamedColor::DarkSeaGreen).unwrap(), json!("darkseagreen"));
+        assert_eq!(to_value(NamedColor::DarkSlateBlue).unwrap(), json!("darkslateblue"));
+        assert_eq!(to_value(NamedColor::DarkSlateGray).unwrap(), json!("darkslategray"));
+        assert_eq!(to_value(NamedColor::DarkSlateGrey).unwrap(), json!("darkslategrey"));
+        assert_eq!(to_value(NamedColor::DarkTurquoise).unwrap(), json!("darkturquoise"));
+        assert_eq!(to_value(NamedColor::DarkViolet).unwrap(), json!("darkviolet"));
+        assert_eq!(to_value(NamedColor::DeepPink).unwrap(), json!("deeppink"));
+        assert_eq!(to_value(NamedColor::DeepSkyBlue).unwrap(), json!("deepskyblue"));
+        assert_eq!(to_value(NamedColor::DimGray).unwrap(), json!("dimgray"));
+        assert_eq!(to_value(NamedColor::DimGrey).unwrap(), json!("dimgrey"));
+        assert_eq!(to_value(NamedColor::DodgerBlue).unwrap(), json!("dodgerblue"));
+        assert_eq!(to_value(NamedColor::FireBrick).unwrap(), json!("firebrick"));
+        assert_eq!(to_value(NamedColor::FloralWhite).unwrap(), json!("floralwhite"));
+        assert_eq!(to_value(NamedColor::ForestGreen).unwrap(), json!("forestgreen"));
+        assert_eq!(to_value(NamedColor::Fuchsia).unwrap(), json!("fuchsia"));
+        assert_eq!(to_value(NamedColor::Gainsboro).unwrap(), json!("gainsboro"));
+        assert_eq!(to_value(NamedColor::GhostWhite).unwrap(), json!("ghostwhite"));
+        assert_eq!(to_value(NamedColor::Gold).unwrap(), json!("gold"));
+        assert_eq!(to_value(NamedColor::Goldenrod).unwrap(), json!("goldenrod"));
+        assert_eq!(to_value(NamedColor::Gray).unwrap(), json!("gray"));
+        assert_eq!(to_value(NamedColor::Grey).unwrap(), json!("grey"));
+        assert_eq!(to_value(NamedColor::Green).unwrap(), json!("green"));
+        assert_eq!(to_value(NamedColor::GreenYellow).unwrap(), json!("greenyellow"));
+        assert_eq!(to_value(NamedColor::Honeydew).unwrap(), json!("honeydew"));
+        assert_eq!(to_value(NamedColor::HotPink).unwrap(), json!("hotpink"));
+        assert_eq!(to_value(NamedColor::IndianRed).unwrap(), json!("indianred"));
+        assert_eq!(to_value(NamedColor::Indigo).unwrap(), json!("indigo"));
+        assert_eq!(to_value(NamedColor::Ivory).unwrap(), json!("ivory"));
+        assert_eq!(to_value(NamedColor::Khaki).unwrap(), json!("khaki"));
+        assert_eq!(to_value(NamedColor::Lavender).unwrap(), json!("lavender"));
+        assert_eq!(to_value(NamedColor::LavenderBlush).unwrap(), json!("lavenderblush"));
+        assert_eq!(to_value(NamedColor::LawnGreen).unwrap(), json!("lawngreen"));
+        assert_eq!(to_value(NamedColor::LemonChiffon).unwrap(), json!("lemonchiffon"));
+        assert_eq!(to_value(NamedColor::LightBlue).unwrap(), json!("lightblue"));
+        assert_eq!(to_value(NamedColor::LightCoral).unwrap(), json!("lightcoral"));
+        assert_eq!(to_value(NamedColor::LightCyan).unwrap(), json!("lightcyan"));
+        assert_eq!(to_value(NamedColor::LightGoldenrodYellow).unwrap(), json!("lightgoldenrodyellow"));
+        assert_eq!(to_value(NamedColor::LightGray).unwrap(), json!("lightgray"));
+        assert_eq!(to_value(NamedColor::LightGrey).unwrap(), json!("lightgrey"));
+        assert_eq!(to_value(NamedColor::LightGreen).unwrap(), json!("lightgreen"));
+        assert_eq!(to_value(NamedColor::LightPink).unwrap(), json!("lightpink"));
+        assert_eq!(to_value(NamedColor::LightSalmon).unwrap(), json!("lightsalmon"));
+        assert_eq!(to_value(NamedColor::LightSeaGreen).unwrap(), json!("lightseagreen"));
+        assert_eq!(to_value(NamedColor::LightSkyBlue).unwrap(), json!("lightskyblue"));
+        assert_eq!(to_value(NamedColor::LightSlateGray).unwrap(), json!("lightslategray"));
+        assert_eq!(to_value(NamedColor::LightSlateGrey).unwrap(), json!("lightslategrey"));
+        assert_eq!(to_value(NamedColor::LightSteelBlue).unwrap(), json!("lightsteelblue"));
+        assert_eq!(to_value(NamedColor::LightYellow).unwrap(), json!("lightyellow"));
+        assert_eq!(to_value(NamedColor::Lime).unwrap(), json!("lime"));
+        assert_eq!(to_value(NamedColor::LimeGreen).unwrap(), json!("limegreen"));
+        assert_eq!(to_value(NamedColor::Linen).unwrap(), json!("linen"));
+        assert_eq!(to_value(NamedColor::Magenta).unwrap(), json!("magenta"));
+        assert_eq!(to_value(NamedColor::Maroon).unwrap(), json!("maroon"));
+        assert_eq!(to_value(NamedColor::MediumAquamarine).unwrap(), json!("mediumaquamarine"));
+        assert_eq!(to_value(NamedColor::MediumBlue).unwrap(), json!("mediumblue"));
+        assert_eq!(to_value(NamedColor::MediumOrchid).unwrap(), json!("mediumorchid"));
+        assert_eq!(to_value(NamedColor::MediumPurple).unwrap(), json!("mediumpurple"));
+        assert_eq!(to_value(NamedColor::MediumSeaGreen).unwrap(), json!("mediumseagreen"));
+        assert_eq!(to_value(NamedColor::MediumSlateBlue).unwrap(), json!("mediumslateblue"));
+        assert_eq!(to_value(NamedColor::MediumSpringGreen).unwrap(), json!("mediumspringgreen"));
+        assert_eq!(to_value(NamedColor::MediumTurquoise).unwrap(), json!("mediumturquoise"));
+        assert_eq!(to_value(NamedColor::MediumVioletRed).unwrap(), json!("mediumvioletred"));
+        assert_eq!(to_value(NamedColor::MidnightBlue).unwrap(), json!("midnightblue"));
+        assert_eq!(to_value(NamedColor::MintCream).unwrap(), json!("mintcream"));
+        assert_eq!(to_value(NamedColor::MistyRose).unwrap(), json!("mistyrose"));
+        assert_eq!(to_value(NamedColor::Moccasin).unwrap(), json!("moccasin"));
+        assert_eq!(to_value(NamedColor::NavajoWhite).unwrap(), json!("navajowhite"));
+        assert_eq!(to_value(NamedColor::Navy).unwrap(), json!("navy"));
+        assert_eq!(to_value(NamedColor::OldLace).unwrap(), json!("oldlace"));
+        assert_eq!(to_value(NamedColor::Olive).unwrap(), json!("olive"));
+        assert_eq!(to_value(NamedColor::OliveDrab).unwrap(), json!("olivedrab"));
+        assert_eq!(to_value(NamedColor::Orange).unwrap(), json!("orange"));
+        assert_eq!(to_value(NamedColor::OrangeRed).unwrap(), json!("orangered"));
+        assert_eq!(to_value(NamedColor::Orchid).unwrap(), json!("orchid"));
+        assert_eq!(to_value(NamedColor::PaleGoldenrod).unwrap(), json!("palegoldenrod"));
+        assert_eq!(to_value(NamedColor::PaleGreen).unwrap(), json!("palegreen"));
+        assert_eq!(to_value(NamedColor::PaleTurquoise).unwrap(), json!("paleturquoise"));
+        assert_eq!(to_value(NamedColor::PaleVioletRed).unwrap(), json!("palevioletred"));
+        assert_eq!(to_value(NamedColor::PapayaWhip).unwrap(), json!("papayawhip"));
+        assert_eq!(to_value(NamedColor::PeachPuff).unwrap(), json!("peachpuff"));
+        assert_eq!(to_value(NamedColor::Peru).unwrap(), json!("peru"));
+        assert_eq!(to_value(NamedColor::Pink).unwrap(), json!("pink"));
+        assert_eq!(to_value(NamedColor::Plum).unwrap(), json!("plum"));
+        assert_eq!(to_value(NamedColor::PowderBlue).unwrap(), json!("powderblue"));
+        assert_eq!(to_value(NamedColor::Purple).unwrap(), json!("purple"));
+        assert_eq!(to_value(NamedColor::RebeccaPurple).unwrap(), json!("rebeccapurple"));
+        assert_eq!(to_value(NamedColor::Red).unwrap(), json!("red"));
+        assert_eq!(to_value(NamedColor::RosyBrown).unwrap(), json!("rosybrown"));
+        assert_eq!(to_value(NamedColor::RoyalBlue).unwrap(), json!("royalblue"));
+        assert_eq!(to_value(NamedColor::SaddleBrown).unwrap(), json!("saddlebrown"));
+        assert_eq!(to_value(NamedColor::Salmon).unwrap(), json!("salmon"));
+        assert_eq!(to_value(NamedColor::SandyBrown).unwrap(), json!("sandybrown"));
+        assert_eq!(to_value(NamedColor::SeaGreen).unwrap(), json!("seagreen"));
+        assert_eq!(to_value(NamedColor::Seashell).unwrap(), json!("seashell"));
+        assert_eq!(to_value(NamedColor::Sienna).unwrap(), json!("sienna"));
+        assert_eq!(to_value(NamedColor::Silver).unwrap(), json!("silver"));
+        assert_eq!(to_value(NamedColor::SkyBlue).unwrap(), json!("skyblue"));
+        assert_eq!(to_value(NamedColor::SlateBlue).unwrap(), json!("slateblue"));
+        assert_eq!(to_value(NamedColor::SlateGray).unwrap(), json!("slategray"));
+        assert_eq!(to_value(NamedColor::SlateGrey).unwrap(), json!("slategrey"));
+        assert_eq!(to_value(NamedColor::Snow).unwrap(), json!("snow"));
+        assert_eq!(to_value(NamedColor::SpringGreen).unwrap(), json!("springgreen"));
+        assert_eq!(to_value(NamedColor::SteelBlue).unwrap(), json!("steelblue"));
+        assert_eq!(to_value(NamedColor::Tan).unwrap(), json!("tan"));
+        assert_eq!(to_value(NamedColor::Teal).unwrap(), json!("teal"));
+        assert_eq!(to_value(NamedColor::Thistle).unwrap(), json!("thistle"));
+        assert_eq!(to_value(NamedColor::Tomato).unwrap(), json!("tomato"));
+        assert_eq!(to_value(NamedColor::Turquoise).unwrap(), json!("turquoise"));
+        assert_eq!(to_value(NamedColor::Violet).unwrap(), json!("violet"));
+        assert_eq!(to_value(NamedColor::Wheat).unwrap(), json!("wheat"));
+        assert_eq!(to_value(NamedColor::White).unwrap(), json!("white"));
+        assert_eq!(to_value(NamedColor::WhiteSmoke).unwrap(), json!("whitesmoke"));
+        assert_eq!(to_value(NamedColor::Yellow).unwrap(), json!("yellow"));
+        assert_eq!(to_value(NamedColor::YellowGreen).unwrap(), json!("yellowgreen"));
+        assert_eq!(to_value(NamedColor::Transparent).unwrap(), json!("transparent"));
     }
 }

--- a/plotly/src/common/mod.rs
+++ b/plotly/src/common/mod.rs
@@ -2,9 +2,8 @@ pub mod color;
 
 use serde::{Serialize, Serializer};
 
-use crate::common::color::ColorWrapper;
+use crate::color::{Color, ColorArray};
 use crate::private;
-use color::Color;
 
 #[derive(Serialize, Clone, Debug)]
 #[serde(untagged)]
@@ -504,7 +503,7 @@ pub struct Line {
     #[serde(skip_serializing_if = "Option::is_none")]
     simplify: Option<bool>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    color: Option<ColorWrapper>,
+    color: Option<Box<dyn Color>>,
     #[serde(skip_serializing_if = "Option::is_none")]
     cauto: Option<bool>,
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -520,7 +519,7 @@ pub struct Line {
     #[serde(skip_serializing_if = "Option::is_none", rename = "reversescale")]
     reverse_scale: Option<bool>,
     #[serde(skip_serializing_if = "Option::is_none", rename = "outliercolor")]
-    outlier_color: Option<ColorWrapper>,
+    outlier_color: Option<Box<dyn Color>>,
     #[serde(skip_serializing_if = "Option::is_none", rename = "outlierwidth")]
     outlier_width: Option<usize>,
 }
@@ -556,7 +555,7 @@ impl Line {
     }
 
     pub fn color<C: Color>(mut self, color: C) -> Self {
-        self.color = Some(color.to_color());
+        self.color = Some(Box::new(color));
         self
     }
 
@@ -596,7 +595,7 @@ impl Line {
     }
 
     pub fn outlier_color<C: Color>(mut self, outlier_color: C) -> Self {
-        self.outlier_color = Some(outlier_color.to_color());
+        self.outlier_color = Some(Box::new(outlier_color));
         self
     }
 
@@ -667,18 +666,21 @@ pub enum ExponentFormat {
 #[derive(Serialize, Clone, Debug)]
 pub struct Gradient {
     r#type: GradientType,
-    color: Dim<ColorWrapper>,
+    color: Dim<Box<dyn Color>>,
 }
 
 impl Gradient {
-    pub fn new<C: Color + Serialize>(gradient_type: GradientType, color: Dim<C>) -> Self {
-        let color = match color {
-            Dim::Scalar(c) => Dim::Scalar(c.to_color()),
-            Dim::Vector(c) => Dim::Vector(private::to_color_array(c)),
-        };
+    pub fn new<C: Color>(gradient_type: GradientType, color: C) -> Self {
         Gradient {
             r#type: gradient_type,
-            color,
+            color: Dim::Scalar(Box::new(color)),
+        }
+    }
+
+    pub fn new_array<C: Color>(gradient_type: GradientType, colors: Vec<C>) -> Self {
+        Gradient {
+            r#type: gradient_type,
+            color: Dim::Vector(ColorArray(colors).into()),
         }
     }
 }
@@ -749,15 +751,15 @@ pub struct ColorBar {
     #[serde(rename = "ypad")]
     y_pad: f64,
     #[serde(skip_serializing_if = "Option::is_none", rename = "outlinecolor")]
-    outline_color: Option<ColorWrapper>,
+    outline_color: Option<Box<dyn Color>>,
     #[serde(rename = "outlinewidth")]
     outline_width: usize,
     #[serde(skip_serializing_if = "Option::is_none", rename = "bordercolor")]
-    border_color: Option<ColorWrapper>,
+    border_color: Option<Box<dyn Color>>,
     #[serde(rename = "borderwidth")]
     border_width: usize,
     #[serde(skip_serializing_if = "Option::is_none", rename = "bgcolor")]
-    background_color: Option<ColorWrapper>,
+    background_color: Option<Box<dyn Color>>,
     #[serde(skip_serializing_if = "Option::is_none", rename = "tickmode")]
     tick_mode: Option<TickMode>,
     #[serde(rename = "nticks")]
@@ -777,7 +779,7 @@ pub struct ColorBar {
     #[serde(rename = "tickwidth")]
     tick_width: usize,
     #[serde(skip_serializing_if = "Option::is_none", rename = "tickcolor")]
-    tick_color: Option<ColorWrapper>,
+    tick_color: Option<Box<dyn Color>>,
     #[serde(rename = "showticklabels")]
     show_tick_labels: bool,
     #[serde(skip_serializing_if = "Option::is_none", rename = "tickfont")]
@@ -906,7 +908,7 @@ impl ColorBar {
     }
 
     pub fn outline_color<C: Color>(mut self, outline_color: C) -> ColorBar {
-        self.outline_color = Some(outline_color.to_color());
+        self.outline_color = Some(Box::new(outline_color));
         self
     }
 
@@ -916,7 +918,7 @@ impl ColorBar {
     }
 
     pub fn border_color<C: Color>(mut self, border_color: C) -> ColorBar {
-        self.border_color = Some(border_color.to_color());
+        self.border_color = Some(Box::new(border_color));
         self
     }
 
@@ -926,7 +928,7 @@ impl ColorBar {
     }
 
     pub fn background_color<C: Color>(mut self, background_color: C) -> ColorBar {
-        self.background_color = Some(background_color.to_color());
+        self.background_color = Some(Box::new(background_color));
         self
     }
 
@@ -976,7 +978,7 @@ impl ColorBar {
     }
 
     pub fn tick_color<C: Color>(mut self, tick_color: C) -> ColorBar {
-        self.tick_color = Some(tick_color.to_color());
+        self.tick_color = Some(Box::new(tick_color));
         self
     }
 
@@ -1076,7 +1078,7 @@ pub struct Marker {
     #[serde(skip_serializing_if = "Option::is_none")]
     gradient: Option<Gradient>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    color: Option<Dim<ColorWrapper>>,
+    color: Option<Dim<Box<dyn Color>>>,
     #[serde(skip_serializing_if = "Option::is_none")]
     cauto: Option<bool>,
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -1096,7 +1098,7 @@ pub struct Marker {
     #[serde(skip_serializing_if = "Option::is_none", rename = "colorbar")]
     color_bar: Option<ColorBar>,
     #[serde(skip_serializing_if = "Option::is_none", rename = "outliercolor")]
-    outlier_color: Option<ColorWrapper>,
+    outlier_color: Option<Box<dyn Color>>,
 }
 
 impl Marker {
@@ -1155,13 +1157,12 @@ impl Marker {
     }
 
     pub fn color<C: Color>(mut self, color: C) -> Self {
-        self.color = Some(Dim::Scalar(color.to_color()));
+        self.color = Some(Dim::Scalar(Box::new(color)));
         self
     }
 
-    pub fn color_array<C: Color>(mut self, color: Vec<C>) -> Self {
-        let color = private::to_color_array(color);
-        self.color = Some(Dim::Vector(color));
+    pub fn color_array<C: Color>(mut self, colors: Vec<C>) -> Self {
+        self.color = Some(Dim::Vector(ColorArray(colors).into()));
         self
     }
 
@@ -1211,7 +1212,7 @@ impl Marker {
     }
 
     pub fn outlier_color<C: Color>(mut self, outlier_color: C) -> Self {
-        self.outlier_color = Some(outlier_color.to_color());
+        self.outlier_color = Some(Box::new(outlier_color));
         self
     }
 }
@@ -1223,7 +1224,7 @@ pub struct Font {
     #[serde(skip_serializing_if = "Option::is_none")]
     size: Option<usize>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    color: Option<ColorWrapper>,
+    color: Option<Box<dyn Color>>,
 }
 
 impl Font {
@@ -1242,7 +1243,7 @@ impl Font {
     }
 
     pub fn color<C: Color>(mut self, color: C) -> Self {
-        self.color = Some(color.to_color());
+        self.color = Some(Box::new(color));
         self
     }
 }
@@ -1364,9 +1365,9 @@ impl Title {
 #[derive(Serialize, Clone, Debug, Default)]
 pub struct Label {
     #[serde(skip_serializing_if = "Option::is_none", rename = "bgcolor")]
-    background_color: Option<ColorWrapper>,
+    background_color: Option<Box<dyn Color>>,
     #[serde(skip_serializing_if = "Option::is_none", rename = "bordercolor")]
-    border_color: Option<ColorWrapper>,
+    border_color: Option<Box<dyn Color>>,
     #[serde(skip_serializing_if = "Option::is_none")]
     font: Option<Font>,
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -1381,12 +1382,12 @@ impl Label {
     }
 
     pub fn background_color<C: Color>(mut self, background_color: C) -> Self {
-        self.background_color = Some(background_color.to_color());
+        self.background_color = Some(Box::new(background_color));
         self
     }
 
     pub fn border_color<C: Color>(mut self, border_color: C) -> Self {
-        self.border_color = Some(border_color.to_color());
+        self.border_color = Some(Box::new(border_color));
         self
     }
 
@@ -1449,7 +1450,7 @@ pub struct ErrorData {
     #[serde(skip_serializing_if = "Option::is_none")]
     copy_ystyle: Option<bool>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    color: Option<ColorWrapper>,
+    color: Option<Box<dyn Color>>,
     #[serde(skip_serializing_if = "Option::is_none")]
     thickness: Option<f64>,
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -1510,7 +1511,7 @@ impl ErrorData {
     }
 
     pub fn color<C: Color>(mut self, color: C) -> Self {
-        self.color = Some(color.to_color());
+        self.color = Some(Box::new(color));
         self
     }
 
@@ -1530,7 +1531,7 @@ mod tests {
     use serde_json::{json, to_value};
 
     use super::*;
-    use crate::NamedColor;
+    use crate::color::NamedColor;
 
     #[test]
     fn test_serialize_domain() {
@@ -1951,7 +1952,7 @@ mod tests {
             "smoothing": 1.0,
             "dash": "dash",
             "simplify": true,
-            "color": "#FFFFFF",
+            "color": "#ffffff",
             "cauto": true,
             "cmin": 0.0,
             "cmax": 1.0,
@@ -2019,8 +2020,12 @@ mod tests {
     #[test]
     #[rustfmt::skip]
     fn test_serialize_gradient() {
-        let gradient = Gradient::new(GradientType::Horizontal, Dim::Scalar("#ffffff"));
-        let expected = json!({"color": "#FFFFFF", "type": "horizontal"});
+        let gradient = Gradient::new(GradientType::Horizontal, "#ffffff");
+        let expected = json!({"color": "#ffffff", "type": "horizontal"});
+        assert_eq!(to_value(gradient).unwrap(), expected);
+
+        let gradient = Gradient::new_array(GradientType::Horizontal, vec!["#ffffff"]);
+        let expected = json!({"color": ["#ffffff"], "type": "horizontal"});
         assert_eq!(to_value(gradient).unwrap(), expected);
     }
 
@@ -2060,7 +2065,7 @@ mod tests {
             .size_min(1)
             .size_mode(SizeMode::Area)
             .line(Line::new())
-            .gradient(Gradient::new(GradientType::Radial, Dim::Scalar("#FFFFFF")))
+            .gradient(Gradient::new(GradientType::Radial, "#FFFFFF"))
             .color(NamedColor::Blue)
             .color_array(vec![NamedColor::Black, NamedColor::Blue])
             .cauto(true)
@@ -2071,7 +2076,7 @@ mod tests {
             .auto_color_scale(true)
             .reverse_scale(true)
             .show_scale(true)
-            // .color_bar(ColorBar::new()) awaiting fix in other branch
+            .color_bar(ColorBar::new())
             .outlier_color("#FFFFFF");
 
         let expected = json!({
@@ -2085,6 +2090,23 @@ mod tests {
             "line": {},
             "gradient": {"type": "radial", "color": "#FFFFFF"},
             "color": ["black", "blue"],
+            "colorbar": {
+                "borderwidth": 0,
+                "len": 1,
+                "nticks": 0,
+                "outlinewidth": 1,
+                "separate_thousands": true,
+                "showticklabels": true,
+                "thickness": 30,
+                "ticklen": 5,
+                "tickwidth": 1,
+                "x": 1.02,
+                "xanchor": "left",
+                "xpad": 10.0,
+                "y": 0.5,
+                "yanchor": "middle",
+                "ypad": 10.0,
+            },
             "cauto": true,
             "cmin": 0.0,
             "cmax": 1.0,

--- a/plotly/src/layout/mod.rs
+++ b/plotly/src/layout/mod.rs
@@ -3,12 +3,12 @@ pub mod themes;
 use serde::{Serialize, Serializer};
 use std::borrow::Cow;
 
-use crate::common::color::{Color, ColorWrapper};
+use crate::color::{Color, ColorArray};
 use crate::common::{
     Anchor, AxisSide, Calendar, ColorBar, ColorScale, DashType, ExponentFormat, Font, Label,
     Orientation, TickFormatStop, TickMode, Title,
 };
-use crate::private::{self, NumOrString, NumOrStringCollection};
+use crate::private::{NumOrString, NumOrStringCollection};
 
 #[derive(Serialize, Debug, Clone)]
 #[serde(rename_all = "lowercase")]
@@ -157,9 +157,9 @@ pub enum GroupClick {
 #[derive(Serialize, Debug, Default, Clone)]
 pub struct Legend {
     #[serde(skip_serializing_if = "Option::is_none", rename = "bgcolor")]
-    background_color: Option<ColorWrapper>,
+    background_color: Option<Box<dyn Color>>,
     #[serde(skip_serializing_if = "Option::is_none", rename = "bordercolor")]
-    border_color: Option<ColorWrapper>,
+    border_color: Option<Box<dyn Color>>,
     #[serde(skip_serializing_if = "Option::is_none", rename = "borderwidth")]
     border_width: Option<usize>,
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -200,12 +200,12 @@ impl Legend {
     }
 
     pub fn background_color<C: Color>(mut self, background_color: C) -> Self {
-        self.background_color = Some(background_color.to_color());
+        self.background_color = Some(Box::new(background_color));
         self
     }
 
     pub fn border_color<C: Color>(mut self, border_color: C) -> Self {
-        self.border_color = Some(border_color.to_color());
+        self.border_color = Some(Box::new(border_color));
         self
     }
 
@@ -424,9 +424,9 @@ impl RangeSliderYAxis {
 #[derive(Serialize, Debug, Default, Clone)]
 pub struct RangeSlider {
     #[serde(skip_serializing_if = "Option::is_none", rename = "bgcolor")]
-    background_color: Option<ColorWrapper>,
+    background_color: Option<Box<dyn Color>>,
     #[serde(skip_serializing_if = "Option::is_none", rename = "bordercolor")]
-    border_color: Option<ColorWrapper>,
+    border_color: Option<Box<dyn Color>>,
     #[serde(skip_serializing_if = "Option::is_none", rename = "borderwidth")]
     border_width: Option<u64>,
     #[serde(skip_serializing_if = "Option::is_none", rename = "autorange")]
@@ -447,12 +447,12 @@ impl RangeSlider {
     }
 
     pub fn background_color<C: Color>(mut self, background_color: C) -> Self {
-        self.background_color = Some(background_color.to_color());
+        self.background_color = Some(Box::new(background_color));
         self
     }
 
     pub fn border_color<C: Color>(mut self, border_color: C) -> Self {
-        self.border_color = Some(border_color.to_color());
+        self.border_color = Some(Box::new(border_color));
         self
     }
 
@@ -582,11 +582,11 @@ pub struct RangeSelector {
     #[serde(skip_serializing_if = "Option::is_none")]
     font: Option<Font>,
     #[serde(skip_serializing_if = "Option::is_none", rename = "bgcolor")]
-    background_color: Option<ColorWrapper>,
+    background_color: Option<Box<dyn Color>>,
     #[serde(skip_serializing_if = "Option::is_none", rename = "activecolor")]
-    active_color: Option<ColorWrapper>,
+    active_color: Option<Box<dyn Color>>,
     #[serde(skip_serializing_if = "Option::is_none", rename = "bordercolor")]
-    border_color: Option<ColorWrapper>,
+    border_color: Option<Box<dyn Color>>,
     #[serde(skip_serializing_if = "Option::is_none", rename = "borderwidth")]
     border_width: Option<usize>,
 }
@@ -632,17 +632,17 @@ impl RangeSelector {
     }
 
     pub fn background_color<C: Color>(mut self, background_color: C) -> Self {
-        self.background_color = Some(background_color.to_color());
+        self.background_color = Some(Box::new(background_color));
         self
     }
 
     pub fn active_color<C: Color>(mut self, active_color: C) -> Self {
-        self.active_color = Some(active_color.to_color());
+        self.active_color = Some(Box::new(active_color));
         self
     }
 
     pub fn border_color<C: Color>(mut self, border_color: C) -> Self {
-        self.border_color = Some(border_color.to_color());
+        self.border_color = Some(Box::new(border_color));
         self
     }
 
@@ -755,7 +755,7 @@ pub struct Axis {
     #[serde(skip_serializing_if = "Option::is_none")]
     visible: Option<bool>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    color: Option<ColorWrapper>,
+    color: Option<Box<dyn Color>>,
     #[serde(skip_serializing_if = "Option::is_none")]
     title: Option<Title>,
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -800,7 +800,7 @@ pub struct Axis {
     #[serde(skip_serializing_if = "Option::is_none", rename = "tickwidth")]
     tick_width: Option<usize>,
     #[serde(skip_serializing_if = "Option::is_none", rename = "tickcolor")]
-    tick_color: Option<ColorWrapper>,
+    tick_color: Option<Box<dyn Color>>,
     #[serde(skip_serializing_if = "Option::is_none", rename = "showticklabels")]
     show_tick_labels: Option<bool>,
     #[serde(skip_serializing_if = "Option::is_none", rename = "automargin")]
@@ -808,7 +808,7 @@ pub struct Axis {
     #[serde(skip_serializing_if = "Option::is_none", rename = "showspikes")]
     show_spikes: Option<bool>,
     #[serde(skip_serializing_if = "Option::is_none", rename = "spikecolor")]
-    spike_color: Option<ColorWrapper>,
+    spike_color: Option<Box<dyn Color>>,
     #[serde(skip_serializing_if = "Option::is_none", rename = "spikethickness")]
     spike_thickness: Option<usize>,
     #[serde(skip_serializing_if = "Option::is_none", rename = "spikedash")]
@@ -844,25 +844,25 @@ pub struct Axis {
     #[serde(skip_serializing_if = "Option::is_none", rename = "showline")]
     show_line: Option<bool>,
     #[serde(skip_serializing_if = "Option::is_none", rename = "linecolor")]
-    line_color: Option<ColorWrapper>,
+    line_color: Option<Box<dyn Color>>,
     #[serde(skip_serializing_if = "Option::is_none", rename = "linewidth")]
     line_width: Option<usize>,
     #[serde(skip_serializing_if = "Option::is_none", rename = "showgrid")]
     show_grid: Option<bool>,
     #[serde(skip_serializing_if = "Option::is_none", rename = "gridcolor")]
-    grid_color: Option<ColorWrapper>,
+    grid_color: Option<Box<dyn Color>>,
     #[serde(skip_serializing_if = "Option::is_none", rename = "gridwidth")]
     grid_width: Option<usize>,
     #[serde(skip_serializing_if = "Option::is_none", rename = "zeroline")]
     zero_line: Option<bool>,
     #[serde(skip_serializing_if = "Option::is_none", rename = "zerolinecolor")]
-    zero_line_color: Option<ColorWrapper>,
+    zero_line_color: Option<Box<dyn Color>>,
     #[serde(skip_serializing_if = "Option::is_none", rename = "zerolinewidth")]
     zero_line_width: Option<usize>,
     #[serde(skip_serializing_if = "Option::is_none", rename = "showdividers")]
     show_dividers: Option<bool>,
     #[serde(skip_serializing_if = "Option::is_none", rename = "dividercolor")]
-    divider_color: Option<ColorWrapper>,
+    divider_color: Option<Box<dyn Color>>,
     #[serde(skip_serializing_if = "Option::is_none", rename = "dividerwidth")]
     divider_width: Option<usize>,
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -901,7 +901,7 @@ impl Axis {
     }
 
     pub fn color<C: Color>(mut self, color: C) -> Self {
-        self.color = Some(color.to_color());
+        self.color = Some(Box::new(color));
         self
     }
 
@@ -1001,7 +1001,7 @@ impl Axis {
     }
 
     pub fn tick_color<C: Color>(mut self, tick_color: C) -> Self {
-        self.tick_color = Some(tick_color.to_color());
+        self.tick_color = Some(Box::new(tick_color));
         self
     }
 
@@ -1021,7 +1021,7 @@ impl Axis {
     }
 
     pub fn spike_color<C: Color>(mut self, spike_color: C) -> Self {
-        self.spike_color = Some(spike_color.to_color());
+        self.spike_color = Some(Box::new(spike_color));
         self
     }
 
@@ -1111,7 +1111,7 @@ impl Axis {
     }
 
     pub fn line_color<C: Color>(mut self, line_color: C) -> Self {
-        self.line_color = Some(line_color.to_color());
+        self.line_color = Some(Box::new(line_color));
         self
     }
 
@@ -1126,7 +1126,7 @@ impl Axis {
     }
 
     pub fn grid_color<C: Color>(mut self, grid_color: C) -> Self {
-        self.grid_color = Some(grid_color.to_color());
+        self.grid_color = Some(Box::new(grid_color));
         self
     }
 
@@ -1141,7 +1141,7 @@ impl Axis {
     }
 
     pub fn zero_line_color<C: Color>(mut self, zero_line_color: C) -> Self {
-        self.zero_line_color = Some(zero_line_color.to_color());
+        self.zero_line_color = Some(Box::new(zero_line_color));
         self
     }
 
@@ -1156,7 +1156,7 @@ impl Axis {
     }
 
     pub fn divider_color<C: Color>(mut self, divider_color: C) -> Self {
-        self.divider_color = Some(divider_color.to_color());
+        self.divider_color = Some(Box::new(divider_color));
         self
     }
 
@@ -1435,11 +1435,11 @@ pub struct ModeBar {
     #[serde(skip_serializing_if = "Option::is_none")]
     orientation: Option<Orientation>,
     #[serde(skip_serializing_if = "Option::is_none", rename = "bgcolor")]
-    background_color: Option<ColorWrapper>,
+    background_color: Option<Box<dyn Color>>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    color: Option<ColorWrapper>,
+    color: Option<Box<dyn Color>>,
     #[serde(skip_serializing_if = "Option::is_none", rename = "activecolor")]
-    active_color: Option<ColorWrapper>,
+    active_color: Option<Box<dyn Color>>,
 }
 
 impl ModeBar {
@@ -1453,17 +1453,17 @@ impl ModeBar {
     }
 
     pub fn background_color<C: Color>(mut self, background_color: C) -> Self {
-        self.background_color = Some(background_color.to_color());
+        self.background_color = Some(Box::new(background_color));
         self
     }
 
     pub fn color<C: Color>(mut self, color: C) -> Self {
-        self.color = Some(color.to_color());
+        self.color = Some(Box::new(color));
         self
     }
 
     pub fn active_color<C: Color>(mut self, active_color: C) -> Self {
-        self.active_color = Some(active_color.to_color());
+        self.active_color = Some(Box::new(active_color));
         self
     }
 }
@@ -1501,7 +1501,7 @@ pub enum FillRule {
 #[derive(Serialize, Debug, Default, Clone)]
 pub struct ShapeLine {
     #[serde(skip_serializing_if = "Option::is_none")]
-    color: Option<ColorWrapper>,
+    color: Option<Box<dyn Color>>,
     #[serde(skip_serializing_if = "Option::is_none")]
     width: Option<f64>,
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -1515,7 +1515,7 @@ impl ShapeLine {
 
     /// Sets the line color.
     pub fn color<C: Color>(mut self, color: C) -> Self {
-        self.color = Some(color.to_color());
+        self.color = Some(Box::new(color));
         self
     }
 
@@ -1568,7 +1568,7 @@ pub struct Shape {
     #[serde(skip_serializing_if = "Option::is_none")]
     line: Option<ShapeLine>,
     #[serde(skip_serializing_if = "Option::is_none", rename = "fillcolor")]
-    fill_color: Option<ColorWrapper>,
+    fill_color: Option<Box<dyn Color>>,
     #[serde(skip_serializing_if = "Option::is_none", rename = "fillrule")]
     fill_rule: Option<FillRule>,
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -1724,7 +1724,7 @@ impl Shape {
 
     /// Sets the color filling the shape's interior. Only applies to closed shapes.
     pub fn fill_color<C: Color>(mut self, fill_color: C) -> Self {
-        self.fill_color = Some(fill_color.to_color());
+        self.fill_color = Some(Box::new(fill_color));
         self
     }
 
@@ -1777,7 +1777,7 @@ pub struct NewShape {
     #[serde(skip_serializing_if = "Option::is_none")]
     line: Option<ShapeLine>,
     #[serde(skip_serializing_if = "Option::is_none", rename = "fillcolor")]
-    fill_color: Option<ColorWrapper>,
+    fill_color: Option<Box<dyn Color>>,
     #[serde(skip_serializing_if = "Option::is_none", rename = "fillrule")]
     fill_rule: Option<FillRule>,
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -1803,7 +1803,7 @@ impl NewShape {
     /// alpha greater than half, drag inside the active shape starts moving the shape underneath,
     /// otherwise a new shape could be started over.
     pub fn fill_color<C: Color>(mut self, fill_color: C) -> Self {
-        self.fill_color = Some(fill_color.to_color());
+        self.fill_color = Some(Box::new(fill_color));
         self
     }
 
@@ -1839,7 +1839,7 @@ impl NewShape {
 #[derive(Serialize, Debug, Default, Clone)]
 pub struct ActiveShape {
     #[serde(skip_serializing_if = "Option::is_none", rename = "fillcolor")]
-    fill_color: Option<ColorWrapper>,
+    fill_color: Option<Box<dyn Color>>,
     #[serde(skip_serializing_if = "Option::is_none")]
     opacity: Option<f64>,
 }
@@ -1851,7 +1851,7 @@ impl ActiveShape {
 
     /// Sets the color filling the active shape' interior.
     pub fn fill_color<C: Color>(mut self, fill_color: C) -> Self {
-        self.fill_color = Some(fill_color.to_color());
+        self.fill_color = Some(Box::new(fill_color));
         self
     }
 
@@ -1913,9 +1913,9 @@ pub struct Annotation {
     #[serde(skip_serializing_if = "Option::is_none")]
     valign: Option<VAlign>,
     #[serde(skip_serializing_if = "Option::is_none", rename = "bgcolor")]
-    background_color: Option<ColorWrapper>,
+    background_color: Option<Box<dyn Color>>,
     #[serde(skip_serializing_if = "Option::is_none", rename = "bordercolor")]
-    border_color: Option<ColorWrapper>,
+    border_color: Option<Box<dyn Color>>,
     #[serde(skip_serializing_if = "Option::is_none", rename = "borderpad")]
     border_pad: Option<f64>,
     #[serde(skip_serializing_if = "Option::is_none", rename = "borderwidth")]
@@ -1923,7 +1923,7 @@ pub struct Annotation {
     #[serde(skip_serializing_if = "Option::is_none", rename = "showarrow")]
     show_arrow: Option<bool>,
     #[serde(skip_serializing_if = "Option::is_none", rename = "arrowcolor")]
-    arrow_color: Option<ColorWrapper>,
+    arrow_color: Option<Box<dyn Color>>,
     #[serde(skip_serializing_if = "Option::is_none", rename = "arrowhead")]
     arrow_head: Option<u8>,
     #[serde(skip_serializing_if = "Option::is_none", rename = "startarrowhead")]
@@ -2050,13 +2050,13 @@ impl Annotation {
 
     /// Sets the background color of the annotation.
     pub fn background_color<C: Color>(mut self, background_color: C) -> Self {
-        self.background_color = Some(background_color.to_color());
+        self.background_color = Some(Box::new(background_color));
         self
     }
 
     /// Sets the color of the border enclosing the annotation `text`.
     pub fn border_color<C: Color>(mut self, border_color: C) -> Self {
-        self.border_color = Some(border_color.to_color());
+        self.border_color = Some(Box::new(border_color));
         self
     }
 
@@ -2081,7 +2081,7 @@ impl Annotation {
 
     /// Sets the color of the annotation arrow.
     pub fn arrow_color<C: Color>(mut self, arrow_color: C) -> Self {
-        self.arrow_color = Some(arrow_color.to_color());
+        self.arrow_color = Some(Box::new(arrow_color));
         self
     }
 
@@ -2434,13 +2434,13 @@ pub struct LayoutTemplate {
     #[serde(skip_serializing_if = "Option::is_none")]
     separators: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none", rename = "paper_bgcolor")]
-    paper_background_color: Option<ColorWrapper>,
+    paper_background_color: Option<Box<dyn Color>>,
     #[serde(skip_serializing_if = "Option::is_none", rename = "plot_bgcolor")]
-    plot_background_color: Option<ColorWrapper>,
+    plot_background_color: Option<Box<dyn Color>>,
     #[serde(skip_serializing_if = "Option::is_none", rename = "colorscale")]
     color_scale: Option<LayoutColorScale>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    colorway: Option<Vec<ColorWrapper>>,
+    colorway: Option<Vec<Box<dyn Color>>>,
     #[serde(skip_serializing_if = "Option::is_none", rename = "coloraxis")]
     color_axis: Option<ColorAxis>,
     #[serde(skip_serializing_if = "Option::is_none", rename = "modebar")]
@@ -2541,12 +2541,12 @@ pub struct LayoutTemplate {
     waterfall_group_gap: Option<f64>,
 
     #[serde(skip_serializing_if = "Option::is_none", rename = "piecolorway")]
-    pie_colorway: Option<Vec<ColorWrapper>>,
+    pie_colorway: Option<Vec<Box<dyn Color>>>,
     #[serde(skip_serializing_if = "Option::is_none", rename = "extendpiecolors")]
     extend_pie_colors: Option<bool>,
 
     #[serde(skip_serializing_if = "Option::is_none", rename = "sunburstcolorway")]
-    sunburst_colorway: Option<Vec<ColorWrapper>>,
+    sunburst_colorway: Option<Vec<Box<dyn Color>>>,
     #[serde(
         skip_serializing_if = "Option::is_none",
         rename = "extendsunburstcolors"
@@ -2610,12 +2610,12 @@ impl LayoutTemplate {
     }
 
     pub fn paper_background_color<C: Color>(mut self, paper_background_color: C) -> Self {
-        self.paper_background_color = Some(paper_background_color.to_color());
+        self.paper_background_color = Some(Box::new(paper_background_color));
         self
     }
 
     pub fn plot_background_color<C: Color>(mut self, plot_background_color: C) -> Self {
-        self.plot_background_color = Some(plot_background_color.to_color());
+        self.plot_background_color = Some(Box::new(plot_background_color));
         self
     }
 
@@ -2625,8 +2625,7 @@ impl LayoutTemplate {
     }
 
     pub fn colorway<C: Color>(mut self, colorway: Vec<C>) -> Self {
-        let colorway = private::to_color_array(colorway);
-        self.colorway = Some(colorway);
+        self.colorway = Some(ColorArray(colorway).into());
         self
     }
 
@@ -2875,8 +2874,7 @@ impl LayoutTemplate {
     }
 
     pub fn pie_colorway<C: Color>(mut self, pie_colorway: Vec<C>) -> Self {
-        let pie_colorway = private::to_color_array(pie_colorway);
-        self.pie_colorway = Some(pie_colorway);
+        self.pie_colorway = Some(ColorArray(pie_colorway).into());
         self
     }
 
@@ -2886,8 +2884,7 @@ impl LayoutTemplate {
     }
 
     pub fn sunburst_colorway<C: Color>(mut self, sunburst_colorway: Vec<C>) -> Self {
-        let sunburst_colorway = private::to_color_array(sunburst_colorway);
-        self.sunburst_colorway = Some(sunburst_colorway);
+        self.sunburst_colorway = Some(ColorArray(sunburst_colorway).into());
         self
     }
 
@@ -2920,13 +2917,13 @@ pub struct Layout {
     #[serde(skip_serializing_if = "Option::is_none")]
     separators: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none", rename = "paper_bgcolor")]
-    paper_background_color: Option<ColorWrapper>,
+    paper_background_color: Option<Box<dyn Color>>,
     #[serde(skip_serializing_if = "Option::is_none", rename = "plot_bgcolor")]
-    plot_background_color: Option<ColorWrapper>,
+    plot_background_color: Option<Box<dyn Color>>,
     #[serde(skip_serializing_if = "Option::is_none", rename = "colorscale")]
     color_scale: Option<LayoutColorScale>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    colorway: Option<Vec<ColorWrapper>>,
+    colorway: Option<Vec<Box<dyn Color>>>,
     #[serde(skip_serializing_if = "Option::is_none", rename = "coloraxis")]
     color_axis: Option<ColorAxis>,
     #[serde(skip_serializing_if = "Option::is_none", rename = "modebar")]
@@ -3030,12 +3027,12 @@ pub struct Layout {
     waterfall_group_gap: Option<f64>,
 
     #[serde(skip_serializing_if = "Option::is_none", rename = "piecolorway")]
-    pie_colorway: Option<Vec<ColorWrapper>>,
+    pie_colorway: Option<Vec<Box<dyn Color>>>,
     #[serde(skip_serializing_if = "Option::is_none", rename = "extendpiecolors")]
     extend_pie_colors: Option<bool>,
 
     #[serde(skip_serializing_if = "Option::is_none", rename = "sunburstcolorway")]
-    sunburst_colorway: Option<Vec<ColorWrapper>>,
+    sunburst_colorway: Option<Vec<Box<dyn Color>>>,
     #[serde(
         skip_serializing_if = "Option::is_none",
         rename = "extendsunburstcolors"
@@ -3103,12 +3100,12 @@ impl Layout {
     }
 
     pub fn paper_background_color<C: Color>(mut self, paper_background_color: C) -> Self {
-        self.paper_background_color = Some(paper_background_color.to_color());
+        self.paper_background_color = Some(Box::new(paper_background_color));
         self
     }
 
     pub fn plot_background_color<C: Color>(mut self, plot_background_color: C) -> Self {
-        self.plot_background_color = Some(plot_background_color.to_color());
+        self.plot_background_color = Some(Box::new(plot_background_color));
         self
     }
 
@@ -3118,8 +3115,7 @@ impl Layout {
     }
 
     pub fn colorway<C: Color>(mut self, colorway: Vec<C>) -> Self {
-        let colorway = private::to_color_array(colorway);
-        self.colorway = Some(colorway);
+        self.colorway = Some(ColorArray(colorway).into());
         self
     }
 
@@ -3376,8 +3372,7 @@ impl Layout {
     }
 
     pub fn pie_colorway<C: Color>(mut self, pie_colorway: Vec<C>) -> Self {
-        let pie_colorway = private::to_color_array(pie_colorway);
-        self.pie_colorway = Some(pie_colorway);
+        self.pie_colorway = Some(ColorArray(pie_colorway).into());
         self
     }
 
@@ -3387,8 +3382,7 @@ impl Layout {
     }
 
     pub fn sunburst_colorway<C: Color>(mut self, sunburst_colorway: Vec<C>) -> Self {
-        let sunburst_colorway = private::to_color_array(sunburst_colorway);
-        self.sunburst_colorway = Some(sunburst_colorway);
+        self.sunburst_colorway = Some(ColorArray(sunburst_colorway).into());
         self
     }
 
@@ -3926,10 +3920,10 @@ mod tests {
             "linecolor": "#CCCDDD",
             "linewidth": 9,
             "showgrid": false,
-            "gridcolor": "#FFF000",
+            "gridcolor": "#fff000",
             "gridwidth": 8,
             "zeroline": true,
-            "zerolinecolor": "#F0F0F0",
+            "zerolinecolor": "#f0f0f0",
             "zerolinewidth": 7,
             "showdividers": false,
             "dividercolor": "#AFAFAF",

--- a/plotly/src/layout/themes.rs
+++ b/plotly/src/layout/themes.rs
@@ -177,7 +177,7 @@ mod tests {
         plot.add_trace(Bar::new(vec![0], vec![1]));
 
         let expected =
-            r##"{"template":{"layout":{"title":{"text":"","x":0.05},"font":{"color":"#F2F5FA"}"##; // etc...
+            r##"{"template":{"layout":{"title":{"text":"","x":0.05},"font":{"color":"#f2f5fa"}"##; // etc...
         assert!(plot.to_json().contains(expected));
     }
 }

--- a/plotly/src/lib.rs
+++ b/plotly/src/lib.rs
@@ -18,7 +18,7 @@ pub mod layout;
 pub mod plot;
 mod traces;
 
-pub use common::color::{NamedColor, Rgb, Rgba};
+pub use common::color;
 pub use configuration::Configuration;
 pub use layout::Layout;
 pub use plot::{ImageFormat, Plot, Trace};

--- a/plotly/src/private.rs
+++ b/plotly/src/private.rs
@@ -1,7 +1,5 @@
 use serde::Serialize;
 
-use crate::common::color::{Color, ColorWrapper};
-
 #[cfg(feature = "plotly_ndarray")]
 use crate::ndarray::ArrayTraces;
 #[cfg(feature = "plotly_ndarray")]
@@ -11,14 +9,6 @@ pub fn owned_string_vector<S: AsRef<str>>(s: Vec<S>) -> Vec<String> {
     s.iter()
         .map(|x| x.as_ref().to_string())
         .collect::<Vec<String>>()
-}
-
-pub fn to_color_array<C: Color>(v: Vec<C>) -> Vec<ColorWrapper> {
-    let mut sv: Vec<ColorWrapper> = Vec::with_capacity(v.len());
-    for e in v.iter() {
-        sv.push(e.to_color());
-    }
-    sv
 }
 
 #[derive(Serialize, Clone, Debug, PartialEq)]

--- a/plotly/src/traces/box_plot.rs
+++ b/plotly/src/traces/box_plot.rs
@@ -1,6 +1,6 @@
 //! Box plot
 
-use crate::common::color::{Color, ColorWrapper};
+use crate::color::Color;
 use crate::common::{
     Calendar, Dim, HoverInfo, Label, Line, Marker, Orientation, PlotType, Visible,
 };
@@ -134,7 +134,7 @@ where
     #[serde(skip_serializing_if = "Option::is_none", rename = "quartilemethod")]
     quartile_method: Option<QuartileMethod>,
     #[serde(skip_serializing_if = "Option::is_none", rename = "fillcolor")]
-    fill_color: Option<ColorWrapper>,
+    fill_color: Option<Box<dyn Color>>,
     #[serde(skip_serializing_if = "Option::is_none", rename = "hoverlabel")]
     hover_label: Option<Label>,
     #[serde(skip_serializing_if = "Option::is_none", rename = "hoveron")]
@@ -364,7 +364,7 @@ where
     }
 
     pub fn fill_color<C: Color>(mut self, fill_color: C) -> Box<BoxPlot<Y, X>> {
-        self.fill_color = Some(fill_color.to_color());
+        self.fill_color = Some(Box::new(fill_color));
         Box::new(self)
     }
 

--- a/plotly/src/traces/candlestick.rs
+++ b/plotly/src/traces/candlestick.rs
@@ -1,6 +1,6 @@
 //! Candlestick plot
 
-use crate::common::color::NamedColor;
+use crate::color::NamedColor;
 use crate::common::{Calendar, Dim, Direction, HoverInfo, Label, Line, PlotType, Visible};
 use crate::private;
 use crate::Trace;

--- a/plotly/src/traces/contour.rs
+++ b/plotly/src/traces/contour.rs
@@ -1,6 +1,6 @@
 //! Contour plot
 
-use crate::common::color::{Color, ColorWrapper};
+use crate::color::Color;
 use crate::common::{
     Calendar, ColorBar, ColorScale, Dim, Font, HoverInfo, Label, Line, PlotType, Visible,
 };
@@ -193,7 +193,7 @@ where
     #[serde(skip_serializing_if = "Option::is_none")]
     contours: Option<Contours>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    fill_color: Option<ColorWrapper>,
+    fill_color: Option<Box<dyn Color>>,
     #[serde(skip_serializing_if = "Option::is_none", rename = "hoverlabel")]
     hover_label: Option<Label>,
     #[serde(skip_serializing_if = "Option::is_none", rename = "hoverongaps")]
@@ -404,7 +404,7 @@ where
     }
 
     pub fn fill_color<C: Color>(mut self, fill_color: C) -> Box<Contour<Z, X, Y>> {
-        self.fill_color = Some(fill_color.to_color());
+        self.fill_color = Some(Box::new(fill_color));
         Box::new(self)
     }
 

--- a/plotly/src/traces/ohlc.rs
+++ b/plotly/src/traces/ohlc.rs
@@ -1,6 +1,6 @@
 //! Open-high-low-close (OHLC) plot
 
-use crate::common::color::NamedColor;
+use crate::color::NamedColor;
 use crate::common::{Calendar, Dim, Direction, HoverInfo, Label, Line, PlotType, Visible};
 use crate::private;
 use crate::Trace;

--- a/plotly/src/traces/scatter.rs
+++ b/plotly/src/traces/scatter.rs
@@ -1,6 +1,6 @@
 //! Scatter plot
 
-use crate::common::color::{Color, ColorWrapper};
+use crate::color::Color;
 use crate::common::{
     Calendar, Dim, ErrorData, Fill, Font, GroupNorm, HoverInfo, Label, Line, Marker, Mode,
     Orientation, PlotType, Position, Visible,
@@ -97,7 +97,7 @@ where
     #[serde(skip_serializing_if = "Option::is_none")]
     fill: Option<Fill>,
     #[serde(skip_serializing_if = "Option::is_none", rename = "fillcolor")]
-    fill_color: Option<ColorWrapper>,
+    fill_color: Option<Box<dyn Color>>,
     #[serde(skip_serializing_if = "Option::is_none", rename = "hoverlabel")]
     hover_label: Option<Label>,
     #[serde(skip_serializing_if = "Option::is_none", rename = "hoveron")]
@@ -603,7 +603,7 @@ where
     /// Sets the fill color. Defaults to a half-transparent variant of the line color, marker color,
     /// or marker line color, whichever is available.
     pub fn fill_color<C: Color>(mut self, fill_color: C) -> Box<Self> {
-        self.fill_color = Some(fill_color.to_color());
+        self.fill_color = Some(Box::new(fill_color));
         Box::new(self)
     }
 

--- a/plotly/src/traces/scatter_polar.rs
+++ b/plotly/src/traces/scatter_polar.rs
@@ -2,7 +2,7 @@
 
 use serde::Serialize;
 
-use crate::common::color::{Color, ColorWrapper};
+use crate::color::Color;
 use crate::common::{
     Dim, Fill, Font, GroupNorm, HoverInfo, Label, Line, Marker, Mode, Orientation, PlotType,
     Position, Visible,
@@ -94,7 +94,7 @@ where
     #[serde(skip_serializing_if = "Option::is_none")]
     fill: Option<Fill>,
     #[serde(skip_serializing_if = "Option::is_none", rename = "fillcolor")]
-    fill_color: Option<ColorWrapper>,
+    fill_color: Option<Box<dyn Color>>,
     #[serde(skip_serializing_if = "Option::is_none", rename = "hoverlabel")]
     hover_label: Option<Label>,
     #[serde(skip_serializing_if = "Option::is_none", rename = "hoveron")]
@@ -584,7 +584,7 @@ where
     /// Sets the fill color. Defaults to a half-transparent variant of the line color, marker color,
     /// or marker line color, whichever is available.
     pub fn fill_color<C: Color>(mut self, fill_color: C) -> Box<Self> {
-        self.fill_color = Some(fill_color.to_color());
+        self.fill_color = Some(Box::new(fill_color));
         Box::new(self)
     }
 

--- a/plotly/src/traces/surface.rs
+++ b/plotly/src/traces/surface.rs
@@ -1,6 +1,6 @@
 //! Surface plot
 
-use crate::common::color::{Color, ColorWrapper};
+use crate::color::{Color, ColorArray};
 use crate::common::{Calendar, ColorBar, ColorScale, Dim, HoverInfo, Label, PlotType, Visible};
 use crate::private;
 use crate::Trace;
@@ -108,7 +108,7 @@ pub struct PlaneContours {
     #[serde(skip_serializing_if = "Option::is_none")]
     project: Option<PlaneProject>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    color: Option<ColorWrapper>,
+    color: Option<Box<dyn Color>>,
     #[serde(skip_serializing_if = "Option::is_none", rename = "usecolormap")]
     use_colormap: Option<bool>,
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -116,7 +116,7 @@ pub struct PlaneContours {
     #[serde(skip_serializing_if = "Option::is_none")]
     highlight: Option<bool>,
     #[serde(skip_serializing_if = "Option::is_none", rename = "highlightcolor")]
-    highlight_color: Option<ColorWrapper>,
+    highlight_color: Option<Box<dyn Color>>,
     #[serde(skip_serializing_if = "Option::is_none", rename = "highlightwidth")]
     highlight_width: Option<usize>,
 }
@@ -152,7 +152,7 @@ impl PlaneContours {
     }
 
     pub fn color<C: Color>(mut self, color: C) -> PlaneContours {
-        self.color = Some(color.to_color());
+        self.color = Some(Box::new(color));
         self
     }
 
@@ -172,7 +172,7 @@ impl PlaneContours {
     }
 
     pub fn highlight_color<C: Color>(mut self, highlight_color: C) -> PlaneContours {
-        self.highlight_color = Some(highlight_color.to_color());
+        self.highlight_color = Some(Box::new(highlight_color));
         self
     }
 
@@ -237,7 +237,7 @@ where
     #[serde(skip_serializing_if = "Option::is_none")]
     opacity: Option<f64>,
     #[serde(skip_serializing_if = "Option::is_none", rename = "surfacecolor")]
-    surface_color: Option<Vec<ColorWrapper>>,
+    surface_color: Option<Vec<Box<dyn Color>>>,
     #[serde(skip_serializing_if = "Option::is_none")]
     text: Option<Dim<String>>,
     #[serde(skip_serializing_if = "Option::is_none", rename = "hovertext")]
@@ -334,8 +334,7 @@ where
     }
 
     pub fn surface_color<C: Color>(mut self, surface_color: Vec<C>) -> Box<Surface<X, Y, Z>> {
-        let surface_color = private::to_color_array(surface_color);
-        self.surface_color = Some(surface_color);
+        self.surface_color = Some(ColorArray(surface_color).into());
         Box::new(self)
     }
 


### PR DESCRIPTION
This is quite a large refactoring of the `color` module just to provide a slightly nicer implementation and interface. By prociding a public `Color` trait, end users can also implement it for their own color types, should they so desire. Tests are also included.