### PR TITLE
Align API for saving/showing plots more closely with plotly.py

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ gh-pages/
 Untitled*
 .ipynb_checkpoints/
 .DS_Store
+.vscode

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [0.8.0] - 2022-xx-xx
+Version 0.8.0 represents a significant release which refactors a lot of the codebase and tries to provide a cleaner API: there are several breaking changes listed below.
 ### Added
 - impl `Clone`, `Serialize` and `PartialEq` for `Plot`
 - impl `Clone` +/- `Copy` for color types
@@ -18,6 +19,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Improve implementation of `private::NumOrString` to support more primitive types ([Issue 
 #47](https://github.com/igiagkiozis/plotly/issues/47))
 - Remove `private::TruthyEnum` in favour of a more robust way of serializing to `String` or `bool`
+- Refactor `Color` module
+- Refactored HTML templates with cleaner Javascript code
+- `Plot::save()` is renamed to `Plot::write_image()`
+- `Plot::show_{png | jpeg}` is now made generic via the new `Plot::show_image()` across static image formats with the `ImageFormat` enum
+- `Plot::write_html()` now takes a filepath and saves the plot to that location
+- `Plot::to_html()` now has similar behaviour to `Plot::to_inline_html()` and just returns a `String`
 ### Fixed
 - Typos in `CONTRIBUTING.md`
 - Serialization of `plotly_kaleido::PlotData` ([Issue #50](https://github.com/igiagkiozis/plotly/issues/50))
@@ -26,8 +33,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `serde` to `1.0.132`.
 - `serde_json` to `1.0.73`.
 - `askama` to `0.11.0`.
-- `rand` to `0.8.4`.
-- `rand_distr` to `0.4.2`.
+- `rand` to `0.8`.
+- `rand_distr` to `0.4`.
 - `plotly.js` to `2.12.1`
 
 ## [0.7.0] - 2022-01-01

--- a/docs/book/src/getting_started.md
+++ b/docs/book/src/getting_started.md
@@ -18,38 +18,28 @@
 
 # Getting Started
 
-To start using [Plotly.rs](https://github.com/igiagkiozis/plotly) in your project add the following to your `Cargo.toml`:
+To start using [plotly.rs](https://github.com/igiagkiozis/plotly) in your project add the following to your `Cargo.toml`:
 
 ```toml
 [dependencies]
 plotly = "0.7.0"
 ```
 
-To add the ability to save plots in the following formats: png, jpeg, webp, svg, pdf and eps, you can use the `kaleido` feature. This feature depends on [plotly/Kaleido](https://github.com/plotly/Kaleido); a cross-platform library for generating static images. All the necessary binaries have been included with `plotly_kaleido` for `linux`, `windows` and `macos`. Previous versions of [Plotly.rs](https://github.com/igiagkiozis/plotly) used the `orca` feature; however this has been deprecated as it provided the same functionality but required additional installation steps. To enable the `kaleido` feature add the following to your `Cargo.toml` instead: 
+[Plotly.rs](https://github.com/igiagkiozis/plotly) is ultimately a thin wrapper around the `plotly.js` library. The main job of this library is to provide `structs` and `enums` which get serialized to `json` and passed to the `plotly.js` library to actually do the heavy lifting. As such, if you are familiar with `plotly.js` or its derivatives (e.g. the equivalent Python library), then you should find [`plotly.rs`](https://github.com/igiagkiozis/plotly) intuitive to use.
 
-```toml
-[dependencies]
-plotly = { version = "0.7.0", features = ["kaleido"] }
-```
+A `Plot` struct contains one or more `Trace` objects which describe the structure of data to be displayed. Optional `Layout` and `Configuration` structs can be used to specify the layout and config of the plot, respectively.
 
-Plotly Kaleido is an open source project 
+The builder pattern is used extensively throughout the library, which means you only need to specify the attributes and details you desire. Any attributes that are not set will fall back to the default value used by `plotly.js`.
 
-
-[Plotly.rs](https://github.com/igiagkiozis/plotly) has three main components: 
-
-- Traces; these are containers for the data for display,
-- Layout, fine tunes the display of traces on the canvas and more generally controls the way that the plot is displayed, and,
-- Plot; is the component that brings traces and the layout together to display the plot in either html format or rasterise the resulting view.
-
-All available traces (e.g. `Scatter`, `Bar`, `Histogram` etc), the `Layout` and `Plot` have been hoisted in the `plotly` namespace so that they can be imported simply using the following: 
+All available traces (e.g. `Scatter`, `Bar`, `Histogram`, etc), the `Layout`, `Configuration` and  `Plot` have been hoisted in the `plotly` namespace so that they can be imported simply using the following: 
 
 ```rust
 use plotly::{Plot, Layout, Scatter};
 ```
 
 The aforementioned components can be combined to produce as simple plot as follows: 
+
 ```rust
-extern crate plotly;
 use plotly::common::Mode;
 use plotly::{Plot, Scatter};
 
@@ -75,26 +65,37 @@ fn main() -> std::io::Result<()> {
 }
 ```
 
-which results in the following figure: 
+which results in the following figure (displayed here as a static png file): 
 
 ![line_and_scatter_plot](img/line_and_scatter_plot.png)
 
-The above code will generate an html page of the `Plot` and display it in the default browser. The `html` for the plot is stored in the platform specific temporary directory. To save the `html` result the following can be used: 
+The above code will generate an interactive `html` page of the `Plot` and display it in the default browser. The `html` for the plot is stored in the platform specific temporary directory. To save the `html` result, you can do so quite simply: 
 
 ```rust
-plot.to_html("/home/user/line_and_scatter_plot.html");
+plot.write_html("/home/user/line_and_scatter_plot.html");
 ```
 
-It is often the case that plots are produced to be included in a document and a different format for the plot is desirable (e.g. png, jpeg etc). Given that the `html` version of the plot is composed of vector graphics, the display when converted to a non-vector format (e.g. png) is not guaranteed to be identical to the one displayed in `html`. This means that some fine tuning may be required to get to the desired output. To support that iterative workflow the `Plot` has `show_*` methods which display the rasterised output to the target format, for example this: 
+It is often the case that plots are produced to be included in a document and a different format for the plot is desirable (e.g. png, jpeg, etc). Given that the `html` version of the plot is composed of vector graphics, the display when converted to a non-vector format (e.g. png) is not guaranteed to be identical to the one displayed in `html`. This means that some fine tuning may be required to get to the desired output. To support that iterative workflow, `Plot` has a `show_image()` method which will display the rasterised output to the target format, for example: 
 
 ```rust
-plot.show_png(1280, 900);
+plot.show_image(ImageFormat::PNG, 1280, 900);
 ```
 
-will display in the browser the rasterised plot; 1280 pixels wide and 900 pixels tall, in png format. Once a satisfactory result is achieved, and assuming the `kaleido` feature is enabled, the plot can be saved using the following: 
+will display in the browser the rasterised plot; 1280 pixels wide and 900 pixels tall, in png format.
+
+Once a satisfactory result is achieved, and assuming the [`kaleido`](getting_started#saving-plots) feature is enabled, the plot can be saved using the following: 
 
 ```rust
-plot.save("/home/user/plot_name.ext", ImageFormat::PNG, 1280, 900, 1.0);
+plot.write_image("/home/user/plot_name.ext", ImageFormat::PNG, 1280, 900, 1.0);
 ```
 
-The extension in the file-name path is optional as the appropriate extension (`ImageFormat::PNG`) will be included. Note that in all functions that save files to disk both relative and absolute paths are supported.
+The extension in the file-name path is optional as the appropriate extension (`ImageFormat::PNG`) will be included. Note that in all functions that save files to disk, both relative and absolute paths are supported.
+
+## Saving Plots
+
+To add the ability to save plots in the following formats: png, jpeg, webp, svg, pdf and eps, you can use the `kaleido` feature. This feature depends on [plotly/Kaleido](https://github.com/plotly/Kaleido): a cross-platform open source library for generating static images. All the necessary binaries have been included with `plotly_kaleido` for `Linux`, `Windows` and `MacOS`. Previous versions of [plotly.rs](https://github.com/igiagkiozis/plotly) used the `orca` feature, however, this has been deprecated as it provided the same functionality but required additional installation steps. To enable the `kaleido` feature add the following to your `Cargo.toml`: 
+
+```toml
+[dependencies]
+plotly = { version = "0.7.0", features = ["kaleido"] }
+```

--- a/docs/book/src/plotly_rs.md
+++ b/docs/book/src/plotly_rs.md
@@ -18,16 +18,19 @@
 
 # Plotly.rs
 
-Plotly.rs is a plotting library powered by [Plotly.js](https://plot.ly/javascript/). The aim is to bring over to Rust all the functionality that `Python` users have come to rely on; with the added benefit of type safety and speed.
+Plotly.rs is a plotting library powered by [Plotly.js](https://plot.ly/javascript/). The aim is to bring over to Rust all the functionality that `Python` users have come to rely on with the added benefit of type safety and speed.
 
 Plotly.rs is free and open source. You can find the source on [GitHub](https://github.com/igiagkiozis/plotly). Issues and feature requests can be posted on the [issue tracker](https://github.com/igiagkiozis/plotly/issues).
 
 ## API Docs
 
-This book is intended to be a *recipe* index and is complemented by the [API documentation](https://docs.rs/plotly).
+This book is intended to be a recipe index, which closely follows the [plotly.js examples](https://plotly.com/javascript/), and is complemented by the [API documentation](https://docs.rs/plotly).
+
+## Contributing
+Contributions are always welcomed, no matter how large or small. Refer to the [contributing guidelines](https://github.com/igiagkiozis/plotly/blob/master/CONTRIBUTING.md) for further pointers, and, if in doubt, [open an issue](https://github.com/igiagkiozis/plotly/issues).
 
 ## License
 
 Plotly.rs is distributed under the terms of the MIT license.
 
-See [LICENSE-MIT](LICENSE-MIT), and [COPYRIGHT](COPYRIGHT) for details.
+See [LICENSE-MIT](https://github.com/igiagkiozis/plotly/blob/master/LICENSE-MIT), and [COPYRIGHT](https://github.com/igiagkiozis/plotly/blob/master/COPYRIGHT) for details.

--- a/plotly/Cargo.toml
+++ b/plotly/Cargo.toml
@@ -32,8 +32,8 @@ once_cell = "1"
 serde = { version = "1.0.132", features = ["derive"] }
 serde_json = "1.0.73"
 serde_repr = "0.1"
-rand = "0.8.4"
-rand_distr = "0.4.2"
+rand = "0.8"
+rand_distr = "0.4"
 wasm-bindgen = { version = "0.2", optional = true }
 wasm-bindgen-futures = { version = "0.4", optional = true }
 

--- a/plotly/src/plot.rs
+++ b/plotly/src/plot.rs
@@ -1,32 +1,32 @@
-#[cfg(feature = "kaleido")]
-extern crate plotly_kaleido;
-
 use askama::Template;
 use dyn_clone::DynClone;
 use erased_serde::Serialize as ErasedSerialize;
-use rand::{thread_rng, Rng};
+use rand::{
+    distributions::{Alphanumeric, DistString},
+    thread_rng,
+};
 use serde::Serialize;
 use std::fs::File;
 use std::io::Write;
 use std::path::Path;
 
 use crate::{Configuration, Layout};
-use rand_distr::Alphanumeric;
-
-#[derive(Template)]
-#[template(path = "plotly.min.js", escape = "none")]
-struct PlotlyJs;
 
 #[derive(Template)]
 #[template(path = "plot.html", escape = "none")]
 struct PlotTemplate<'a> {
     plot: &'a Plot,
-    plotly_javascript: &'a str,
     remote_plotly_js: bool,
-    export_image: bool,
-    image_type: &'a str,
-    image_width: usize,
-    image_height: usize,
+}
+
+#[derive(Template)]
+#[template(path = "static_plot.html", escape = "none")]
+struct StaticPlotTemplate<'a> {
+    plot: &'a Plot,
+    format: ImageFormat,
+    remote_plotly_js: bool,
+    width: usize,
+    height: usize,
 }
 
 #[derive(Template)]
@@ -43,7 +43,30 @@ struct JupyterNotebookPlotTemplate<'a> {
     plot_div_id: &'a str,
 }
 
+#[cfg(not(feature = "wasm"))]
+const DEFAULT_HTML_APP_NOT_FOUND: &str = r#"Could not find default application for HTML files.
+Consider using the `to_html` method obtain a string representation instead. If using the `kaleido` feature the
+`write_image` method can be used to produce a static image in one of the following formats:
+- ImageFormat::PNG
+- ImageFormat::JPEG
+- ImageFormat::WEBP
+- ImageFormat::SVG
+- ImageFormat::PDF
+- ImageFormat::EPS
+
+Used as follows:
+let plot = Plot::new();
+...
+let width = 1024;
+let height = 680;
+let scale = 1.0;
+plot.write_image("filename", ImageFormat::PNG, width, height, scale);
+
+See https://igiagkiozis.github.io/plotly/content/getting_started.html for further details.
+"#;
+
 /// Image format for static image export.
+#[derive(Debug)]
 pub enum ImageFormat {
     PNG,
     JPEG,
@@ -51,6 +74,23 @@ pub enum ImageFormat {
     SVG,
     PDF,
     EPS,
+}
+
+impl std::fmt::Display for ImageFormat {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(
+            f,
+            "{}",
+            match self {
+                Self::PNG => "png",
+                Self::JPEG => "jpeg",
+                Self::WEBP => "webp",
+                Self::SVG => "svg",
+                Self::PDF => "pdf",
+                Self::EPS => "eps",
+            }
+        )
+    }
 }
 
 /// A struct that implements `Trace` can be serialized to json format that is understood by Plotly.js.
@@ -98,7 +138,6 @@ impl Traces {
 /// # Examples
 ///
 /// ```
-/// extern crate plotly;
 /// use plotly::common::Mode;
 /// use plotly::{Layout, Plot, Scatter};
 ///
@@ -109,7 +148,8 @@ impl Traces {
 ///     let trace2 = Scatter::new(vec![2, 3, 4, 5], vec![16, 5, 11, 9])
 ///         .name("trace2")
 ///         .mode(Mode::Lines);
-///     let trace3 = Scatter::new(vec![1, 2, 3, 4], vec![12, 9, 15, 12]).name("trace3");
+///     let trace3 = Scatter::new(vec![1, 2, 3, 4], vec![12, 9, 15, 12])
+///         .name("trace3");
 ///
 ///     let mut plot = Plot::new();
 ///     plot.add_trace(trace1);
@@ -138,28 +178,6 @@ pub struct Plot {
     remote_plotly_js: bool,
 }
 
-#[cfg(not(feature = "wasm"))]
-const DEFAULT_HTML_APP_NOT_FOUND: &str = r#"Could not find default application for HTML files.
-Consider using the `to_html` method to save the plot instead. If using the `kaleido` feature the
-`save` method can be used to produce a static image in one of the following formats:
-- ImageFormat::PNG
-- ImageFormat::JPEG
-- ImageFormat::WEBP
-- ImageFormat::SVG
-- ImageFormat::PDF
-- ImageFormat::EPS
-
-used as follows:
-let plot = Plot::new();
-...
-let width = 1024;
-let height = 680;
-let scale = 1.0;
-plot.save("filename", ImageFormat::PNG, width, height, scale);
-
-See https://igiagkiozis.github.io/plotly/content/getting_started.html for further details.
-"#;
-
 impl Plot {
     /// Create a new `Plot`.
     pub fn new() -> Plot {
@@ -172,6 +190,9 @@ impl Plot {
 
     /// This option results in the plotly.js library being written directly in the html output. The benefit is that the
     /// plot will load faster in the browser and the downside is that the resulting html will be much larger.
+    ///
+    /// Note that when using `Plot::to_inline_html()`, it is assumed that the `plotly.js` library is already in scope,
+    /// so setting this attribute will have no effect.
     pub fn use_local_plotly(&mut self) {
         self.remote_plotly_js = false;
     }
@@ -213,164 +234,103 @@ impl Plot {
         &self.configuration
     }
 
-    /// Renders the contents of the `Plot` and displays them in the system default browser.
+    /// Display the fully rendered HTML `Plot` in the default system browser.
     ///
-    /// This will serialize the `Trace`s and `Layout` in an html page which is saved in the temp
-    /// directory. For example on Linux it will generate a file `plotly_<22 random characters>.html`
-    /// in the /tmp directory.
+    /// The HTML file is saved in a temp file, from which it is read and displayed by the browser.
     #[cfg(not(feature = "wasm"))]
     pub fn show(&self) {
         use std::env;
 
-        let rendered = self.render(false, "", 0, 0);
-        let rendered = rendered.as_bytes();
-        let mut temp = env::temp_dir();
+        let rendered = self.render();
 
-        let mut plot_name = String::from_utf8(
-            thread_rng()
-                .sample_iter(&Alphanumeric)
-                .take(22)
-                .collect::<Vec<u8>>(),
-        )
-        .unwrap();
+        // Set up the temp file with a unique filename.
+        let mut temp = env::temp_dir();
+        let mut plot_name = Alphanumeric.sample_string(&mut thread_rng(), 22);
         plot_name.push_str(".html");
         plot_name = format!("plotly_{}", plot_name);
-
         temp.push(plot_name);
+
+        // Save the rendered plot to the temp file.
         let temp_path = temp.to_str().unwrap();
-        {
-            let mut file = File::create(temp_path).unwrap();
-            file.write_all(rendered)
-                .expect("failed to write html output");
-            file.flush().unwrap();
-        }
-
-        Plot::show_with_default_app(temp_path);
-    }
-
-    /// Renders the contents of the `Plot`, creates a png raster and displays it in the system default browser.
-    ///
-    /// To save the resulting png right-click on the resulting image and select `Save As...`.
-    #[cfg(not(feature = "wasm"))]
-    pub fn show_png(&self, width: usize, height: usize) {
-        use std::env;
-
-        let rendered = self.render(true, "png", width, height);
-        let rendered = rendered.as_bytes();
-        let mut temp = env::temp_dir();
-
-        let mut plot_name = String::from_utf8(
-            thread_rng()
-                .sample_iter(&Alphanumeric)
-                .take(22)
-                .collect::<Vec<u8>>(),
-        )
-        .unwrap();
-        plot_name.push_str(".html");
-
-        temp.push(plot_name);
-        let temp_path = temp.to_str().unwrap();
-        {
-            let mut file = File::create(temp_path).unwrap();
-            file.write_all(rendered)
-                .expect("failed to write html output");
-            file.flush().unwrap();
-        }
-
-        Plot::show_with_default_app(temp_path);
-    }
-
-    /// Renders the contents of the `Plot`, creates a jpeg raster and displays it in the system default browser.
-    ///
-    /// To save the resulting png right-click on the resulting image and select `Save As...`.
-    #[cfg(not(feature = "wasm"))]
-    pub fn show_jpeg(&self, width: usize, height: usize) {
-        use std::env;
-
-        let rendered = self.render(true, "jpg", width, height);
-        let rendered = rendered.as_bytes();
-        let mut temp = env::temp_dir();
-
-        let mut plot_name: String = String::from_utf8(
-            thread_rng()
-                .sample_iter(&Alphanumeric)
-                .take(22)
-                .collect::<Vec<u8>>(),
-        )
-        .unwrap();
-        plot_name.push_str(".html");
-
-        temp.push(plot_name);
-        let temp_path = temp.to_str().unwrap();
-        {
-            let mut file = File::create(temp_path).unwrap();
-            file.write_all(rendered)
-                .expect("failed to write html output");
-            file.flush().unwrap();
-        }
-
-        Plot::show_with_default_app(temp_path);
-    }
-
-    /// Renders the contents of the `Plot` and displays it in the system default browser.
-    ///
-    /// In contrast to `Plot::show()` this will save the resulting html in a user specified location
-    /// instead of the system temp directory.
-    ///
-    /// In contrast to `Plot::write_html`, this will save the resulting html to a file located at a
-    /// user specified location, instead of a writing it to anything that implements `std::io::Write`.
-    pub fn to_html<P: AsRef<Path>>(&self, filename: P) {
-        let mut file = File::create(filename.as_ref()).unwrap();
-
-        self.write_html(&mut file);
-    }
-
-    /// Renders the contents of the `Plot` to HTML and outputs them to a writable buffer.
-    ///
-    /// In contrast to `Plot::to_html`, this will save the resulting html to a byte buffer using the
-    /// `std::io::Write` trait, instead of to a user specified file.
-    pub fn write_html<W: Write>(&self, buffer: &mut W) {
-        let rendered = self.render(false, "", 0, 0);
-        let rendered = rendered.as_bytes();
-
-        buffer
-            .write_all(rendered)
+        let mut file = File::create(temp_path).unwrap();
+        file.write_all(rendered.as_bytes())
             .expect("failed to write html output");
+        file.flush().unwrap();
+
+        // Hand off the job of opening the browser to an OS-specific implementation.
+        Plot::show_with_default_app(temp_path);
     }
 
-    /// Renders the contents of the `Plot` and returns it as a String, for embedding in
-    /// web-pages or Jupyter notebooks. A `div` is generated with the supplied id followed by the
-    /// script that generates the plot. The assumption is that plotly.js is available within the
-    /// html page that this element is embedded. If that assumption is violated then the plot will
-    /// not be displayed.
+    /// Display the fully rendered `Plot` as a static image of the given format in the default system browser.
+    #[cfg(not(feature = "wasm"))]
+    pub fn show_image(&self, format: ImageFormat, width: usize, height: usize) {
+        use std::env;
+
+        let rendered = self.render_static(format, width, height);
+
+        // Set up the temp file with a unique filename.
+        let mut temp = env::temp_dir();
+        let mut plot_name = Alphanumeric.sample_string(&mut thread_rng(), 22);
+        plot_name.push_str(".html");
+        plot_name = format!("plotly_{}", plot_name);
+        temp.push(plot_name);
+
+        // Save the rendered plot to the temp file.
+        let temp_path = temp.to_str().unwrap();
+        let mut file = File::create(temp_path).unwrap();
+        file.write_all(rendered.as_bytes())
+            .expect("failed to write html output");
+        file.flush().unwrap();
+
+        // Hand off the job of opening the browser to an OS-specific implementation.
+        Plot::show_with_default_app(temp_path);
+    }
+
+    /// Save the rendered `Plot` to a file at the given location.
     ///
-    /// If `plot_div_id` is `None` the plot div id will be randomly generated, otherwise the user
-    /// supplied div id is used.
+    /// This method will render the plot to a full, standalone HTML document, before saving it to
+    /// the given location.
+    #[cfg(not(feature = "wasm"))]
+    pub fn write_html<P: AsRef<Path>>(&self, filename: P) {
+        let rendered = self.to_html();
+
+        let mut file = File::create(filename).unwrap();
+        file.write_all(rendered.as_bytes())
+            .expect("failed to write html output");
+        file.flush().unwrap();
+    }
+
+    /// Convert a `Plot` to an HTML string representation.
+    ///
+    /// This method will generate a full, standalone HTML document. To generate a minimal HTML string
+    /// which can be embedded within an existing HTML page, use `Plot::to_inline_html()`.
+    pub fn to_html(&self) -> String {
+        self.render()
+    }
+
+    /// Renders the contents of the `Plot` and returns it as a String suitable for embedding within
+    /// web pages or Jupyter notebooks.
+    ///
+    /// A `div` is generated with the supplied id followed by the `script` block that generates the plot.
+    /// The assumption is that `plotly.js` is available within the HTML page that this element is embedded. If
+    /// that assumption is violated then the plot will not be displayed.
+    ///
+    /// If `plot_div_id` is `None` the plot div id will be randomly generated, otherwise the user-supplied
+    /// `plot_div_id` is used.
+    ///
+    /// To generate a full, standalone HTML string or file, use `Plot::to_html()` and `Plot::write_html()`,
+    /// respectively.
     pub fn to_inline_html<T: Into<Option<&'static str>>>(&self, plot_div_id: T) -> String {
         let plot_div_id = plot_div_id.into();
-        match plot_div_id {
-            Some(id) => self.render_inline(id.as_ref()),
-            None => {
-                let rand_id = String::from_utf8(
-                    thread_rng()
-                        .sample_iter(&Alphanumeric)
-                        .take(20)
-                        .collect::<Vec<u8>>(),
-                )
-                .unwrap();
-                self.render_inline(rand_id.as_str())
-            }
-        }
+        let plot_div_id = match plot_div_id {
+            Some(id) => id.to_string(),
+            None => Alphanumeric.sample_string(&mut thread_rng(), 20),
+        };
+        self.render_inline(&plot_div_id)
     }
 
     fn to_jupyter_notebook_html(&self) -> String {
-        let plot_div_id = String::from_utf8(
-            thread_rng()
-                .sample_iter(&Alphanumeric)
-                .take(20)
-                .collect::<Vec<u8>>(),
-        )
-        .unwrap();
+        let plot_div_id = Alphanumeric.sample_string(&mut thread_rng(), 20);
 
         let tmpl = JupyterNotebookPlotTemplate {
             plot: self,
@@ -403,9 +363,9 @@ impl Plot {
         self.lab_display();
     }
 
-    /// Saves the `Plot` to the selected image format.
+    /// Convert the `Plot` to a static image of the given image format and save at the given location.
     #[cfg(feature = "kaleido")]
-    pub fn save<P: AsRef<Path>>(
+    pub fn write_image<P: AsRef<Path>>(
         &self,
         filename: P,
         format: ImageFormat,
@@ -414,19 +374,11 @@ impl Plot {
         scale: f64,
     ) {
         let kaleido = plotly_kaleido::Kaleido::new();
-        let image_format = match format {
-            ImageFormat::PNG => "png",
-            ImageFormat::JPEG => "jpeg",
-            ImageFormat::SVG => "svg",
-            ImageFormat::PDF => "pdf",
-            ImageFormat::EPS => "eps",
-            ImageFormat::WEBP => "webp",
-        };
         kaleido
             .save(
                 filename.as_ref(),
                 &serde_json::to_value(self).unwrap(),
-                image_format,
+                &format.to_string(),
                 width,
                 height,
                 scale,
@@ -434,22 +386,21 @@ impl Plot {
             .unwrap_or_else(|_| panic!("failed to export plot to {:?}", filename.as_ref()));
     }
 
-    fn render(
-        &self,
-        export_image: bool,
-        image_type: &str,
-        image_width: usize,
-        image_height: usize,
-    ) -> String {
-        let plotly_js = PlotlyJs {}.render().unwrap();
+    fn render(&self) -> String {
         let tmpl = PlotTemplate {
             plot: self,
-            plotly_javascript: plotly_js.as_str(),
             remote_plotly_js: self.remote_plotly_js,
-            export_image,
-            image_type,
-            image_width,
-            image_height,
+        };
+        tmpl.render().unwrap()
+    }
+
+    fn render_static(&self, format: ImageFormat, width: usize, height: usize) -> String {
+        let tmpl = StaticPlotTemplate {
+            plot: self,
+            format,
+            remote_plotly_js: self.remote_plotly_js,
+            width,
+            height,
         };
         tmpl.render().unwrap()
     }
@@ -516,7 +467,6 @@ impl PartialEq for Plot {
 #[cfg(test)]
 mod tests {
     use serde_json::{json, to_value};
-    #[cfg(feature = "kaleido")]
     use std::path::PathBuf;
 
     use super::*;
@@ -666,11 +616,27 @@ mod tests {
     }
 
     #[test]
+    fn test_show_image() {
+        let plot = create_test_plot();
+        plot.show_image(ImageFormat::PNG, 1024, 680);
+    }
+
+    #[test]
+    fn test_save_html() {
+        let plot = create_test_plot();
+        let dst = PathBuf::from("example.html");
+        plot.write_html(&dst);
+        assert!(dst.exists());
+        assert!(std::fs::remove_file(&dst).is_ok());
+        assert!(!dst.exists());
+    }
+
+    #[test]
     #[cfg(feature = "kaleido")]
     fn test_save_to_png() {
         let plot = create_test_plot();
         let dst = PathBuf::from("example.png");
-        plot.save(&dst, ImageFormat::PNG, 1024, 680, 1.0);
+        plot.write_image(&dst, ImageFormat::PNG, 1024, 680, 1.0);
         assert!(dst.exists());
         assert!(std::fs::remove_file(&dst).is_ok());
         assert!(!dst.exists());
@@ -681,7 +647,7 @@ mod tests {
     fn test_save_to_jpeg() {
         let plot = create_test_plot();
         let dst = PathBuf::from("example.jpeg");
-        plot.save(&dst, ImageFormat::JPEG, 1024, 680, 1.0);
+        plot.write_image(&dst, ImageFormat::JPEG, 1024, 680, 1.0);
         assert!(dst.exists());
         assert!(std::fs::remove_file(&dst).is_ok());
         assert!(!dst.exists());
@@ -692,7 +658,7 @@ mod tests {
     fn test_save_to_svg() {
         let plot = create_test_plot();
         let dst = PathBuf::from("example.svg");
-        plot.save(&dst, ImageFormat::SVG, 1024, 680, 1.0);
+        plot.write_image(&dst, ImageFormat::SVG, 1024, 680, 1.0);
         assert!(dst.exists());
         assert!(std::fs::remove_file(&dst).is_ok());
         assert!(!dst.exists());
@@ -704,7 +670,7 @@ mod tests {
     fn test_save_to_eps() {
         let plot = create_test_plot();
         let dst = PathBuf::from("example.eps");
-        plot.save(&dst, ImageFormat::EPS, 1024, 680, 1.0);
+        plot.write_image(&dst, ImageFormat::EPS, 1024, 680, 1.0);
         assert!(dst.exists());
         assert!(std::fs::remove_file(&dst).is_ok());
         assert!(!dst.exists());
@@ -715,7 +681,7 @@ mod tests {
     fn test_save_to_pdf() {
         let plot = create_test_plot();
         let dst = PathBuf::from("example.pdf");
-        plot.save(&dst, ImageFormat::PDF, 1024, 680, 1.0);
+        plot.write_image(&dst, ImageFormat::PDF, 1024, 680, 1.0);
         assert!(dst.exists());
         assert!(std::fs::remove_file(&dst).is_ok());
         assert!(!dst.exists());
@@ -726,7 +692,7 @@ mod tests {
     fn test_save_to_webp() {
         let plot = create_test_plot();
         let dst = PathBuf::from("example.webp");
-        plot.save(&dst, ImageFormat::WEBP, 1024, 680, 1.0);
+        plot.write_image(&dst, ImageFormat::WEBP, 1024, 680, 1.0);
         assert!(dst.exists());
         assert!(std::fs::remove_file(&dst).is_ok());
         assert!(!dst.exists());

--- a/plotly/templates/inline_plot.html
+++ b/plotly/templates/inline_plot.html
@@ -1,9 +1,4 @@
 <div id="{{ plot_div_id }}" class="plotly-graph-div" style="height:100%; width:100%;"></div>
 <script type="text/javascript">
-    window.PLOTLYENV=window.PLOTLYENV || {};
-    if (document.getElementById("{{ plot_div_id }}")) {
-        var image_element = document.getElementById('image-export')
-
-        Plotly.newPlot('{{ plot_div_id }}', {{ plot|tojson|safe }});
-    };
+    Plotly.newPlot("{{ plot_div_id }}", {{ plot|tojson|safe }});
 </script>

--- a/plotly/templates/jupyter_notebook_plot.html
+++ b/plotly/templates/jupyter_notebook_plot.html
@@ -2,36 +2,31 @@
     <div id="{{ plot_div_id }}" class="plotly-graph-div" style="height:100%; width:100%;"></div>
     <script type="text/javascript">
         require(['https://cdn.plot.ly/plotly-2.12.1.min.js'], function(Plotly) {
-            window.PLOTLYENV=window.PLOTLYENV || {};
+            Plotly.newPlot(
+                "{{ plot_div_id }}",
+                {{ plot|tojson|safe }}
+            ).then(function() {
+                var gd = document.getElementById('{{ plot_div_id }}');
+                var x = new MutationObserver(function (mutations, observer) { {
+                        var display = window.getComputedStyle(gd).display;
+                        if (!display || display === 'none') { {
+                            Plotly.purge(gd);
+                            observer.disconnect();
+                        } }
+                } });
 
-            if (document.getElementById("{{ plot_div_id }}")) {
-                Plotly.newPlot(
-                    '{{ plot_div_id }}',
-                    {{ plot|tojson|safe }}
-                ).then(function() {
-                    var gd = document.getElementById('{{ plot_div_id }}');
-                    var x = new MutationObserver(function (mutations, observer) { {
-                            var display = window.getComputedStyle(gd).display;
-                            if (!display || display === 'none') { {
-                                console.log([gd, 'removed!']);
-                                Plotly.purge(gd);
-                                observer.disconnect();
-                            } }
-                    } });
+                // Listen for the removal of the full notebook cells
+                var notebookContainer = gd.closest('#notebook-container');
+                if (notebookContainer) { {
+                    x.observe(notebookContainer, {childList: true});
+                } }
 
-                    // Listen for the removal of the full notebook cells
-                    var notebookContainer = gd.closest('#notebook-container');
-                    if (notebookContainer) { {
-                        x.observe(notebookContainer, {childList: true});
-                    } }
-
-                    // Listen for the clearing of the current output cell
-                    var outputEl = gd.closest('.output');
-                    if (outputEl) { {
-                        x.observe(outputEl, {childList: true});
-                    } }
-                })
-            };
+                // Listen for the clearing of the current output cell
+                var outputEl = gd.closest('.output');
+                if (outputEl) { {
+                    x.observe(outputEl, {childList: true});
+                } }
+            })
         });
     </script>
 </div>

--- a/plotly/templates/static_plot.html
+++ b/plotly/templates/static_plot.html
@@ -12,11 +12,24 @@
             <script type="text/javascript">{% include "plotly.min.js" %}</script>
             {% endif -%}
 
-            <div id="plotly-html-element" class="plotly-graph-div" style="height:100%; width:100%;"></div>
+            <div id="plotly-html-element" hidden></div>
+            <img id="plotly-img-element"></img>
 
             <script type="module">
                 const graph_div = document.getElementById("plotly-html-element");
                 await Plotly.newPlot(graph_div, {{ plot|tojson|safe }});
+                
+                const img_element = document.getElementById("plotly-img-element");
+                const data_url = await Plotly.toImage(
+                    graph_div,
+                    {
+                        format: "{{ format }}",
+                        width: {{ width }},
+                        height: {{ height }},
+                    }
+                );
+
+                img_element.setAttribute("src", data_url);
             </script>
         </div>
     </body>

--- a/plotly_kaleido/src/lib.rs
+++ b/plotly_kaleido/src/lib.rs
@@ -123,13 +123,13 @@ impl Kaleido {
         &self,
         dst: &Path,
         plotly_data: &Value,
-        image_format: &str,
+        format: &str,
         width: usize,
         height: usize,
         scale: f64,
     ) -> Result<(), Box<dyn std::error::Error>> {
         let mut dst = PathBuf::from(dst);
-        dst.set_extension(image_format);
+        dst.set_extension(format);
 
         let p = self.cmd_path.as_path();
         let p = p.to_str().unwrap();
@@ -152,8 +152,7 @@ impl Kaleido {
             .expect("failed to spawn Kaleido binary");
 
         {
-            let plot_data =
-                PlotData::new(plotly_data, image_format, width, height, scale).to_json();
+            let plot_data = PlotData::new(plotly_data, format, width, height, scale).to_json();
             let mut process_stdin = process.stdin.unwrap();
             process_stdin
                 .write_all(plot_data.as_bytes())
@@ -165,7 +164,7 @@ impl Kaleido {
         for line in output_lines.flatten() {
             let res = KaleidoResult::from(line.as_str());
             if let Some(image_data) = res.result {
-                let data: Vec<u8> = match image_format {
+                let data: Vec<u8> = match format {
                     "svg" | "eps" => image_data.as_bytes().to_vec(),
                     _ => base64::decode(image_data).unwrap(),
                 };


### PR DESCRIPTION
This PR refactors the main API for showing and saving plots to more closely align with the familiar [plotly.py](https://plotly.com/python-api-reference/plotly.io.html#io).

`Plot::show()` displays the interactive HTML plot in the broswer.
`Plot::show_image(...)` displays a static image of the given format in the browser.
`Plot::to{_inline}_html(...)` renders the plot as an HTML string, either fully standalone or inline.
`Plot::write_html(...)` saves the image to an HTML file (kaleido not required).
`Plot::write_image(...)` uses kaleido to save a static image of the plot.

During the process, I've also refactored the HTML templates to use cleaner Javascript code, and added some tests, too.