### PR TITLE
Button support and FieldSetter derive macro

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,5 +1,6 @@
 [workspace]
 members = [
     "plotly",
+    "plotly_derive",
     "plotly_kaleido"
 ]

--- a/plotly/Cargo.toml
+++ b/plotly/Cargo.toml
@@ -27,6 +27,7 @@ erased-serde = "0.3"
 getrandom = { version = "0.2", features = ["js"], optional = true }
 js-sys = { version = "0.3", optional = true }
 plotly_kaleido = { version = "0.3.0", path = "../plotly_kaleido", optional = true }
+plotly_derive = { path = "../plotly_derive" }
 ndarray = { version = "0.15.4", optional = true }
 once_cell = "1"
 serde = { version = "1.0.132", features = ["derive"] }

--- a/plotly/examples/buttons.rs
+++ b/plotly/examples/buttons.rs
@@ -1,0 +1,117 @@
+use itertools::Itertools;
+use plotly::{
+    common::{Anchor, ColorScalePalette, Visible},
+    layout::{
+        update_menu::{ButtonBuilder, UpdateMenu, UpdateMenuDirection, UpdateMenuType},
+        BarMode,
+    },
+    Bar, HeatMap, Layout, Plot,
+};
+
+// Dropdown to alternate between two bar plots
+fn bar_plot_visible_dropdown(show: bool) {
+    type BarType = Bar<&'static str, i32>;
+    let mut plot = Plot::new();
+    plot.add_trace(
+        BarType::new(vec!["giraffes", "orangutans", "monkeys"], vec![20, 14, 23]).name("Animals"),
+    );
+    plot.add_trace(
+        BarType::new(
+            vec!["parrot", "chicken", "bluebird", "own"],
+            vec![8, 23, 17, 2],
+        )
+        .name("Birds")
+        .visible(Visible::False),
+    );
+    let buttons = vec![
+        ButtonBuilder::new()
+            .label("Animals")
+            .push_restyle(BarType::modify_visible(vec![Visible::True, Visible::False]))
+            .build(),
+        ButtonBuilder::new()
+            .label("Birds")
+            .push_restyle(BarType::modify_visible(vec![Visible::False, Visible::True]))
+            .build(),
+    ];
+    plot.set_layout(Layout::new().update_menus(vec![UpdateMenu::new().y(0.8).buttons(buttons)]));
+    if show {
+        plot.show();
+    }
+    println!("{}", plot.to_inline_html(Some("bar_plot_visible_dropdown")));
+}
+
+// Heatmap with buttons to choose colorscale
+fn basic_heat_map(show: bool) {
+    type HeatMapType = HeatMap<f64, f64, Vec<f64>>;
+    let gauss = |v: i32| (-v as f64 * v as f64 / 200.0).exp();
+    let z = (-30..30)
+        .map(|x| (-30..30).map(|y| gauss(x) * gauss(y)).collect_vec())
+        .collect_vec();
+    let trace = HeatMapType::new_z(z).color_scale(ColorScalePalette::Viridis.into());
+    let mut plot = Plot::new();
+    plot.add_trace(trace);
+
+    let buttons = IntoIterator::into_iter([
+        ("Viridis", ColorScalePalette::Viridis),
+        ("Portland", ColorScalePalette::Portland),
+        ("Blackbody", ColorScalePalette::Blackbody),
+    ])
+    .map(|(label, palette)| {
+        ButtonBuilder::new()
+            .label(label)
+            .push_restyle(HeatMapType::modify_all_color_scale(palette.into()))
+            .build()
+    })
+    .collect_vec();
+
+    plot.set_layout(Layout::new().update_menus(vec![UpdateMenu::new()
+            .ty(UpdateMenuType::Buttons)
+            .y(0.8)
+            .buttons(buttons)]));
+
+    if show {
+        plot.show();
+    }
+    println!("{}", plot.to_inline_html(Some("basic_heat_map")));
+}
+
+// Button to change barmode
+fn bar_plot_relayout(show: bool) {
+    type BarType = Bar<&'static str, i32>;
+    let mut plot = Plot::new();
+    plot.add_trace(
+        BarType::new(vec!["giraffes", "orangutans", "monkeys"], vec![20, 14, 23]).name("Africa"),
+    );
+    plot.add_trace(
+        BarType::new(vec!["giraffes", "orangutans", "monkeys"], vec![30, 8, 15]).name("Australia"),
+    );
+    let buttons = vec![("Group", BarMode::Group), ("Stack", BarMode::Stack)]
+        .into_iter()
+        .map(|(label, bar_mode)| {
+            ButtonBuilder::new()
+                .label(label)
+                .push_relayout(Layout::modify_bar_mode(bar_mode))
+                .build()
+        })
+        .collect_vec();
+
+    plot.set_layout(Layout::new().update_menus(vec![UpdateMenu::new()
+            .x(0.1)
+            .x_anchor(Anchor::Left)
+            .y(1.2)
+            .y_anchor(Anchor::Top)
+            .ty(UpdateMenuType::Buttons)
+            .direction(UpdateMenuDirection::Right)
+            .buttons(buttons)]));
+    if show {
+        plot.show();
+    }
+    println!("{}", plot.to_inline_html(Some("bar_plot_relayout")));
+}
+
+fn main() -> std::io::Result<()> {
+    bar_plot_visible_dropdown(true);
+    basic_heat_map(true);
+    bar_plot_relayout(true);
+    Ok(())
+}

--- a/plotly/src/common/mod.rs
+++ b/plotly/src/common/mod.rs
@@ -472,6 +472,12 @@ pub enum ColorScale {
     Vector(Vec<ColorScaleElement>),
 }
 
+impl From<ColorScalePalette> for ColorScale {
+    fn from(src: ColorScalePalette) -> Self {
+        ColorScale::Palette(src)
+    }
+}
+
 #[derive(Serialize, Clone, Debug)]
 #[serde(rename_all = "lowercase")]
 pub enum LineShape {

--- a/plotly/src/layout/mod.rs
+++ b/plotly/src/layout/mod.rs
@@ -1,17 +1,20 @@
 pub mod themes;
+pub mod update_menu;
 
 use std::borrow::Cow;
 
+use plotly_derive::FieldSetter;
 use serde::{Serialize, Serializer};
 
 use crate::{
-    color::{Color, ColorArray},
+    color::Color,
     common::{
         Anchor, AxisSide, Calendar, ColorBar, ColorScale, DashType, ExponentFormat, Font, Label,
         Orientation, TickFormatStop, TickMode, Title,
     },
     private::{NumOrString, NumOrStringCollection},
 };
+use update_menu::UpdateMenu;
 
 #[derive(Serialize, Debug, Clone)]
 #[serde(rename_all = "lowercase")]
@@ -158,7 +161,7 @@ pub enum GroupClick {
 }
 
 #[serde_with::skip_serializing_none]
-#[derive(Serialize, Debug, Default, Clone)]
+#[derive(Serialize, Debug, Clone, FieldSetter)]
 pub struct Legend {
     #[serde(rename = "bgcolor")]
     background_color: Option<Box<dyn Color>>,
@@ -196,96 +199,6 @@ impl Legend {
     pub fn new() -> Self {
         Default::default()
     }
-
-    pub fn background_color<C: Color>(mut self, background_color: C) -> Self {
-        self.background_color = Some(Box::new(background_color));
-        self
-    }
-
-    pub fn border_color<C: Color>(mut self, border_color: C) -> Self {
-        self.border_color = Some(Box::new(border_color));
-        self
-    }
-
-    pub fn border_width(mut self, border_width: usize) -> Self {
-        self.border_width = Some(border_width);
-        self
-    }
-
-    pub fn font(mut self, font: Font) -> Self {
-        self.font = Some(font);
-        self
-    }
-
-    pub fn orientation(mut self, orientation: Orientation) -> Self {
-        self.orientation = Some(orientation);
-        self
-    }
-
-    pub fn trace_order(mut self, trace_order: TraceOrder) -> Self {
-        self.trace_order = Some(trace_order);
-        self
-    }
-
-    pub fn trace_group_gap(mut self, trace_group_gap: usize) -> Self {
-        self.trace_group_gap = Some(trace_group_gap);
-        self
-    }
-
-    pub fn item_sizing(mut self, item_sizing: ItemSizing) -> Self {
-        self.item_sizing = Some(item_sizing);
-        self
-    }
-
-    pub fn item_click(mut self, item_click: ItemClick) -> Self {
-        self.item_click = Some(item_click);
-        self
-    }
-
-    pub fn item_double_click(mut self, item_double_click: ItemClick) -> Self {
-        self.item_double_click = Some(item_double_click);
-        self
-    }
-
-    pub fn x(mut self, x: f64) -> Self {
-        self.x = Some(x);
-        self
-    }
-
-    pub fn x_anchor(mut self, x_anchor: Anchor) -> Self {
-        self.x_anchor = Some(x_anchor);
-        self
-    }
-
-    pub fn y(mut self, y: f64) -> Self {
-        self.y = Some(y);
-        self
-    }
-
-    pub fn y_anchor(mut self, y_anchor: Anchor) -> Self {
-        self.y_anchor = Some(y_anchor);
-        self
-    }
-
-    pub fn valign(mut self, valign: VAlign) -> Self {
-        self.valign = Some(valign);
-        self
-    }
-
-    pub fn title(mut self, title: Title) -> Self {
-        self.title = Some(title);
-        self
-    }
-
-    pub fn group_click(mut self, group_click: GroupClick) -> Self {
-        self.group_click = Some(group_click);
-        self
-    }
-
-    pub fn item_width(mut self, item_width: usize) -> Self {
-        self.item_width = Some(item_width);
-        self
-    }
 }
 
 #[derive(Serialize, Debug, Clone)]
@@ -305,12 +218,16 @@ pub enum HAlign {
 }
 
 #[serde_with::skip_serializing_none]
-#[derive(Serialize, Debug, Default, Clone)]
+#[derive(Serialize, Debug, Clone, FieldSetter)]
 pub struct Margin {
-    l: Option<usize>,
-    r: Option<usize>,
-    t: Option<usize>,
-    b: Option<usize>,
+    #[serde(rename = "l")]
+    left: Option<usize>,
+    #[serde(rename = "r")]
+    right: Option<usize>,
+    #[serde(rename = "t")]
+    top: Option<usize>,
+    #[serde(rename = "b")]
+    bottom: Option<usize>,
     pad: Option<usize>,
     #[serde(rename = "autoexpand")]
     auto_expand: Option<bool>,
@@ -320,40 +237,10 @@ impl Margin {
     pub fn new() -> Self {
         Default::default()
     }
-
-    pub fn left(mut self, left: usize) -> Self {
-        self.l = Some(left);
-        self
-    }
-
-    pub fn right(mut self, right: usize) -> Self {
-        self.r = Some(right);
-        self
-    }
-
-    pub fn top(mut self, top: usize) -> Self {
-        self.t = Some(top);
-        self
-    }
-
-    pub fn bottom(mut self, bottom: usize) -> Self {
-        self.b = Some(bottom);
-        self
-    }
-
-    pub fn pad(mut self, pad: usize) -> Self {
-        self.pad = Some(pad);
-        self
-    }
-
-    pub fn auto_expand(mut self, auto_expand: bool) -> Self {
-        self.auto_expand = Some(auto_expand);
-        self
-    }
 }
 
 #[serde_with::skip_serializing_none]
-#[derive(Serialize, Debug, Default, Clone)]
+#[derive(Serialize, Debug, Clone, FieldSetter)]
 pub struct LayoutColorScale {
     sequential: Option<ColorScale>,
     #[serde(rename = "sequentialminus")]
@@ -364,21 +251,6 @@ pub struct LayoutColorScale {
 impl LayoutColorScale {
     pub fn new() -> Self {
         Default::default()
-    }
-
-    pub fn sequential(mut self, sequential: ColorScale) -> Self {
-        self.sequential = Some(sequential);
-        self
-    }
-
-    pub fn sequential_minus(mut self, sequential_minus: ColorScale) -> Self {
-        self.sequential_minus = Some(sequential_minus);
-        self
-    }
-
-    pub fn diverging(mut self, diverging: ColorScale) -> Self {
-        self.diverging = Some(diverging);
-        self
     }
 }
 
@@ -391,7 +263,7 @@ pub enum SliderRangeMode {
 }
 
 #[serde_with::skip_serializing_none]
-#[derive(Serialize, Debug, Default, Clone)]
+#[derive(Serialize, Debug, Clone, FieldSetter)]
 pub struct RangeSliderYAxis {
     #[serde(rename = "rangemode")]
     range_mode: Option<SliderRangeMode>,
@@ -402,20 +274,10 @@ impl RangeSliderYAxis {
     pub fn new() -> Self {
         Default::default()
     }
-
-    pub fn range_mode(mut self, range_mode: SliderRangeMode) -> Self {
-        self.range_mode = Some(range_mode);
-        self
-    }
-
-    pub fn range<V: Into<NumOrString> + Clone>(mut self, range: Vec<V>) -> Self {
-        self.range = Some(range.into());
-        self
-    }
 }
 
 #[serde_with::skip_serializing_none]
-#[derive(Serialize, Debug, Default, Clone)]
+#[derive(Serialize, Debug, Clone, FieldSetter)]
 pub struct RangeSlider {
     #[serde(rename = "bgcolor")]
     background_color: Option<Box<dyn Color>>,
@@ -435,46 +297,6 @@ pub struct RangeSlider {
 impl RangeSlider {
     pub fn new() -> Self {
         Default::default()
-    }
-
-    pub fn background_color<C: Color>(mut self, background_color: C) -> Self {
-        self.background_color = Some(Box::new(background_color));
-        self
-    }
-
-    pub fn border_color<C: Color>(mut self, border_color: C) -> Self {
-        self.border_color = Some(Box::new(border_color));
-        self
-    }
-
-    pub fn border_width(mut self, border_width: u64) -> Self {
-        self.border_width = Some(border_width);
-        self
-    }
-
-    pub fn auto_range(mut self, auto_range: bool) -> Self {
-        self.auto_range = Some(auto_range);
-        self
-    }
-
-    pub fn range<V: Into<NumOrString> + Clone>(mut self, range: Vec<V>) -> Self {
-        self.range = Some(range.into());
-        self
-    }
-
-    pub fn thickness(mut self, thickness: f64) -> Self {
-        self.thickness = Some(thickness);
-        self
-    }
-
-    pub fn visible(mut self, visible: bool) -> Self {
-        self.visible = Some(visible);
-        self
-    }
-
-    pub fn y_axis(mut self, axis: RangeSliderYAxis) -> Self {
-        self.y_axis = Some(axis);
-        self
     }
 }
 
@@ -498,7 +320,7 @@ pub enum StepMode {
 }
 
 #[serde_with::skip_serializing_none]
-#[derive(Serialize, Debug, Default, Clone)]
+#[derive(Serialize, Debug, Clone, FieldSetter)]
 pub struct SelectorButton {
     visible: Option<bool>,
     step: Option<SelectorStep>,
@@ -515,45 +337,10 @@ impl SelectorButton {
     pub fn new() -> Self {
         Default::default()
     }
-
-    pub fn visible(mut self, visible: bool) -> Self {
-        self.visible = Some(visible);
-        self
-    }
-
-    pub fn step(mut self, step: SelectorStep) -> Self {
-        self.step = Some(step);
-        self
-    }
-
-    pub fn step_mode(mut self, step_mode: StepMode) -> Self {
-        self.step_mode = Some(step_mode);
-        self
-    }
-
-    pub fn count(mut self, count: usize) -> Self {
-        self.count = Some(count);
-        self
-    }
-
-    pub fn label(mut self, label: &str) -> Self {
-        self.label = Some(label.to_owned());
-        self
-    }
-
-    pub fn name(mut self, name: &str) -> Self {
-        self.name = Some(name.to_owned());
-        self
-    }
-
-    pub fn template_item_name(mut self, template_item_name: &str) -> Self {
-        self.template_item_name = Some(template_item_name.to_owned());
-        self
-    }
 }
 
 #[serde_with::skip_serializing_none]
-#[derive(Serialize, Debug, Default, Clone)]
+#[derive(Serialize, Debug, Clone, FieldSetter)]
 pub struct RangeSelector {
     visible: Option<bool>,
     buttons: Option<Vec<SelectorButton>>,
@@ -578,65 +365,10 @@ impl RangeSelector {
     pub fn new() -> Self {
         Default::default()
     }
-
-    pub fn visible(mut self, visible: bool) -> Self {
-        self.visible = Some(visible);
-        self
-    }
-
-    pub fn buttons(mut self, buttons: Vec<SelectorButton>) -> Self {
-        self.buttons = Some(buttons);
-        self
-    }
-
-    pub fn x(mut self, x: f64) -> Self {
-        self.x = Some(x);
-        self
-    }
-
-    pub fn x_anchor(mut self, x_anchor: Anchor) -> Self {
-        self.x_anchor = Some(x_anchor);
-        self
-    }
-
-    pub fn y(mut self, y: f64) -> Self {
-        self.y = Some(y);
-        self
-    }
-
-    pub fn y_anchor(mut self, y_anchor: Anchor) -> Self {
-        self.y_anchor = Some(y_anchor);
-        self
-    }
-
-    pub fn font(mut self, font: Font) -> Self {
-        self.font = Some(font);
-        self
-    }
-
-    pub fn background_color<C: Color>(mut self, background_color: C) -> Self {
-        self.background_color = Some(Box::new(background_color));
-        self
-    }
-
-    pub fn active_color<C: Color>(mut self, active_color: C) -> Self {
-        self.active_color = Some(Box::new(active_color));
-        self
-    }
-
-    pub fn border_color<C: Color>(mut self, border_color: C) -> Self {
-        self.border_color = Some(Box::new(border_color));
-        self
-    }
-
-    pub fn border_width(mut self, border_width: usize) -> Self {
-        self.border_width = Some(border_width);
-        self
-    }
 }
 
 #[serde_with::skip_serializing_none]
-#[derive(Serialize, Debug, Default, Clone)]
+#[derive(Serialize, Debug, Clone, FieldSetter)]
 pub struct ColorAxis {
     cauto: Option<bool>,
     cmin: Option<f64>,
@@ -657,51 +389,6 @@ pub struct ColorAxis {
 impl ColorAxis {
     pub fn new() -> Self {
         Default::default()
-    }
-
-    pub fn cauto(mut self, cauto: bool) -> Self {
-        self.cauto = Some(cauto);
-        self
-    }
-
-    pub fn cmin(mut self, cmin: f64) -> Self {
-        self.cmin = Some(cmin);
-        self
-    }
-
-    pub fn cmax(mut self, cmax: f64) -> Self {
-        self.cmax = Some(cmax);
-        self
-    }
-
-    pub fn cmid(mut self, cmid: f64) -> Self {
-        self.cmid = Some(cmid);
-        self
-    }
-
-    pub fn color_scale(mut self, color_scale: ColorScale) -> Self {
-        self.color_scale = Some(color_scale);
-        self
-    }
-
-    pub fn auto_color_scale(mut self, auto_color_scale: bool) -> Self {
-        self.auto_color_scale = Some(auto_color_scale);
-        self
-    }
-
-    pub fn reverse_scale(mut self, reverse_scale: bool) -> Self {
-        self.reverse_scale = Some(reverse_scale);
-        self
-    }
-
-    pub fn show_scale(mut self, show_scale: bool) -> Self {
-        self.show_scale = Some(show_scale);
-        self
-    }
-
-    pub fn color_bar(mut self, color_bar: ColorBar) -> Self {
-        self.color_bar = Some(color_bar);
-        self
     }
 }
 
@@ -731,11 +418,12 @@ pub enum SpikeSnap {
 }
 
 #[serde_with::skip_serializing_none]
-#[derive(Serialize, Debug, Default, Clone)]
+#[derive(Serialize, Debug, Clone, FieldSetter)]
 pub struct Axis {
     visible: Option<bool>,
     color: Option<Box<dyn Color>>,
     title: Option<Title>,
+    #[field_setter(skip)]
     r#type: Option<AxisType>,
     #[serde(rename = "autorange")]
     auto_range: Option<bool>,
@@ -755,6 +443,7 @@ pub struct Axis {
     tick0: Option<f64>,
     dtick: Option<f64>,
 
+    #[field_setter(skip)]
     matches: Option<String>,
 
     #[serde(rename = "tickvals")]
@@ -838,6 +527,7 @@ pub struct Axis {
     anchor: Option<String>,
     side: Option<AxisSide>,
     overlaying: Option<String>,
+    #[field_setter(skip)]
     domain: Option<Vec<f64>>,
     position: Option<f64>,
     #[serde(rename = "rangeslider")]
@@ -859,313 +549,13 @@ impl Axis {
         self
     }
 
-    pub fn visible(mut self, visible: bool) -> Self {
-        self.visible = Some(visible);
-        self
-    }
-
-    pub fn color<C: Color>(mut self, color: C) -> Self {
-        self.color = Some(Box::new(color));
-        self
-    }
-
-    pub fn title(mut self, title: Title) -> Self {
-        self.title = Some(title);
-        self
-    }
-
     pub fn type_(mut self, t: AxisType) -> Self {
         self.r#type = Some(t);
         self
     }
 
-    pub fn auto_range(mut self, auto_range: bool) -> Self {
-        self.auto_range = Some(auto_range);
-        self
-    }
-
-    pub fn range_mode(mut self, range_mode: RangeMode) -> Self {
-        self.range_mode = Some(range_mode);
-        self
-    }
-
-    pub fn range<V: Into<NumOrString> + Clone>(mut self, range: Vec<V>) -> Self {
-        self.range = Some(range.into());
-        self
-    }
-
-    pub fn fixed_range(mut self, fixed_range: bool) -> Self {
-        self.fixed_range = Some(fixed_range);
-        self
-    }
-
-    pub fn constrain(mut self, constrain: AxisConstrain) -> Self {
-        self.constrain = Some(constrain);
-        self
-    }
-
-    pub fn constrain_toward(mut self, constrain_toward: ConstrainDirection) -> Self {
-        self.constrain_toward = Some(constrain_toward);
-        self
-    }
-
-    pub fn tick_mode(mut self, tick_mode: TickMode) -> Self {
-        self.tick_mode = Some(tick_mode);
-        self
-    }
-
-    pub fn n_ticks(mut self, n_ticks: usize) -> Self {
-        self.n_ticks = Some(n_ticks);
-        self
-    }
-
-    pub fn tick0(mut self, tick0: f64) -> Self {
-        self.tick0 = Some(tick0);
-        self
-    }
-
-    pub fn dtick(mut self, dtick: f64) -> Self {
-        self.dtick = Some(dtick);
-        self
-    }
-
-    pub fn tick_values(mut self, tick_values: Vec<f64>) -> Self {
-        self.tick_values = Some(tick_values);
-        self
-    }
-
-    pub fn tick_text(mut self, tick_text: Vec<String>) -> Self {
-        self.tick_text = Some(tick_text);
-        self
-    }
-
-    pub fn ticks(mut self, ticks: TicksDirection) -> Self {
-        self.ticks = Some(ticks);
-        self
-    }
-
-    pub fn ticks_on(mut self, ticks_on: TicksPosition) -> Self {
-        self.ticks_on = Some(ticks_on);
-        self
-    }
-
-    pub fn mirror(mut self, mirror: bool) -> Self {
-        self.mirror = Some(mirror);
-        self
-    }
-
-    pub fn tick_length(mut self, tick_length: usize) -> Self {
-        self.tick_length = Some(tick_length);
-        self
-    }
-
-    pub fn tick_width(mut self, tick_width: usize) -> Self {
-        self.tick_width = Some(tick_width);
-        self
-    }
-
-    pub fn tick_color<C: Color>(mut self, tick_color: C) -> Self {
-        self.tick_color = Some(Box::new(tick_color));
-        self
-    }
-
-    pub fn show_tick_labels(mut self, show_tick_labels: bool) -> Self {
-        self.show_tick_labels = Some(show_tick_labels);
-        self
-    }
-
-    pub fn auto_margin(mut self, auto_margin: bool) -> Self {
-        self.auto_margin = Some(auto_margin);
-        self
-    }
-
-    pub fn show_spikes(mut self, show_spikes: bool) -> Self {
-        self.show_spikes = Some(show_spikes);
-        self
-    }
-
-    pub fn spike_color<C: Color>(mut self, spike_color: C) -> Self {
-        self.spike_color = Some(Box::new(spike_color));
-        self
-    }
-
-    pub fn spike_thickness(mut self, spike_thickness: usize) -> Self {
-        self.spike_thickness = Some(spike_thickness);
-        self
-    }
-
-    pub fn spike_dash(mut self, spike_dash: DashType) -> Self {
-        self.spike_dash = Some(spike_dash);
-        self
-    }
-
-    pub fn spike_mode(mut self, spike_mode: SpikeMode) -> Self {
-        self.spike_mode = Some(spike_mode);
-        self
-    }
-
-    pub fn spike_snap(mut self, spike_snap: SpikeSnap) -> Self {
-        self.spike_snap = Some(spike_snap);
-        self
-    }
-
-    pub fn tick_font(mut self, tick_font: Font) -> Self {
-        self.tick_font = Some(tick_font);
-        self
-    }
-
-    pub fn tick_angle(mut self, tick_angle: f64) -> Self {
-        self.tick_angle = Some(tick_angle);
-        self
-    }
-
-    pub fn tick_prefix(mut self, tick_prefix: &str) -> Self {
-        self.tick_prefix = Some(tick_prefix.to_owned());
-        self
-    }
-
-    pub fn show_tick_prefix(mut self, show_tick_prefix: ArrayShow) -> Self {
-        self.show_tick_prefix = Some(show_tick_prefix);
-        self
-    }
-
-    pub fn tick_suffix(mut self, tick_suffix: &str) -> Self {
-        self.tick_suffix = Some(tick_suffix.to_owned());
-        self
-    }
-
-    pub fn show_tick_suffix(mut self, show_tick_suffix: ArrayShow) -> Self {
-        self.show_tick_suffix = Some(show_tick_suffix);
-        self
-    }
-
-    pub fn show_exponent(mut self, show_exponent: ArrayShow) -> Self {
-        self.show_exponent = Some(show_exponent);
-        self
-    }
-
-    pub fn exponent_format(mut self, exponent_format: ExponentFormat) -> Self {
-        self.exponent_format = Some(exponent_format);
-        self
-    }
-
-    pub fn separate_thousands(mut self, separate_thousands: bool) -> Self {
-        self.separate_thousands = Some(separate_thousands);
-        self
-    }
-
-    pub fn tick_format(mut self, tick_format: &str) -> Self {
-        self.tick_format = Some(tick_format.to_owned());
-        self
-    }
-
-    pub fn tick_format_stops(mut self, tick_format_stops: Vec<TickFormatStop>) -> Self {
-        self.tick_format_stops = Some(tick_format_stops);
-        self
-    }
-
-    pub fn hover_format(mut self, hover_format: &str) -> Self {
-        self.hover_format = Some(hover_format.to_owned());
-        self
-    }
-
-    pub fn show_line(mut self, show_line: bool) -> Self {
-        self.show_line = Some(show_line);
-        self
-    }
-
-    pub fn line_color<C: Color>(mut self, line_color: C) -> Self {
-        self.line_color = Some(Box::new(line_color));
-        self
-    }
-
-    pub fn line_width(mut self, line_width: usize) -> Self {
-        self.line_width = Some(line_width);
-        self
-    }
-
-    pub fn show_grid(mut self, show_grid: bool) -> Self {
-        self.show_grid = Some(show_grid);
-        self
-    }
-
-    pub fn grid_color<C: Color>(mut self, grid_color: C) -> Self {
-        self.grid_color = Some(Box::new(grid_color));
-        self
-    }
-
-    pub fn grid_width(mut self, grid_width: usize) -> Self {
-        self.grid_width = Some(grid_width);
-        self
-    }
-
-    pub fn zero_line(mut self, zero_line: bool) -> Self {
-        self.zero_line = Some(zero_line);
-        self
-    }
-
-    pub fn zero_line_color<C: Color>(mut self, zero_line_color: C) -> Self {
-        self.zero_line_color = Some(Box::new(zero_line_color));
-        self
-    }
-
-    pub fn zero_line_width(mut self, zero_line_width: usize) -> Self {
-        self.zero_line_width = Some(zero_line_width);
-        self
-    }
-
-    pub fn show_dividers(mut self, show_dividers: bool) -> Self {
-        self.show_dividers = Some(show_dividers);
-        self
-    }
-
-    pub fn divider_color<C: Color>(mut self, divider_color: C) -> Self {
-        self.divider_color = Some(Box::new(divider_color));
-        self
-    }
-
-    pub fn divider_width(mut self, divider_width: usize) -> Self {
-        self.divider_width = Some(divider_width);
-        self
-    }
-
-    pub fn anchor(mut self, anchor: &str) -> Self {
-        self.anchor = Some(anchor.to_owned());
-        self
-    }
-
-    pub fn side(mut self, side: AxisSide) -> Self {
-        self.side = Some(side);
-        self
-    }
-
-    pub fn overlaying(mut self, overlaying: &str) -> Self {
-        self.overlaying = Some(overlaying.to_owned());
-        self
-    }
-
     pub fn domain(mut self, domain: &[f64]) -> Self {
         self.domain = Some(domain.to_vec());
-        self
-    }
-
-    pub fn position(mut self, position: f64) -> Self {
-        self.position = Some(position);
-        self
-    }
-
-    pub fn range_slider(mut self, slider: RangeSlider) -> Self {
-        self.range_slider = Some(slider);
-        self
-    }
-
-    pub fn range_selector(mut self, range_selector: RangeSelector) -> Self {
-        self.range_selector = Some(range_selector);
-        self
-    }
-
-    pub fn calendar(mut self, calendar: Calendar) -> Self {
-        self.calendar = Some(calendar);
         self
     }
 }
@@ -1208,7 +598,7 @@ pub enum GridYSide {
 }
 
 #[serde_with::skip_serializing_none]
-#[derive(Serialize, Debug, Default, Clone)]
+#[derive(Serialize, Debug, Clone, FieldSetter)]
 pub struct GridDomain {
     x: Option<Vec<f64>>,
     y: Option<Vec<f64>>,
@@ -1218,20 +608,10 @@ impl GridDomain {
     pub fn new() -> Self {
         Default::default()
     }
-
-    pub fn x(mut self, x: Vec<f64>) -> Self {
-        self.x = Some(x);
-        self
-    }
-
-    pub fn y(mut self, y: Vec<f64>) -> Self {
-        self.y = Some(y);
-        self
-    }
 }
 
 #[serde_with::skip_serializing_none]
-#[derive(Serialize, Debug, Default, Clone)]
+#[derive(Serialize, Debug, Clone, FieldSetter)]
 pub struct LayoutGrid {
     rows: Option<usize>,
     #[serde(rename = "roworder")]
@@ -1259,65 +639,6 @@ impl LayoutGrid {
     pub fn new() -> Self {
         Default::default()
     }
-
-    pub fn rows(mut self, rows: usize) -> Self {
-        self.rows = Some(rows);
-        self
-    }
-
-    pub fn row_order(mut self, row_order: RowOrder) -> Self {
-        self.row_order = Some(row_order);
-        self
-    }
-
-    pub fn columns(mut self, columns: usize) -> Self {
-        self.columns = Some(columns);
-        self
-    }
-
-    pub fn sub_plots(mut self, sub_plots: Vec<String>) -> Self {
-        self.sub_plots = Some(sub_plots);
-        self
-    }
-
-    pub fn x_axes(mut self, x_axes: Vec<String>) -> Self {
-        self.x_axes = Some(x_axes);
-        self
-    }
-
-    pub fn y_axes(mut self, y_axes: Vec<String>) -> Self {
-        self.y_axes = Some(y_axes);
-        self
-    }
-
-    pub fn pattern(mut self, pattern: GridPattern) -> Self {
-        self.pattern = Some(pattern);
-        self
-    }
-
-    pub fn x_gap(mut self, x_gap: f64) -> Self {
-        self.x_gap = Some(x_gap);
-        self
-    }
-
-    pub fn y_gap(mut self, y_gap: f64) -> Self {
-        self.y_gap = Some(y_gap);
-        self
-    }
-
-    pub fn domain(mut self, domain: GridDomain) -> Self {
-        self.domain = Some(domain);
-        self
-    }
-
-    pub fn x_side(mut self, x_side: GridXSide) -> Self {
-        self.x_side = Some(x_side);
-        self
-    }
-    pub fn y_side(mut self, y_side: GridYSide) -> Self {
-        self.y_side = Some(y_side);
-        self
-    }
 }
 
 #[derive(Debug, Clone)]
@@ -1341,7 +662,7 @@ impl Serialize for UniformTextMode {
 }
 
 #[serde_with::skip_serializing_none]
-#[derive(Serialize, Debug, Default, Clone)]
+#[derive(Serialize, Debug, Clone, FieldSetter)]
 pub struct UniformText {
     mode: Option<UniformTextMode>,
     #[serde(rename = "minsize")]
@@ -1351,16 +672,6 @@ pub struct UniformText {
 impl UniformText {
     pub fn new() -> Self {
         Default::default()
-    }
-
-    pub fn mode(mut self, mode: UniformTextMode) -> Self {
-        self.mode = Some(mode);
-        self
-    }
-
-    pub fn min_size(mut self, min_size: usize) -> Self {
-        self.min_size = Some(min_size);
-        self
     }
 }
 
@@ -1391,7 +702,7 @@ impl Serialize for HoverMode {
 }
 
 #[serde_with::skip_serializing_none]
-#[derive(Serialize, Debug, Default, Clone)]
+#[derive(Serialize, Debug, Clone, FieldSetter)]
 pub struct ModeBar {
     orientation: Option<Orientation>,
     #[serde(rename = "bgcolor")]
@@ -1404,26 +715,6 @@ pub struct ModeBar {
 impl ModeBar {
     pub fn new() -> Self {
         Default::default()
-    }
-
-    pub fn orientation(mut self, orientation: Orientation) -> Self {
-        self.orientation = Some(orientation);
-        self
-    }
-
-    pub fn background_color<C: Color>(mut self, background_color: C) -> Self {
-        self.background_color = Some(Box::new(background_color));
-        self
-    }
-
-    pub fn color<C: Color>(mut self, color: C) -> Self {
-        self.color = Some(Box::new(color));
-        self
-    }
-
-    pub fn active_color<C: Color>(mut self, active_color: C) -> Self {
-        self.active_color = Some(Box::new(active_color));
-        self
     }
 }
 
@@ -1458,10 +749,14 @@ pub enum FillRule {
 }
 
 #[serde_with::skip_serializing_none]
-#[derive(Serialize, Debug, Default, Clone)]
+#[derive(Serialize, Debug, Clone, FieldSetter)]
 pub struct ShapeLine {
+    /// Sets the line color.
     color: Option<Box<dyn Color>>,
+    /// Sets the line width (in px).
     width: Option<f64>,
+    /// Sets the dash style of lines. Set to a dash type string ("solid", "dot", "dash", "longdash",
+    /// "dashdot", or "longdashdot") or a dash length list in px (eg "5px,10px,2px,2px").
     dash: Option<DashType>,
 }
 
@@ -1469,175 +764,67 @@ impl ShapeLine {
     pub fn new() -> Self {
         Default::default()
     }
-
-    /// Sets the line color.
-    pub fn color<C: Color>(mut self, color: C) -> Self {
-        self.color = Some(Box::new(color));
-        self
-    }
-
-    /// Sets the line width (in px).
-    pub fn width(mut self, width: f64) -> Self {
-        self.width = Some(width);
-        self
-    }
-
-    /// Sets the dash style of lines. Set to a dash type string ("solid", "dot", "dash", "longdash",
-    /// "dashdot", or "longdashdot") or a dash length list in px (eg "5px,10px,2px,2px").
-    pub fn dash(mut self, dash: DashType) -> Self {
-        self.dash = Some(dash);
-        self
-    }
 }
 
 #[serde_with::skip_serializing_none]
-#[derive(Serialize, Debug, Default, Clone)]
+#[derive(Serialize, Debug, Clone, FieldSetter)]
 pub struct Shape {
-    visible: Option<bool>,
-    r#type: Option<ShapeType>,
-    layer: Option<ShapeLayer>,
-    #[serde(rename = "xref")]
-    x_ref: Option<String>,
-    #[serde(rename = "xsizemode")]
-    x_size_mode: Option<ShapeSizeMode>,
-    #[serde(rename = "xanchor")]
-    x_anchor: Option<NumOrString>,
-    x0: Option<NumOrString>,
-    x1: Option<NumOrString>,
-    #[serde(rename = "yref")]
-    y_ref: Option<String>,
-    #[serde(rename = "ysizemode")]
-    y_size_mode: Option<ShapeSizeMode>,
-    #[serde(rename = "yanchor")]
-    y_anchor: Option<NumOrString>,
-    y0: Option<NumOrString>,
-    y1: Option<NumOrString>,
-    path: Option<String>,
-    opacity: Option<f64>,
-    line: Option<ShapeLine>,
-    #[serde(rename = "fillcolor")]
-    fill_color: Option<Box<dyn Color>>,
-    #[serde(rename = "fillrule")]
-    fill_rule: Option<FillRule>,
-    editable: Option<bool>,
-    name: Option<String>,
-    #[serde(rename = "templateitemname")]
-    template_item_name: Option<String>,
-}
-
-impl Shape {
-    pub fn new() -> Self {
-        Default::default()
-    }
-
     /// Determines whether or not this shape is visible.
-    pub fn visible(mut self, visible: bool) -> Self {
-        self.visible = Some(visible);
-        self
-    }
-
-    /// Specifies the shape type to be drawn. If "line", a line is drawn from (`x0`,`y0`) to
-    /// (`x1`,`y1`) with respect to the axes' sizing mode. If "circle", a circle is drawn from
-    /// ((`x0`+`x1`)/2, (`y0`+`y1`)/2)) with radius (|(`x0`+`x1`)/2 - `x0`|, |(`y0`+`y1`)/2 -`y0`)|)
-    /// with respect to the axes' sizing mode. If "rect", a rectangle is drawn linking
-    /// (`x0`,`y0`), (`x1`,`y0`), (`x1`,`y1`), (`x0`,`y1`), (`x0`,`y0`) with respect to the axes'
-    /// sizing mode. If "path", draw a custom SVG path using `path`. with respect to the axes'
-    /// sizing mode.
-    pub fn shape_type(mut self, shape_type: ShapeType) -> Self {
-        self.r#type = Some(shape_type);
-        self
-    }
-
+    visible: Option<bool>,
+    #[field_setter(skip)]
+    r#type: Option<ShapeType>,
     /// Specifies whether shapes are drawn below or above traces.
-    pub fn layer(mut self, layer: ShapeLayer) -> Self {
-        self.layer = Some(layer);
-        self
-    }
-
+    layer: Option<ShapeLayer>,
     /// Sets the shape's x coordinate axis. If set to an x axis id (e.g. "x" or "x2"), the `x`
     /// position refers to an x coordinate. If set to "paper", the `x` position refers to the
     /// distance from the left side of the plotting area in normalized coordinates where "0" ("1")
     /// corresponds to the left (right) side. If the axis `type` is "log", then you must take the
     /// log of your desired range. If the axis `type` is "date", then you must convert the date to
     /// unix time in milliseconds.
-    pub fn x_ref(mut self, x_ref: &str) -> Self {
-        self.x_ref = Some(x_ref.to_owned());
-        self
-    }
-
+    #[serde(rename = "xref")]
+    x_ref: Option<String>,
     /// Sets the shapes's sizing mode along the x axis. If set to "scaled", `x0`, `x1` and x
     /// coordinates within `path` refer to data values on the x axis or a fraction of the plot
     /// area's width (`xref` set to "paper"). If set to "pixel", `xanchor` specifies the x position
     /// in terms of data or plot fraction but `x0`, `x1` and x coordinates within `path` are pixels
     /// relative to `xanchor`. This way, the shape can have a fixed width while maintaining a
     /// position relative to data or plot fraction.
-    pub fn x_size_mode(mut self, x_size_mode: ShapeSizeMode) -> Self {
-        self.x_size_mode = Some(x_size_mode);
-        self
-    }
-
+    #[serde(rename = "xsizemode")]
+    x_size_mode: Option<ShapeSizeMode>,
     /// Only relevant in conjunction with `xsizemode` set to "pixel". Specifies the anchor point on
     /// the x axis to which `x0`, `x1` and x coordinates within `path` are relative to. E.g. useful
     /// to attach a pixel sized shape to a certain data value. No effect when `xsizemode` not set
     /// to "pixel".
-    pub fn x_anchor<V: Into<NumOrString>>(mut self, x_anchor: V) -> Self {
-        self.x_anchor = Some(x_anchor.into());
-        self
-    }
-
+    #[serde(rename = "xanchor")]
+    x_anchor: Option<NumOrString>,
     /// Sets the shape's starting x position. See `type` and `xsizemode` for more info.
-    pub fn x0<V: Into<NumOrString>>(mut self, x0: V) -> Self {
-        self.x0 = Some(x0.into());
-        self
-    }
-
+    x0: Option<NumOrString>,
     /// Sets the shape's end x position. See `type` and `xsizemode` for more info.
-    pub fn x1<V: Into<NumOrString>>(mut self, x1: V) -> Self {
-        self.x1 = Some(x1.into());
-        self
-    }
-
+    x1: Option<NumOrString>,
     /// Sets the annotation's y coordinate axis. If set to an y axis id (e.g. "y" or "y2"),
     /// the `y` position refers to an y coordinate If set to "paper", the `y` position refers to
     /// the distance from the bottom of the plotting area in normalized coordinates where "0" ("1")
     /// corresponds to the bottom (top).
-    pub fn y_ref(mut self, y_ref: &str) -> Self {
-        self.y_ref = Some(y_ref.to_owned());
-        self
-    }
-
+    #[serde(rename = "yref")]
+    y_ref: Option<String>,
     /// Sets the shapes's sizing mode along the y axis. If set to "scaled", `y0`, `y1` and y
     /// coordinates within `path` refer to data values on the y axis or a fraction of the plot
     /// area's height (`yref` set to "paper"). If set to "pixel", `yanchor` specifies the y position
     /// in terms of data or plot fraction but `y0`, `y1` and y coordinates within `path` are pixels
     /// relative to `yanchor`. This way, the shape can have a fixed height while maintaining a
     /// position relative to data or plot fraction.
-    pub fn y_size_mode(mut self, y_size_mode: ShapeSizeMode) -> Self {
-        self.y_size_mode = Some(y_size_mode);
-        self
-    }
-
+    #[serde(rename = "ysizemode")]
+    y_size_mode: Option<ShapeSizeMode>,
     /// Only relevant in conjunction with `ysizemode` set to "pixel". Specifies the anchor point on
     /// the y axis to which `y0`, `y1` and y coordinates within `path` are relative to. E.g. useful
     /// to attach a pixel sized shape to a certain data value. No effect when `ysizemode` not set
     /// to "pixel".
-    pub fn y_anchor<V: Into<NumOrString>>(mut self, y_anchor: V) -> Self {
-        self.y_anchor = Some(y_anchor.into());
-        self
-    }
-
+    #[serde(rename = "yanchor")]
+    y_anchor: Option<NumOrString>,
     /// Sets the shape's starting y position. See `type` and `ysizemode` for more info.
-    pub fn y0<V: Into<NumOrString>>(mut self, y0: V) -> Self {
-        self.y0 = Some(y0.into());
-        self
-    }
-
+    y0: Option<NumOrString>,
     /// Sets the shape's end y position. See `type` and `ysizemode` for more info.
-    pub fn y1<V: Into<NumOrString>>(mut self, y1: V) -> Self {
-        self.y1 = Some(y1.into());
-        self
-    }
-
+    y1: Option<NumOrString>,
     /// For `type` "path" - a valid SVG path with the pixel values replaced by data values in
     /// `xsizemode`/`ysizemode` being "scaled" and taken unmodified as pixels relative to
     /// `xanchor` and `yanchor` in case of "pixel" size mode. There are a few restrictions / quirks
@@ -1651,60 +838,50 @@ impl Shape {
     /// there would be no way to describe fractional positions On data axes: because space and T are
     /// both normal components of path strings, we can't use either to separate date from time parts.
     /// Therefore we'll use underscore for this purpose: 2015-02-21_13:45:56.789
-    pub fn path(mut self, path: &str) -> Self {
-        self.path = Some(path.to_owned());
-        self
-    }
-
+    path: Option<String>,
     /// Sets the opacity of the shape. Number between or equal to 0 and 1.
-    pub fn opacity(mut self, opacity: f64) -> Self {
-        self.opacity = Some(opacity);
-        self
-    }
-
+    opacity: Option<f64>,
     /// Sets the shape line properties (`color`, `width`, `dash`).
-    pub fn line(mut self, line: ShapeLine) -> Self {
-        self.line = Some(line);
-        self
-    }
-
+    line: Option<ShapeLine>,
     /// Sets the color filling the shape's interior. Only applies to closed shapes.
-    pub fn fill_color<C: Color>(mut self, fill_color: C) -> Self {
-        self.fill_color = Some(Box::new(fill_color));
-        self
-    }
-
+    #[serde(rename = "fillcolor")]
+    fill_color: Option<Box<dyn Color>>,
     /// Determines which regions of complex paths constitute the interior. For more info please
     /// visit https://developer.mozilla.org/en-US/docs/Web/SVG/Attribute/fill-rule
-    pub fn fill_rule(mut self, fill_rule: FillRule) -> Self {
-        self.fill_rule = Some(fill_rule);
-        self
-    }
-
+    #[serde(rename = "fillrule")]
+    fill_rule: Option<FillRule>,
     /// Determines whether the shape could be activated for edit or not. Has no effect when the
     /// older editable shapes mode is enabled via `config.editable` or `config.edits.shapePosition`.
-    pub fn editable(mut self, editable: bool) -> Self {
-        self.editable = Some(editable);
-        self
-    }
-
+    editable: Option<bool>,
     /// When used in a template, named items are created in the output figure in addition to any
     /// items the figure already has in this array. You can modify these items in the output figure
     /// by making your own item with `templateitemname` matching this `name` alongside your
     /// modifications (including `visible: false` or `enabled: false` to hide it). Has no effect
     /// outside of a template.
-    pub fn name(mut self, name: &str) -> Self {
-        self.name = Some(name.to_owned());
-        self
-    }
-
+    name: Option<String>,
     /// Used to refer to a named item in this array in the template. Named items from the template
     /// will be created even without a matching item in the input figure, but you can modify one
     /// by making an item with `templateitemname` matching its `name`, alongside your modifications
     /// (including `visible: false` or `enabled: false` to hide it). If there is no template or no
     /// matching item, this item will be hidden unless you explicitly show it with `visible: true`.
-    pub fn template_item_name(mut self, template_item_name: &str) -> Self {
-        self.template_item_name = Some(template_item_name.to_owned());
+    #[serde(rename = "templateitemname")]
+    template_item_name: Option<String>,
+}
+
+impl Shape {
+    pub fn new() -> Self {
+        Default::default()
+    }
+
+    /// Specifies the shape type to be drawn. If "line", a line is drawn from (`x0`,`y0`) to
+    /// (`x1`,`y1`) with respect to the axes' sizing mode. If "circle", a circle is drawn from
+    /// ((`x0`+`x1`)/2, (`y0`+`y1`)/2)) with radius (|(`x0`+`x1`)/2 - `x0`|, |(`y0`+`y1`)/2 -`y0`)|)
+    /// with respect to the axes' sizing mode. If "rect", a rectangle is drawn linking
+    /// (`x0`,`y0`), (`x1`,`y0`), (`x1`,`y1`), (`x0`,`y1`), (`x0`,`y0`) with respect to the axes'
+    /// sizing mode. If "path", draw a custom SVG path using `path`. with respect to the axes'
+    /// sizing mode.
+    pub fn shape_type(mut self, shape_type: ShapeType) -> Self {
+        self.r#type = Some(shape_type);
         self
     }
 }
@@ -1719,15 +896,27 @@ pub enum DrawDirection {
 }
 
 #[serde_with::skip_serializing_none]
-#[derive(Serialize, Debug, Default, Clone)]
+#[derive(Serialize, Debug, Clone, FieldSetter)]
 pub struct NewShape {
+    /// Sets the shape line properties (`color`, `width`, `dash`).
     line: Option<ShapeLine>,
+    /// Sets the color filling new shapes' interior. Please note that if using a fillcolor with
+    /// alpha greater than half, drag inside the active shape starts moving the shape underneath,
+    /// otherwise a new shape could be started over.
     #[serde(rename = "fillcolor")]
     fill_color: Option<Box<dyn Color>>,
+    /// Determines the path's interior. For more info please
+    /// visit https://developer.mozilla.org/en-US/docs/Web/SVG/Attribute/fill-rule
     #[serde(rename = "fillrule")]
     fill_rule: Option<FillRule>,
+    /// Sets the opacity of new shapes. Number between or equal to 0 and 1.
     opacity: Option<f64>,
+    /// Specifies whether new shapes are drawn below or above traces.
     layer: Option<ShapeLayer>,
+    /// When `dragmode` is set to "drawrect", "drawline" or "drawcircle" this limits the drag to be
+    /// horizontal, vertical or diagonal. Using "diagonal" there is no limit e.g. in drawing lines
+    /// in any direction. "ortho" limits the draw to be either horizontal or vertical. "horizontal"
+    /// allows horizontal extend. "vertical" allows vertical extend.
     #[serde(rename = "drawdirection")]
     draw_direction: Option<DrawDirection>,
 }
@@ -1736,73 +925,21 @@ impl NewShape {
     pub fn new() -> Self {
         Default::default()
     }
-
-    /// Sets the shape line properties (`color`, `width`, `dash`).
-    pub fn line(mut self, line: ShapeLine) -> Self {
-        self.line = Some(line);
-        self
-    }
-
-    /// Sets the color filling new shapes' interior. Please note that if using a fillcolor with
-    /// alpha greater than half, drag inside the active shape starts moving the shape underneath,
-    /// otherwise a new shape could be started over.
-    pub fn fill_color<C: Color>(mut self, fill_color: C) -> Self {
-        self.fill_color = Some(Box::new(fill_color));
-        self
-    }
-
-    /// Determines the path's interior. For more info please
-    /// visit https://developer.mozilla.org/en-US/docs/Web/SVG/Attribute/fill-rule
-    pub fn fill_rule(mut self, fill_rule: FillRule) -> Self {
-        self.fill_rule = Some(fill_rule);
-        self
-    }
-
-    /// Sets the opacity of new shapes. Number between or equal to 0 and 1.
-    pub fn opacity(mut self, opacity: f64) -> Self {
-        self.opacity = Some(opacity);
-        self
-    }
-
-    /// Specifies whether new shapes are drawn below or above traces.
-    pub fn layer(mut self, layer: ShapeLayer) -> Self {
-        self.layer = Some(layer);
-        self
-    }
-
-    /// When `dragmode` is set to "drawrect", "drawline" or "drawcircle" this limits the drag to be
-    /// horizontal, vertical or diagonal. Using "diagonal" there is no limit e.g. in drawing lines
-    /// in any direction. "ortho" limits the draw to be either horizontal or vertical. "horizontal"
-    /// allows horizontal extend. "vertical" allows vertical extend.
-    pub fn draw_direction(mut self, draw_direction: DrawDirection) -> Self {
-        self.draw_direction = Some(draw_direction);
-        self
-    }
 }
 
 #[serde_with::skip_serializing_none]
-#[derive(Serialize, Debug, Default, Clone)]
+#[derive(Serialize, Debug, Clone, FieldSetter)]
 pub struct ActiveShape {
+    /// Sets the color filling the active shape' interior.
     #[serde(rename = "fillcolor")]
     fill_color: Option<Box<dyn Color>>,
+    /// Sets the opacity of the active shape. Number between or equal to 0 and 1.
     opacity: Option<f64>,
 }
 
 impl ActiveShape {
     pub fn new() -> Self {
         Default::default()
-    }
-
-    /// Sets the color filling the active shape' interior.
-    pub fn fill_color<C: Color>(mut self, fill_color: C) -> Self {
-        self.fill_color = Some(Box::new(fill_color));
-        self
-    }
-
-    /// Sets the opacity of the active shape. Number between or equal to 0 and 1.
-    pub fn opacity(mut self, opacity: f64) -> Self {
-        self.opacity = Some(opacity);
-        self
     }
 }
 
@@ -1837,352 +974,155 @@ impl Serialize for ClickToShow {
 }
 
 #[serde_with::skip_serializing_none]
-#[derive(Serialize, Debug, Default, Clone)]
+#[derive(Serialize, Debug, Clone, FieldSetter)]
 pub struct Annotation {
-    visible: Option<bool>,
-    text: Option<String>,
-    #[serde(rename = "textangle")]
-    text_angle: Option<f64>,
-    font: Option<Font>,
-    width: Option<f64>,
-    height: Option<f64>,
-    opacity: Option<f64>,
-    align: Option<HAlign>,
-    valign: Option<VAlign>,
-    #[serde(rename = "bgcolor")]
-    background_color: Option<Box<dyn Color>>,
-    #[serde(rename = "bordercolor")]
-    border_color: Option<Box<dyn Color>>,
-    #[serde(rename = "borderpad")]
-    border_pad: Option<f64>,
-    #[serde(rename = "borderwidth")]
-    border_width: Option<f64>,
-    #[serde(rename = "showarrow")]
-    show_arrow: Option<bool>,
-    #[serde(rename = "arrowcolor")]
-    arrow_color: Option<Box<dyn Color>>,
-    #[serde(rename = "arrowhead")]
-    arrow_head: Option<u8>,
-    #[serde(rename = "startarrowhead")]
-    start_arrow_head: Option<u8>,
-    #[serde(rename = "arrowside")]
-    arrow_side: Option<ArrowSide>,
-    #[serde(rename = "arrowsize")]
-    arrow_size: Option<f64>,
-    #[serde(rename = "startarrowsize")]
-    start_arrow_size: Option<f64>,
-    #[serde(rename = "arrowwidth")]
-    arrow_width: Option<f64>,
-    #[serde(rename = "standoff")]
-    stand_off: Option<f64>,
-    #[serde(rename = "startstandoff")]
-    start_stand_off: Option<f64>,
-    ax: Option<NumOrString>,
-    ay: Option<NumOrString>,
-    #[serde(rename = "axref")]
-    ax_ref: Option<String>,
-    #[serde(rename = "ayref")]
-    ay_ref: Option<String>,
-    #[serde(rename = "xref")]
-    x_ref: Option<String>,
-    x: Option<NumOrString>,
-    #[serde(rename = "xanchor")]
-    x_anchor: Option<Anchor>,
-    #[serde(rename = "xshift")]
-    x_shift: Option<f64>,
-    #[serde(rename = "yref")]
-    y_ref: Option<String>,
-    y: Option<NumOrString>,
-    #[serde(rename = "yanchor")]
-    y_anchor: Option<Anchor>,
-    #[serde(rename = "yshift")]
-    y_shift: Option<f64>,
-    #[serde(rename = "clicktoshow")]
-    click_to_show: Option<ClickToShow>,
-    #[serde(rename = "xclick")]
-    x_click: Option<NumOrString>,
-    #[serde(rename = "yclick")]
-    y_click: Option<NumOrString>,
-    #[serde(rename = "hovertext")]
-    hover_text: Option<String>,
-    #[serde(rename = "hoverlabel")]
-    hover_label: Option<Label>,
-    #[serde(rename = "captureevents")]
-    capture_events: Option<bool>,
-    name: Option<String>,
-    #[serde(rename = "templateitemname")]
-    template_item_name: Option<String>,
-}
-
-impl Annotation {
-    pub fn new() -> Self {
-        Default::default()
-    }
-
     /// Determines whether or not this annotation is visible.
-    pub fn visible(mut self, visible: bool) -> Self {
-        self.visible = Some(visible);
-        self
-    }
-
+    visible: Option<bool>,
     /// Sets the text associated with this annotation. Plotly uses a subset of HTML tags to do
     /// things like newline (<br>), bold (<b></b>), italics (<i></i>), hyperlinks
     /// (<a href='...'></a>). Tags <em>, <sup>, <sub> <span> are also supported.
-    pub fn text(mut self, text: &str) -> Self {
-        self.text = Some(text.to_owned());
-        self
-    }
-
+    text: Option<String>,
     /// Sets the angle at which the `text` is drawn with respect to the horizontal.
-    pub fn text_angle(mut self, text_angle: f64) -> Self {
-        self.text_angle = Some(text_angle);
-        self
-    }
-
+    #[serde(rename = "textangle")]
+    text_angle: Option<f64>,
     /// Sets the annotation text font.
-    pub fn font(mut self, font: Font) -> Self {
-        self.font = Some(font);
-        self
-    }
-
+    font: Option<Font>,
     /// Sets an explicit width for the text box. null (default) lets the text set the box width.
     /// Wider text will be clipped. There is no automatic wrapping; use <br> to start a new line.
-    pub fn width(mut self, width: f64) -> Self {
-        self.width = Some(width);
-        self
-    }
-
+    width: Option<f64>,
     /// Sets an explicit height for the text box. null (default) lets the text set the box height.
     /// Taller text will be clipped.
-    pub fn height(mut self, height: f64) -> Self {
-        self.height = Some(height);
-        self
-    }
-
+    height: Option<f64>,
     /// Sets the opacity of the annotation (text + arrow).
-    pub fn opacity(mut self, opacity: f64) -> Self {
-        self.opacity = Some(opacity);
-        self
-    }
-
+    opacity: Option<f64>,
     /// Sets the horizontal alignment of the `text` within the box. Has an effect only if `text`
     /// spans two or more lines (i.e. `text` contains one or more <br> HTML tags) or if an explicit
     /// width is set to override the text width.
-    pub fn align(mut self, align: HAlign) -> Self {
-        self.align = Some(align);
-        self
-    }
-
+    align: Option<HAlign>,
     /// Sets the vertical alignment of the `text` within the box. Has an effect only if an explicit
     /// height is set to override the text height.
-    pub fn valign(mut self, valign: VAlign) -> Self {
-        self.valign = Some(valign);
-        self
-    }
-
+    valign: Option<VAlign>,
     /// Sets the background color of the annotation.
-    pub fn background_color<C: Color>(mut self, background_color: C) -> Self {
-        self.background_color = Some(Box::new(background_color));
-        self
-    }
-
+    #[serde(rename = "bgcolor")]
+    background_color: Option<Box<dyn Color>>,
     /// Sets the color of the border enclosing the annotation `text`.
-    pub fn border_color<C: Color>(mut self, border_color: C) -> Self {
-        self.border_color = Some(Box::new(border_color));
-        self
-    }
-
+    #[serde(rename = "bordercolor")]
+    border_color: Option<Box<dyn Color>>,
     /// Sets the padding (in px) between the `text` and the enclosing border.
-    pub fn border_pad(mut self, border_pad: f64) -> Self {
-        self.border_pad = Some(border_pad);
-        self
-    }
-
+    #[serde(rename = "borderpad")]
+    border_pad: Option<f64>,
     /// Sets the width (in px) of the border enclosing the annotation `text`.
-    pub fn border_width(mut self, border_width: f64) -> Self {
-        self.border_width = Some(border_width);
-        self
-    }
-
+    #[serde(rename = "borderwidth")]
+    border_width: Option<f64>,
     /// Determines whether or not the annotation is drawn with an arrow. If "True", `text` is
     /// placed near the arrow's tail. If "False", `text` lines up with the `x` and `y` provided.
-    pub fn show_arrow(mut self, show_arrow: bool) -> Self {
-        self.show_arrow = Some(show_arrow);
-        self
-    }
-
+    #[serde(rename = "showarrow")]
+    show_arrow: Option<bool>,
     /// Sets the color of the annotation arrow.
-    pub fn arrow_color<C: Color>(mut self, arrow_color: C) -> Self {
-        self.arrow_color = Some(Box::new(arrow_color));
-        self
-    }
-
+    #[serde(rename = "arrowcolor")]
+    arrow_color: Option<Box<dyn Color>>,
     /// Sets the end annotation arrow head style. Integer between or equal to 0 and 8.
-    pub fn arrow_head(mut self, arrow_head: u8) -> Self {
-        self.arrow_head = Some(arrow_head);
-        self
-    }
-
+    #[serde(rename = "arrowhead")]
+    arrow_head: Option<u8>,
     /// Sets the start annotation arrow head style. Integer between or equal to 0 and 8.
-    pub fn start_arrow_head(mut self, start_arrow_head: u8) -> Self {
-        self.start_arrow_head = Some(start_arrow_head);
-        self
-    }
-
+    #[serde(rename = "startarrowhead")]
+    start_arrow_head: Option<u8>,
     /// Sets the annotation arrow head position.
-    pub fn arrow_side(mut self, arrow_side: ArrowSide) -> Self {
-        self.arrow_side = Some(arrow_side);
-        self
-    }
-
+    #[serde(rename = "arrowside")]
+    arrow_side: Option<ArrowSide>,
     /// Sets the size of the end annotation arrow head, relative to `arrowwidth`. A value of 1
     /// (default) gives a head about 3x as wide as the line.
-    pub fn arrow_size(mut self, arrow_size: f64) -> Self {
-        self.arrow_size = Some(arrow_size);
-        self
-    }
-
+    #[serde(rename = "arrowsize")]
+    arrow_size: Option<f64>,
     /// Sets the size of the start annotation arrow head, relative to `arrowwidth`. A value of 1
     /// (default) gives a head about 3x as wide as the line.
-    pub fn start_arrow_size(mut self, start_arrow_size: f64) -> Self {
-        self.start_arrow_size = Some(start_arrow_size);
-        self
-    }
-
+    #[serde(rename = "startarrowsize")]
+    start_arrow_size: Option<f64>,
     /// Sets the width (in px) of annotation arrow line.
-    pub fn arrow_width(mut self, arrow_width: f64) -> Self {
-        self.arrow_width = Some(arrow_width);
-        self
-    }
-
+    #[serde(rename = "arrowwidth")]
+    arrow_width: Option<f64>,
     /// Sets a distance, in pixels, to move the end arrowhead away from the position it is pointing
     /// at, for example to point at the edge of a marker independent of zoom. Note that this
     /// shortens the arrow from the `ax` / `ay` vector, in contrast to `xshift` / `yshift` which
     /// moves everything by this amount.
-    pub fn stand_off(mut self, stand_off: f64) -> Self {
-        self.stand_off = Some(stand_off);
-        self
-    }
-
+    #[serde(rename = "standoff")]
+    stand_off: Option<f64>,
     /// Sets a distance, in pixels, to move the start arrowhead away from the position it is
     /// pointing at, for example to point at the edge of a marker independent of zoom. Note that
     /// this shortens the arrow from the `ax` / `ay` vector, in contrast to `xshift` / `yshift`
     /// which moves everything by this amount.
-    pub fn start_stand_off(mut self, start_stand_off: f64) -> Self {
-        self.start_stand_off = Some(start_stand_off);
-        self
-    }
-
+    #[serde(rename = "startstandoff")]
+    start_stand_off: Option<f64>,
     /// Sets the x component of the arrow tail about the arrow head. If `axref` is `pixel`, a
     /// positive (negative) component corresponds to an arrow pointing from right to left (left
     /// to right). If `axref` is an axis, this is an absolute value on that axis, like `x`, NOT a
     /// relative value.
-    pub fn ax<V: Into<NumOrString>>(mut self, ax: V) -> Self {
-        self.ax = Some(ax.into());
-        self
-    }
-
+    ax: Option<NumOrString>,
     /// Sets the y component of the arrow tail about the arrow head. If `ayref` is `pixel`, a
     /// positive (negative) component corresponds to an arrow pointing from bottom to top (top to
     /// bottom). If `ayref` is an axis, this is an absolute value on that axis, like `y`, NOT a
     /// relative value.
-    pub fn ay<V: Into<NumOrString>>(mut self, ay: V) -> Self {
-        self.ay = Some(ay.into());
-        self
-    }
-
+    ay: Option<NumOrString>,
     /// Indicates in what terms the tail of the annotation (ax,ay) is specified. If `pixel`, `ax`
     /// is a relative offset in pixels from `x`. If set to an x axis id (e.g. "x" or "x2"), `ax` is
     /// specified in the same terms as that axis. This is useful for trendline annotations which
     /// should continue to indicate the correct trend when zoomed.
-    pub fn ax_ref(mut self, ax_ref: &str) -> Self {
-        self.ax_ref = Some(ax_ref.to_owned());
-        self
-    }
-
+    #[serde(rename = "axref")]
+    ax_ref: Option<String>,
     /// Indicates in what terms the tail of the annotation (ax,ay) is specified. If `pixel`, `ay`
     /// is a relative offset in pixels from `y`. If set to a y axis id (e.g. "y" or "y2"), `ay` is
     /// specified in the same terms as that axis. This is useful for trendline annotations which
     /// should continue to indicate the correct trend when zoomed.
-    pub fn ay_ref(mut self, ay_ref: &str) -> Self {
-        self.ay_ref = Some(ay_ref.to_owned());
-        self
-    }
-
+    #[serde(rename = "ayref")]
+    ay_ref: Option<String>,
     /// Sets the annotation's x coordinate axis. If set to an x axis id (e.g. "x" or "x2"), the `x`
     /// position refers to an x coordinate If set to "paper", the `x` position refers to the
     /// distance from the left side of the plotting area in normalized coordinates where 0 (1)
     /// corresponds to the left (right) side.
-    pub fn x_ref(mut self, x_ref: &str) -> Self {
-        self.x_ref = Some(x_ref.to_owned());
-        self
-    }
-
+    #[serde(rename = "xref")]
+    x_ref: Option<String>,
     /// Sets the annotation's x position. If the axis `type` is "log", then you must take the log
     /// of your desired range. If the axis `type` is "date", it should be date strings, like date
     /// data, though Date objects and unix milliseconds will be accepted and converted to strings.
     /// If the axis `type` is "category", it should be numbers, using the scale where each category
     /// is assigned a serial number from zero in the order it appears.
-    pub fn x<V: Into<NumOrString>>(mut self, x: V) -> Self {
-        self.x = Some(x.into());
-        self
-    }
-
+    x: Option<NumOrString>,
     /// Sets the text box's horizontal position anchor This anchor binds the `x` position to the
     /// "left", "center" or "right" of the annotation. For example, if `x` is set to 1, `xref` to
     /// "paper" and `xanchor` to "right" then the right-most portion of the annotation lines up with
     /// the right-most edge of the plotting area. If "auto", the anchor is equivalent to "center"
     /// for data-referenced annotations or if there is an arrow, whereas for paper-referenced with
     /// no arrow, the anchor picked corresponds to the closest side.
-    pub fn x_anchor(mut self, x_anchor: Anchor) -> Self {
-        self.x_anchor = Some(x_anchor);
-        self
-    }
-
+    #[serde(rename = "xanchor")]
+    x_anchor: Option<Anchor>,
     /// Shifts the position of the whole annotation and arrow to the right (positive) or left
     /// (negative) by this many pixels.
-    pub fn x_shift(mut self, x_shift: f64) -> Self {
-        self.x_shift = Some(x_shift);
-        self
-    }
-
+    #[serde(rename = "xshift")]
+    x_shift: Option<f64>,
     /// Sets the annotation's y coordinate axis. If set to an y axis id (e.g. "y" or "y2"), the `y`
     /// position refers to an y coordinate If set to "paper", the `y` position refers to the
     /// distance from the bottom of the plotting area in normalized coordinates where 0 (1)
     /// corresponds to the bottom (top).
-    pub fn y_ref(mut self, y_ref: &str) -> Self {
-        self.y_ref = Some(y_ref.to_owned());
-        self
-    }
-
+    #[serde(rename = "yref")]
+    y_ref: Option<String>,
     /// Sets the annotation's y position. If the axis `type` is "log", then you must take the log of
     /// your desired range. If the axis `type` is "date", it should be date strings, like date data,
     /// though Date objects and unix milliseconds will be accepted and converted to strings. If the
     /// axis `type` is "category", it should be numbers, using the scale where each category is
     /// assigned a serial number from zero in the order it appears.
-    pub fn y<V: Into<NumOrString>>(mut self, y: V) -> Self {
-        self.y = Some(y.into());
-        self
-    }
-
+    y: Option<NumOrString>,
     /// Sets the text box's vertical position anchor This anchor binds the `y` position to the
     /// "top", "middle" or "bottom" of the annotation. For example, if `y` is set to 1, `yref` to
     /// "paper" and `yanchor` to "top" then the top-most portion of the annotation lines up with the
     /// top-most edge of the plotting area. If "auto", the anchor is equivalent to "middle" for
     /// data-referenced annotations or if there is an arrow, whereas for paper-referenced with no
     /// arrow, the anchor picked corresponds to the closest side.
-    pub fn y_anchor(mut self, y_anchor: Anchor) -> Self {
-        self.y_anchor = Some(y_anchor);
-        self
-    }
-
+    #[serde(rename = "yanchor")]
+    y_anchor: Option<Anchor>,
     /// Shifts the position of the whole annotation and arrow up (positive) or down (negative) by
     /// this many pixels.
-    pub fn y_shift(mut self, y_shift: f64) -> Self {
-        self.y_shift = Some(y_shift);
-        self
-    }
-
+    #[serde(rename = "yshift")]
+    y_shift: Option<f64>,
     /// Makes this annotation respond to clicks on the plot. If you click a data point that exactly
     /// matches the `x` and `y` values of this annotation, and it is hidden (visible: false), it
     /// will appear. In "onoff" mode, you must click the same point again to make it disappear, so
@@ -2191,65 +1131,47 @@ impl Annotation {
     /// need to show/hide this annotation in response to different `x` or `y` values, you can set
     /// `xclick` and/or `yclick`. This is useful for example to label the side of a bar. To label
     /// markers though, `standoff` is preferred over `xclick` and `yclick`.
-    pub fn click_to_show(mut self, click_to_show: ClickToShow) -> Self {
-        self.click_to_show = Some(click_to_show);
-        self
-    }
-
+    #[serde(rename = "clicktoshow")]
+    click_to_show: Option<ClickToShow>,
     /// Toggle this annotation when clicking a data point whose `x` value is `xclick` rather than
     /// the annotation's `x` value.
-    pub fn x_click<V: Into<NumOrString>>(mut self, x_click: V) -> Self {
-        self.x_click = Some(x_click.into());
-        self
-    }
-
+    #[serde(rename = "xclick")]
+    x_click: Option<NumOrString>,
     /// Toggle this annotation when clicking a data point whose `y` value is `yclick` rather than
     /// the annotation's `y` value.
-    pub fn y_click<V: Into<NumOrString>>(mut self, y_click: V) -> Self {
-        self.y_click = Some(y_click.into());
-        self
-    }
-
+    #[serde(rename = "yclick")]
+    y_click: Option<NumOrString>,
     /// Sets text to appear when hovering over this annotation. If omitted or blank, no hover label
     /// will appear.
-    pub fn hover_text(mut self, hover_text: &str) -> Self {
-        self.hover_text = Some(hover_text.to_owned());
-        self
-    }
-
+    #[serde(rename = "hovertext")]
+    hover_text: Option<String>,
     /// Label displayed on mouse hover.
-    pub fn hover_label(mut self, hover_label: Label) -> Self {
-        self.hover_label = Some(hover_label);
-        self
-    }
-
+    #[serde(rename = "hoverlabel")]
+    hover_label: Option<Label>,
     /// Determines whether the annotation text box captures mouse move and click events, or allows
     /// those events to pass through to data points in the plot that may be behind the annotation.
     /// By default `captureevents` is "false" unless `hovertext` is provided. If you use the event
     /// `plotly_clickannotation` without `hovertext` you must explicitly enable `captureevents`.
-    pub fn capture_events(mut self, capture_events: bool) -> Self {
-        self.capture_events = Some(capture_events);
-        self
-    }
-
+    #[serde(rename = "captureevents")]
+    capture_events: Option<bool>,
     /// When used in a template, named items are created in the output figure in addition to any
     /// items the figure already has in this array. You can modify these items in the output figure
     /// by making your own item with `templateitemname` matching this `name` alongside your
     /// modifications (including `visible: false` or `enabled: false` to hide it). Has no effect
     /// outside of a template.
-    pub fn name(mut self, name: &str) -> Self {
-        self.name = Some(name.to_owned());
-        self
-    }
-
+    name: Option<String>,
     /// Used to refer to a named item in this array in the template. Named items from the template
     /// will be created even without a matching item in the input figure, but you can modify one by
     /// making an item with `templateitemname` matching its `name`, alongside your modifications
     /// (including `visible: false` or `enabled: false` to hide it). If there is no template or no
     /// matching item, this item will be hidden unless you explicitly show it with `visible: true`.
-    pub fn template_item_name(mut self, template_item_name: &str) -> Self {
-        self.template_item_name = Some(template_item_name.to_owned());
-        self
+    #[serde(rename = "templateitemname")]
+    template_item_name: Option<String>,
+}
+
+impl Annotation {
+    pub fn new() -> Self {
+        Default::default()
     }
 }
 
@@ -2314,7 +1236,7 @@ pub enum SelectDirection {
 }
 
 #[serde_with::skip_serializing_none]
-#[derive(Serialize, Debug, Default, Clone)]
+#[derive(Serialize, Debug, Clone, FieldSetter)]
 pub struct Template {
     layout: Option<LayoutTemplate>,
 }
@@ -2322,11 +1244,6 @@ pub struct Template {
 impl Template {
     pub fn new() -> Self {
         Default::default()
-    }
-
-    pub fn layout(mut self, layout: LayoutTemplate) -> Self {
-        self.layout = Some(layout);
-        self
     }
 }
 
@@ -2346,7 +1263,7 @@ impl Into<Cow<'static, Template>> for &'static Template {
 
 // LayoutTemplate matches Layout except it lacks a field for template
 #[serde_with::skip_serializing_none]
-#[derive(Serialize, Debug, Default, Clone)]
+#[derive(Serialize, Debug, Clone, FieldSetter)]
 pub struct LayoutTemplate {
     title: Option<Title>,
     #[serde(rename = "showlegend")]
@@ -2372,6 +1289,16 @@ pub struct LayoutTemplate {
     color_axis: Option<ColorAxis>,
     #[serde(rename = "modebar")]
     mode_bar: Option<ModeBar>,
+    /// Determines the mode of hover interactions. If "closest", a single hoverlabel will appear for the "closest"
+    /// point within the `hoverdistance`. If "x" (or "y"), multiple hoverlabels will appear for multiple points at
+    /// the "closest" x- (or y-) coordinate within the `hoverdistance`, with the caveat that no more than one hoverlabel
+    /// will appear per trace. If "x unified" (or "y unified"), a single hoverlabel will appear multiple points at
+    /// the closest x- (or y-) coordinate within the `hoverdistance` with the caveat that no more than one hoverlabel
+    /// will appear per trace. In this mode, spikelines are enabled by default perpendicular to the specified axis.
+    /// If false, hover interactions are disabled. If `clickmode` includes the "select" flag, `hovermode` defaults to
+    /// "closest". If `clickmode` lacks the "select" flag, it defaults to "x" or "y"
+    /// (depending on the trace's `orientation` value) for plots based on cartesian coordinates. For anything
+    /// else the default value is "closest".
     #[serde(rename = "hovermode")]
     hover_mode: Option<HoverMode>,
     #[serde(rename = "clickmode")]
@@ -2479,236 +1406,11 @@ impl LayoutTemplate {
         Default::default()
     }
 
-    pub fn title(mut self, title: Title) -> Self {
-        self.title = Some(title);
-        self
-    }
-
-    pub fn show_legend(mut self, show_legend: bool) -> Self {
-        self.show_legend = Some(show_legend);
-        self
-    }
-
-    pub fn legend(mut self, legend: Legend) -> Self {
-        self.legend = Some(legend);
-        self
-    }
-
-    pub fn margin(mut self, margin: Margin) -> Self {
-        self.margin = Some(margin);
-        self
-    }
-
-    pub fn auto_size(mut self, auto_size: bool) -> Self {
-        self.auto_size = Some(auto_size);
-        self
-    }
-
-    pub fn width(mut self, width: usize) -> Self {
-        self.width = Some(width);
-        self
-    }
-
-    pub fn height(mut self, height: usize) -> Self {
-        self.height = Some(height);
-        self
-    }
-
-    pub fn font(mut self, font: Font) -> Self {
-        self.font = Some(font);
-        self
-    }
-
-    pub fn uniform_text(mut self, uniform_text: UniformText) -> Self {
-        self.uniform_text = Some(uniform_text);
-        self
-    }
-
-    pub fn separators(mut self, separators: &str) -> Self {
-        self.separators = Some(separators.to_owned());
-        self
-    }
-
-    pub fn paper_background_color<C: Color>(mut self, paper_background_color: C) -> Self {
-        self.paper_background_color = Some(Box::new(paper_background_color));
-        self
-    }
-
-    pub fn plot_background_color<C: Color>(mut self, plot_background_color: C) -> Self {
-        self.plot_background_color = Some(Box::new(plot_background_color));
-        self
-    }
-
-    pub fn color_scale(mut self, color_scale: LayoutColorScale) -> Self {
-        self.color_scale = Some(color_scale);
-        self
-    }
-
-    pub fn colorway<C: Color>(mut self, colorway: Vec<C>) -> Self {
-        self.colorway = Some(ColorArray(colorway).into());
-        self
-    }
-
-    pub fn color_axis(mut self, color_axis: ColorAxis) -> Self {
-        self.color_axis = Some(color_axis);
-        self
-    }
-
-    pub fn mode_bar(mut self, mode_bar: ModeBar) -> Self {
-        self.mode_bar = Some(mode_bar);
-        self
-    }
-
-    /// Determines the mode of hover interactions. If "closest", a single hoverlabel will appear for the "closest"
-    /// point within the `hoverdistance`. If "x" (or "y"), multiple hoverlabels will appear for multiple points at
-    /// the "closest" x- (or y-) coordinate within the `hoverdistance`, with the caveat that no more than one hoverlabel
-    /// will appear per trace. If "x unified" (or "y unified"), a single hoverlabel will appear multiple points at
-    /// the closest x- (or y-) coordinate within the `hoverdistance` with the caveat that no more than one hoverlabel
-    /// will appear per trace. In this mode, spikelines are enabled by default perpendicular to the specified axis.
-    /// If false, hover interactions are disabled. If `clickmode` includes the "select" flag, `hovermode` defaults to
-    /// "closest". If `clickmode` lacks the "select" flag, it defaults to "x" or "y"
-    /// (depending on the trace's `orientation` value) for plots based on cartesian coordinates. For anything
-    /// else the default value is "closest".
-    pub fn hover_mode(mut self, hover_mode: HoverMode) -> Self {
-        self.hover_mode = Some(hover_mode);
-        self
-    }
-
-    pub fn click_mode(mut self, click_mode: ClickMode) -> Self {
-        self.click_mode = Some(click_mode);
-        self
-    }
-
-    pub fn drag_mode(mut self, drag_mode: DragMode) -> Self {
-        self.drag_mode = Some(drag_mode);
-        self
-    }
-
-    pub fn select_direction(mut self, select_direction: SelectDirection) -> Self {
-        self.select_direction = Some(select_direction);
-        self
-    }
-
-    pub fn hover_distance(mut self, hover_distance: i32) -> Self {
-        self.hover_distance = Some(hover_distance);
-        self
-    }
-
-    pub fn spike_distance(mut self, spike_distance: i32) -> Self {
-        self.spike_distance = Some(spike_distance);
-        self
-    }
-
-    pub fn hover_label(mut self, hover_label: Label) -> Self {
-        self.hover_label = Some(hover_label);
-        self
-    }
-
-    pub fn grid(mut self, grid: LayoutGrid) -> Self {
-        self.grid = Some(grid);
-        self
-    }
-
-    pub fn calendar(mut self, calendar: Calendar) -> Self {
-        self.calendar = Some(calendar);
-        self
-    }
-
-    pub fn x_axis(mut self, xaxis: Axis) -> Self {
-        self.x_axis = Some(Box::new(xaxis));
-        self
-    }
-
-    pub fn y_axis(mut self, yaxis: Axis) -> Self {
-        self.y_axis = Some(Box::new(yaxis));
-        self
-    }
-
-    pub fn x_axis2(mut self, xaxis: Axis) -> Self {
-        self.x_axis2 = Some(Box::new(xaxis));
-        self
-    }
-
-    pub fn y_axis2(mut self, yaxis: Axis) -> Self {
-        self.y_axis2 = Some(Box::new(yaxis));
-        self
-    }
-
-    pub fn x_axis3(mut self, xaxis: Axis) -> Self {
-        self.x_axis3 = Some(Box::new(xaxis));
-        self
-    }
-
-    pub fn y_axis3(mut self, yaxis: Axis) -> Self {
-        self.y_axis3 = Some(Box::new(yaxis));
-        self
-    }
-
-    pub fn x_axis4(mut self, xaxis: Axis) -> Self {
-        self.x_axis4 = Some(Box::new(xaxis));
-        self
-    }
-
-    pub fn y_axis4(mut self, yaxis: Axis) -> Self {
-        self.y_axis4 = Some(Box::new(yaxis));
-        self
-    }
-
-    pub fn x_axis5(mut self, xaxis: Axis) -> Self {
-        self.x_axis5 = Some(Box::new(xaxis));
-        self
-    }
-
-    pub fn y_axis5(mut self, yaxis: Axis) -> Self {
-        self.y_axis5 = Some(Box::new(yaxis));
-        self
-    }
-
-    pub fn x_axis6(mut self, xaxis: Axis) -> Self {
-        self.x_axis6 = Some(Box::new(xaxis));
-        self
-    }
-
-    pub fn y_axis6(mut self, yaxis: Axis) -> Self {
-        self.y_axis6 = Some(Box::new(yaxis));
-        self
-    }
-
-    pub fn x_axis7(mut self, xaxis: Axis) -> Self {
-        self.x_axis7 = Some(Box::new(xaxis));
-        self
-    }
-
-    pub fn y_axis7(mut self, yaxis: Axis) -> Self {
-        self.y_axis7 = Some(Box::new(yaxis));
-        self
-    }
-
-    pub fn x_axis8(mut self, xaxis: Axis) -> Self {
-        self.x_axis8 = Some(Box::new(xaxis));
-        self
-    }
-
-    pub fn y_axis8(mut self, yaxis: Axis) -> Self {
-        self.y_axis8 = Some(Box::new(yaxis));
-        self
-    }
-
-    pub fn annotations(mut self, annotations: Vec<Annotation>) -> Self {
-        self.annotations = Some(annotations);
-        self
-    }
-
     pub fn add_annotation(&mut self, annotation: Annotation) {
         if self.annotations.is_none() {
             self.annotations = Some(Vec::new());
         }
         self.annotations.as_mut().unwrap().push(annotation);
-    }
-
-    pub fn shapes(mut self, shapes: Vec<Shape>) -> Self {
-        self.shapes = Some(shapes);
-        self
     }
 
     pub fn add_shape(&mut self, shape: Shape) {
@@ -2717,105 +1419,11 @@ impl LayoutTemplate {
         }
         self.shapes.as_mut().unwrap().push(shape);
     }
-
-    pub fn new_shape(mut self, new_shape: NewShape) -> Self {
-        self.new_shape = Some(new_shape);
-        self
-    }
-
-    pub fn active_shape(mut self, active_shape: ActiveShape) -> Self {
-        self.active_shape = Some(active_shape);
-        self
-    }
-
-    pub fn box_mode(mut self, box_mode: BoxMode) -> Self {
-        self.box_mode = Some(box_mode);
-        self
-    }
-
-    pub fn box_gap(mut self, box_gap: f64) -> Self {
-        self.box_gap = Some(box_gap);
-        self
-    }
-
-    pub fn box_group_gap(mut self, box_group_gap: f64) -> Self {
-        self.box_group_gap = Some(box_group_gap);
-        self
-    }
-
-    pub fn bar_mode(mut self, bar_mode: BarMode) -> Self {
-        self.bar_mode = Some(bar_mode);
-        self
-    }
-
-    pub fn bar_norm(mut self, bar_norm: BarNorm) -> Self {
-        self.bar_norm = Some(bar_norm);
-        self
-    }
-
-    pub fn bar_gap(mut self, bar_gap: f64) -> Self {
-        self.bar_gap = Some(bar_gap);
-        self
-    }
-
-    pub fn bar_group_gap(mut self, bar_group_gap: f64) -> Self {
-        self.bar_group_gap = Some(bar_group_gap);
-        self
-    }
-
-    pub fn violin_mode(mut self, violin_mode: ViolinMode) -> Self {
-        self.violin_mode = Some(violin_mode);
-        self
-    }
-
-    pub fn violin_gap(mut self, violin_gap: f64) -> Self {
-        self.violin_gap = Some(violin_gap);
-        self
-    }
-
-    pub fn violin_group_gap(mut self, violin_group_gap: f64) -> Self {
-        self.violin_group_gap = Some(violin_group_gap);
-        self
-    }
-
-    pub fn waterfall_mode(mut self, waterfall_mode: WaterfallMode) -> Self {
-        self.waterfall_mode = Some(waterfall_mode);
-        self
-    }
-
-    pub fn waterfall_gap(mut self, waterfall_gap: f64) -> Self {
-        self.waterfall_gap = Some(waterfall_gap);
-        self
-    }
-
-    pub fn waterfall_group_gap(mut self, waterfall_group_gap: f64) -> Self {
-        self.waterfall_group_gap = Some(waterfall_group_gap);
-        self
-    }
-
-    pub fn pie_colorway<C: Color>(mut self, pie_colorway: Vec<C>) -> Self {
-        self.pie_colorway = Some(ColorArray(pie_colorway).into());
-        self
-    }
-
-    pub fn extend_pie_colors(mut self, extend_pie_colors: bool) -> Self {
-        self.extend_pie_colors = Some(extend_pie_colors);
-        self
-    }
-
-    pub fn sunburst_colorway<C: Color>(mut self, sunburst_colorway: Vec<C>) -> Self {
-        self.sunburst_colorway = Some(ColorArray(sunburst_colorway).into());
-        self
-    }
-
-    pub fn extend_sunburst_colors(mut self, extend_sunburst_colors: bool) -> Self {
-        self.extend_sunburst_colors = Some(extend_sunburst_colors);
-        self
-    }
 }
 
 #[serde_with::skip_serializing_none]
-#[derive(Serialize, Debug, Default, Clone)]
+#[derive(Serialize, Debug, Clone, FieldSetter)]
+#[field_setter(kind = "layout")]
 pub struct Layout {
     title: Option<Title>,
     #[serde(rename = "showlegend")]
@@ -2841,6 +1449,16 @@ pub struct Layout {
     color_axis: Option<ColorAxis>,
     #[serde(rename = "modebar")]
     mode_bar: Option<ModeBar>,
+    /// Determines the mode of hover interactions. If "closest", a single hoverlabel will appear for the "closest"
+    /// point within the `hoverdistance`. If "x" (or "y"), multiple hoverlabels will appear for multiple points at
+    /// the "closest" x- (or y-) coordinate within the `hoverdistance`, with the caveat that no more than one hoverlabel
+    /// will appear per trace. If "x unified" (or "y unified"), a single hoverlabel will appear multiple points at
+    /// the closest x- (or y-) coordinate within the `hoverdistance` with the caveat that no more than one hoverlabel
+    /// will appear per trace. In this mode, spikelines are enabled by default perpendicular to the specified axis.
+    /// If false, hover interactions are disabled. If `clickmode` includes the "select" flag, `hovermode` defaults to
+    /// "closest". If `clickmode` lacks the "select" flag, it defaults to "x" or "y"
+    /// (depending on the trace's `orientation` value) for plots based on cartesian coordinates. For anything
+    /// else the default value is "closest".
     #[serde(rename = "hovermode")]
     hover_mode: Option<HoverMode>,
     #[serde(rename = "clickmode")]
@@ -2855,7 +1473,7 @@ pub struct Layout {
     spike_distance: Option<i32>,
     #[serde(rename = "hoverlabel")]
     hover_label: Option<Label>,
-
+    #[field_setter(skip)]
     template: Option<Box<Cow<'static, Template>>>,
 
     grid: Option<LayoutGrid>,
@@ -2960,6 +1578,9 @@ pub struct Layout {
     sunburst_colorway: Option<Vec<Box<dyn Color>>>,
     #[serde(rename = "extendsunburstcolors")]
     extend_sunburst_colors: Option<bool>,
+
+    #[serde(rename = "updatemenus")]
+    update_menus: Option<Vec<UpdateMenu>>,
 }
 
 impl Layout {
@@ -2971,241 +1592,11 @@ impl Layout {
         serde_json::to_string(self).unwrap()
     }
 
-    pub fn title(mut self, title: Title) -> Self {
-        self.title = Some(title);
-        self
-    }
-
-    pub fn show_legend(mut self, show_legend: bool) -> Self {
-        self.show_legend = Some(show_legend);
-        self
-    }
-
-    pub fn legend(mut self, legend: Legend) -> Self {
-        self.legend = Some(legend);
-        self
-    }
-
-    pub fn margin(mut self, margin: Margin) -> Self {
-        self.margin = Some(margin);
-        self
-    }
-
-    pub fn auto_size(mut self, auto_size: bool) -> Self {
-        self.auto_size = Some(auto_size);
-        self
-    }
-
-    pub fn width(mut self, width: usize) -> Self {
-        self.width = Some(width);
-        self
-    }
-
-    pub fn height(mut self, height: usize) -> Self {
-        self.height = Some(height);
-        self
-    }
-
-    pub fn font(mut self, font: Font) -> Self {
-        self.font = Some(font);
-        self
-    }
-
-    pub fn uniform_text(mut self, uniform_text: UniformText) -> Self {
-        self.uniform_text = Some(uniform_text);
-        self
-    }
-
-    pub fn separators(mut self, separators: &str) -> Self {
-        self.separators = Some(separators.to_owned());
-        self
-    }
-
-    pub fn paper_background_color<C: Color>(mut self, paper_background_color: C) -> Self {
-        self.paper_background_color = Some(Box::new(paper_background_color));
-        self
-    }
-
-    pub fn plot_background_color<C: Color>(mut self, plot_background_color: C) -> Self {
-        self.plot_background_color = Some(Box::new(plot_background_color));
-        self
-    }
-
-    pub fn color_scale(mut self, color_scale: LayoutColorScale) -> Self {
-        self.color_scale = Some(color_scale);
-        self
-    }
-
-    pub fn colorway<C: Color>(mut self, colorway: Vec<C>) -> Self {
-        self.colorway = Some(ColorArray(colorway).into());
-        self
-    }
-
-    pub fn color_axis(mut self, color_axis: ColorAxis) -> Self {
-        self.color_axis = Some(color_axis);
-        self
-    }
-
-    pub fn mode_bar(mut self, mode_bar: ModeBar) -> Self {
-        self.mode_bar = Some(mode_bar);
-        self
-    }
-
-    /// Determines the mode of hover interactions. If "closest", a single hoverlabel will appear for the "closest"
-    /// point within the `hoverdistance`. If "x" (or "y"), multiple hoverlabels will appear for multiple points at
-    /// the "closest" x- (or y-) coordinate within the `hoverdistance`, with the caveat that no more than one hoverlabel
-    /// will appear per trace. If "x unified" (or "y unified"), a single hoverlabel will appear multiple points at
-    /// the closest x- (or y-) coordinate within the `hoverdistance` with the caveat that no more than one hoverlabel
-    /// will appear per trace. In this mode, spikelines are enabled by default perpendicular to the specified axis.
-    /// If false, hover interactions are disabled. If `clickmode` includes the "select" flag, `hovermode` defaults to
-    /// "closest". If `clickmode` lacks the "select" flag, it defaults to "x" or "y"
-    /// (depending on the trace's `orientation` value) for plots based on cartesian coordinates. For anything
-    /// else the default value is "closest".
-    pub fn hover_mode(mut self, hover_mode: HoverMode) -> Self {
-        self.hover_mode = Some(hover_mode);
-        self
-    }
-
-    pub fn click_mode(mut self, click_mode: ClickMode) -> Self {
-        self.click_mode = Some(click_mode);
-        self
-    }
-
-    pub fn drag_mode(mut self, drag_mode: DragMode) -> Self {
-        self.drag_mode = Some(drag_mode);
-        self
-    }
-
-    pub fn select_direction(mut self, select_direction: SelectDirection) -> Self {
-        self.select_direction = Some(select_direction);
-        self
-    }
-
-    pub fn hover_distance(mut self, hover_distance: i32) -> Self {
-        self.hover_distance = Some(hover_distance);
-        self
-    }
-
-    pub fn spike_distance(mut self, spike_distance: i32) -> Self {
-        self.spike_distance = Some(spike_distance);
-        self
-    }
-
-    pub fn hover_label(mut self, hover_label: Label) -> Self {
-        self.hover_label = Some(hover_label);
-        self
-    }
-
-    pub fn grid(mut self, grid: LayoutGrid) -> Self {
-        self.grid = Some(grid);
-        self
-    }
-
-    pub fn calendar(mut self, calendar: Calendar) -> Self {
-        self.calendar = Some(calendar);
-        self
-    }
-
-    pub fn x_axis(mut self, xaxis: Axis) -> Self {
-        self.x_axis = Some(Box::new(xaxis));
-        self
-    }
-
-    pub fn y_axis(mut self, yaxis: Axis) -> Self {
-        self.y_axis = Some(Box::new(yaxis));
-        self
-    }
-
-    pub fn z_axis(mut self, zaxis: Axis) -> Layout {
-        self.z_axis = Some(Box::new(zaxis));
-        self
-    }
-
-    pub fn x_axis2(mut self, xaxis: Axis) -> Layout {
-        self.x_axis2 = Some(Box::new(xaxis));
-        self
-    }
-
-    pub fn y_axis2(mut self, yaxis: Axis) -> Self {
-        self.y_axis2 = Some(Box::new(yaxis));
-        self
-    }
-
-    pub fn x_axis3(mut self, xaxis: Axis) -> Self {
-        self.x_axis3 = Some(Box::new(xaxis));
-        self
-    }
-
-    pub fn y_axis3(mut self, yaxis: Axis) -> Self {
-        self.y_axis3 = Some(Box::new(yaxis));
-        self
-    }
-
-    pub fn x_axis4(mut self, xaxis: Axis) -> Self {
-        self.x_axis4 = Some(Box::new(xaxis));
-        self
-    }
-
-    pub fn y_axis4(mut self, yaxis: Axis) -> Self {
-        self.y_axis4 = Some(Box::new(yaxis));
-        self
-    }
-
-    pub fn x_axis5(mut self, xaxis: Axis) -> Self {
-        self.x_axis5 = Some(Box::new(xaxis));
-        self
-    }
-
-    pub fn y_axis5(mut self, yaxis: Axis) -> Self {
-        self.y_axis5 = Some(Box::new(yaxis));
-        self
-    }
-
-    pub fn x_axis6(mut self, xaxis: Axis) -> Self {
-        self.x_axis6 = Some(Box::new(xaxis));
-        self
-    }
-
-    pub fn y_axis6(mut self, yaxis: Axis) -> Self {
-        self.y_axis6 = Some(Box::new(yaxis));
-        self
-    }
-
-    pub fn x_axis7(mut self, xaxis: Axis) -> Self {
-        self.x_axis7 = Some(Box::new(xaxis));
-        self
-    }
-
-    pub fn y_axis7(mut self, yaxis: Axis) -> Self {
-        self.y_axis7 = Some(Box::new(yaxis));
-        self
-    }
-
-    pub fn x_axis8(mut self, xaxis: Axis) -> Self {
-        self.x_axis8 = Some(Box::new(xaxis));
-        self
-    }
-
-    pub fn y_axis8(mut self, yaxis: Axis) -> Self {
-        self.y_axis8 = Some(Box::new(yaxis));
-        self
-    }
-
-    pub fn annotations(mut self, annotations: Vec<Annotation>) -> Self {
-        self.annotations = Some(annotations);
-        self
-    }
-
     pub fn add_annotation(&mut self, annotation: Annotation) {
         if self.annotations.is_none() {
             self.annotations = Some(Vec::new());
         }
         self.annotations.as_mut().unwrap().push(annotation);
-    }
-
-    pub fn shapes(mut self, shapes: Vec<Shape>) -> Self {
-        self.shapes = Some(shapes);
-        self
     }
 
     pub fn add_shape(&mut self, shape: Shape) {
@@ -3215,106 +1606,11 @@ impl Layout {
         self.shapes.as_mut().unwrap().push(shape);
     }
 
-    pub fn new_shape(mut self, new_shape: NewShape) -> Self {
-        self.new_shape = Some(new_shape);
-        self
-    }
-
-    pub fn active_shape(mut self, active_shape: ActiveShape) -> Self {
-        self.active_shape = Some(active_shape);
-        self
-    }
-
     pub fn template<T>(mut self, template: T) -> Layout
     where
         T: Into<Cow<'static, Template>>,
     {
         self.template = Some(Box::new(template.into()));
-        self
-    }
-
-    pub fn box_mode(mut self, box_mode: BoxMode) -> Self {
-        self.box_mode = Some(box_mode);
-        self
-    }
-
-    pub fn box_gap(mut self, box_gap: f64) -> Self {
-        self.box_gap = Some(box_gap);
-        self
-    }
-
-    pub fn box_group_gap(mut self, box_group_gap: f64) -> Self {
-        self.box_group_gap = Some(box_group_gap);
-        self
-    }
-
-    pub fn bar_mode(mut self, bar_mode: BarMode) -> Self {
-        self.bar_mode = Some(bar_mode);
-        self
-    }
-
-    pub fn bar_norm(mut self, bar_norm: BarNorm) -> Self {
-        self.bar_norm = Some(bar_norm);
-        self
-    }
-
-    pub fn bar_gap(mut self, bar_gap: f64) -> Self {
-        self.bar_gap = Some(bar_gap);
-        self
-    }
-
-    pub fn bar_group_gap(mut self, bar_group_gap: f64) -> Self {
-        self.bar_group_gap = Some(bar_group_gap);
-        self
-    }
-
-    pub fn violin_mode(mut self, violin_mode: ViolinMode) -> Self {
-        self.violin_mode = Some(violin_mode);
-        self
-    }
-
-    pub fn violin_gap(mut self, violin_gap: f64) -> Self {
-        self.violin_gap = Some(violin_gap);
-        self
-    }
-
-    pub fn violin_group_gap(mut self, violin_group_gap: f64) -> Self {
-        self.violin_group_gap = Some(violin_group_gap);
-        self
-    }
-
-    pub fn waterfall_mode(mut self, waterfall_mode: WaterfallMode) -> Self {
-        self.waterfall_mode = Some(waterfall_mode);
-        self
-    }
-
-    pub fn waterfall_gap(mut self, waterfall_gap: f64) -> Self {
-        self.waterfall_gap = Some(waterfall_gap);
-        self
-    }
-
-    pub fn waterfall_group_gap(mut self, waterfall_group_gap: f64) -> Self {
-        self.waterfall_group_gap = Some(waterfall_group_gap);
-        self
-    }
-
-    pub fn pie_colorway<C: Color>(mut self, pie_colorway: Vec<C>) -> Self {
-        self.pie_colorway = Some(ColorArray(pie_colorway).into());
-        self
-    }
-
-    pub fn extend_pie_colors(mut self, extend_pie_colors: bool) -> Self {
-        self.extend_pie_colors = Some(extend_pie_colors);
-        self
-    }
-
-    pub fn sunburst_colorway<C: Color>(mut self, sunburst_colorway: Vec<C>) -> Self {
-        self.sunburst_colorway = Some(ColorArray(sunburst_colorway).into());
-        self
-    }
-
-    pub fn extend_sunburst_colors(mut self, extend_sunburst_colors: bool) -> Self {
-        self.extend_sunburst_colors = Some(extend_sunburst_colors);
         self
     }
 }

--- a/plotly/src/layout/update_menu.rs
+++ b/plotly/src/layout/update_menu.rs
@@ -1,0 +1,315 @@
+//!
+//! Buttons and Dropdowns
+//!
+
+use plotly_derive::FieldSetter;
+use serde::Serialize;
+use serde_json::{Map, Value};
+
+use crate::{
+    color::Color,
+    common::{Anchor, Font, Pad},
+    Relayout, Restyle,
+};
+
+/// Sets the Plotly method to be called on click. If the `skip` method is used, the API
+/// updatemenu will function as normal but will perform no API calls and will not bind
+/// automatically to state updates. This may be used to create a component interface
+/// and attach to updatemenu events manually via JavaScript.
+///
+#[derive(Serialize, Debug, Copy, Clone)]
+#[serde(rename_all = "snake_case")]
+pub enum ButtonMethod {
+    /// The restyle method should be used when modifying the data and data attributes of the graph
+    Restyle,
+    /// The relayout method should be used when modifying the layout attributes of the graph.
+    Relayout,
+    Animate,
+    /// The update method should be used when modifying the data and layout sections of the graph.
+    Update,
+    Skip,
+}
+
+#[serde_with::skip_serializing_none]
+#[derive(Serialize, Clone, Debug, FieldSetter)]
+pub struct Button {
+    /// Sets the arguments values to be passed to the Plotly method set in `method` on click.
+    args: Option<Value>,
+    /// Sets a 2nd set of `args`, these arguments values are passed to the Plotly method set in
+    /// `method` when clicking this button while in the active state. Use this to create toggle buttons.
+    args2: Option<Value>,
+    /// When true, the API method is executed. When false, all other behaviors are the same and
+    /// command execution is skipped. This may be useful when hooking into, for example, the
+    /// `plotly_buttonclicked` method and executing the API command manually without losing the
+    /// benefit of the updatemenu automatically binding to the state of the plot through the
+    /// specification of `method` and `args`.
+    ///
+    /// Default: true
+    execute: Option<bool>,
+    /// Sets the text label to appear on the button.
+    label: Option<String>,
+    /// Sets the Plotly method to be called on click. If the `skip` method is used, the API
+    /// updatemenu will function as normal but will perform no API calls and will not bind
+    /// automatically to state updates. This may be used to create a component interface and
+    /// attach to updatemenu events manually via JavaScript.
+    method: Option<ButtonMethod>,
+    /// When used in a template, named items are created in the output figure in addition to any
+    /// items the figure already has in this array. You can modify these items in the output figure
+    /// by making your own item with `templateitemname` matching this `name` alongside your
+    /// modifications (including `visible: false` or `enabled: false` to hide it). Has no effect
+    /// outside of a template.
+    name: Option<String>,
+    /// Used to refer to a named item in this array in the template. Named items from the template
+    /// will be created even without a matching item in the input figure, but you can modify one
+    /// by making an item with `templateitemname` matching its `name`, alongside your modifications
+    /// (including `visible: false` or `enabled: false` to hide it). If there is no template or no
+    /// matching item, this item will be hidden unless you explicitly show it with `visible: true`
+    #[serde(rename = "templateitemname")]
+    template_item_name: Option<String>,
+    /// Determines whether or not this button is visible.
+    visible: Option<bool>,
+}
+
+impl Button {
+    pub fn new() -> Self {
+        Default::default()
+    }
+}
+
+/// Builder struct to create buttons which can do restyles and/or relayouts
+#[derive(FieldSetter)]
+pub struct ButtonBuilder {
+    label: Option<String>,
+    name: Option<String>,
+    template_item_name: Option<String>,
+    visible: Option<bool>,
+    #[field_setter(default = "Map::new()")]
+    restyles: Map<String, Value>,
+    #[field_setter(default = "Map::new()")]
+    relayouts: Map<String, Value>,
+}
+
+impl ButtonBuilder {
+    pub fn new() -> Self {
+        Default::default()
+    }
+    pub fn push_restyle(mut self, restyle: impl Restyle + Serialize) -> Self {
+        let restyle = serde_json::to_value(&restyle).unwrap();
+        for (k, v) in restyle.as_object().unwrap() {
+            self.restyles.insert(k.clone(), v.clone());
+        }
+        self
+    }
+
+    pub fn push_relayout(mut self, relayout: impl Relayout + Serialize) -> Self {
+        let relayout = serde_json::to_value(&relayout).unwrap();
+        for (k, v) in relayout.as_object().unwrap() {
+            self.relayouts.insert(k.clone(), v.clone());
+        }
+        self
+    }
+
+    fn method_and_args(
+        restyles: Map<String, Value>,
+        relayouts: Map<String, Value>,
+    ) -> (ButtonMethod, Value) {
+        match (restyles.is_empty(), relayouts.is_empty()) {
+            (true, true) => (ButtonMethod::Skip, Value::Null),
+            (false, true) => (ButtonMethod::Restyle, vec![restyles].into()),
+            (true, false) => (ButtonMethod::Relayout, vec![relayouts].into()),
+            (false, false) => (ButtonMethod::Update, vec![restyles, relayouts].into()),
+        }
+    }
+
+    pub fn build(self) -> Button {
+        let (method, args) = Self::method_and_args(self.restyles, self.relayouts);
+        Button {
+            label: self.label,
+            args: Some(args),
+            method: Some(method),
+            name: self.name,
+            template_item_name: self.template_item_name,
+            visible: self.visible,
+            ..Default::default()
+        }
+    }
+}
+
+/// Determines whether the buttons are accessible via a dropdown menu or whether the
+/// buttons are stacked horizontally or vertically
+///
+/// Default: "dropdown"
+#[derive(Serialize, Debug, Clone)]
+#[serde(rename_all = "snake_case")]
+pub enum UpdateMenuType {
+    Dropdown,
+    Buttons,
+}
+
+/// Determines the direction in which the buttons are laid out, whether in a dropdown menu or a
+/// row/column of buttons. For `left` and `up`, the buttons will still appear in left-to-right
+/// or top-to-bottom order respectively.
+///
+/// Default: "down"
+///
+#[derive(Serialize, Debug, Clone)]
+#[serde(rename_all = "snake_case")]
+pub enum UpdateMenuDirection {
+    Left,
+    Right,
+    Up,
+    Down,
+}
+
+#[serde_with::skip_serializing_none]
+#[derive(Serialize, Debug, FieldSetter, Clone)]
+pub struct UpdateMenu {
+    /// Determines which button (by index starting from 0) is considered active.
+    active: Option<i32>,
+    /// Sets the background color of the update menu buttons.
+    #[serde(rename = "bgcolor")]
+    background_color: Option<Box<dyn Color>>,
+    /// Sets the color of the border enclosing the update menu.
+    #[serde(rename = "bordercolor")]
+    border_color: Option<Box<dyn Color>>,
+    /// Sets the width (in px) of the border enclosing the update menu.
+    #[serde(rename = "borderwidth")]
+    border_width: Option<usize>,
+    buttons: Option<Vec<Button>>,
+    /// Determines the direction in which the buttons are laid out, whether in
+    /// a dropdown menu or a row/column of buttons. For `left` and `up`,
+    /// the buttons will still appear in left-to-right or top-to-bottom order
+    /// respectively.
+    direction: Option<UpdateMenuDirection>,
+    /// Sets the font of the update menu button text.
+    font: Option<Font>,
+    /// When used in a template, named items are created in the output figure in addition to any
+    /// items the figure already has in this array. You can modify these items in the output figure
+    /// by making your own item with `templateitemname` matching this `name` alongside your
+    /// modifications (including `visible: false` or `enabled: false` to hide it). Has no effect
+    /// outside of a template.
+    name: Option<String>,
+    /// Sets the padding around the buttons or dropdown menu.
+    pad: Option<Pad>,
+    /// Highlights active dropdown item or active button if true.
+    #[serde(rename = "showactive")]
+    show_active: Option<bool>,
+    /// Used to refer to a named item in this array in the template. Named items from the template
+    /// will be created even without a matching item in the input figure, but you can modify one by
+    /// making an item with `templateitemname` matching its `name`, alongside your modifications
+    /// (including `visible: false` or `enabled: false` to hide it). If there is no template or no
+    /// matching item, this item will be hidden unless you explicitly show it with `visible: true`.
+    template_item_name: Option<String>,
+    /// Determines whether the buttons are accessible via a dropdown menu or whether the
+    /// buttons are stacked horizontally or vertically
+    #[serde(rename = "type")]
+    ty: Option<UpdateMenuType>,
+    /// Determines whether or not the update menu is visible.
+    visible: Option<bool>,
+    /// Type: number between or equal to -2 and 3
+    /// Default: -0.05
+    /// Sets the x position (in normalized coordinates) of the update menu.
+    x: Option<f64>,
+    /// Sets the update menu's horizontal position anchor. This anchor binds the `x` position to
+    /// the "left", "center" or "right" of the range selector.
+    /// Default: "right"
+    #[serde(rename = "xanchor")]
+    x_anchor: Option<Anchor>,
+    /// Type: number between or equal to -2 and 3
+    /// Default: 1
+    /// Sets the y position (in normalized coordinates) of the update menu.
+    y: Option<f64>,
+    /// Sets the update menu's vertical position anchor This anchor binds the `y` position to the
+    /// "top", "middle" or "bottom" of the range selector.
+    /// Default: "top"
+    #[serde(rename = "yanchor")]
+    y_anchor: Option<Anchor>,
+}
+
+impl UpdateMenu {
+    pub fn new() -> Self {
+        Default::default()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::{
+        common::{Title, Visible},
+        Layout,
+    };
+
+    use super::*;
+    use serde_json::{json, to_value};
+
+    #[test]
+    fn test_serialize_button_method() {
+        assert_eq!(to_value(ButtonMethod::Restyle).unwrap(), json!("restyle"));
+        assert_eq!(to_value(ButtonMethod::Relayout).unwrap(), json!("relayout"));
+        assert_eq!(to_value(ButtonMethod::Animate).unwrap(), json!("animate"));
+        assert_eq!(to_value(ButtonMethod::Update).unwrap(), json!("update"));
+        assert_eq!(to_value(ButtonMethod::Skip).unwrap(), json!("skip"));
+    }
+
+    #[test]
+    fn test_serialize_button() {
+        let button = Button::new()
+            .args(json!([
+                { "visible": [true, false] },
+                { "width": 20},
+            ]))
+            .args2(json!([]))
+            .execute(true)
+            .label("Label")
+            .method(ButtonMethod::Update)
+            .name("Name")
+            .template_item_name("Template")
+            .visible(true);
+
+        let expected = json!({
+            "args": [
+                { "visible": [true, false] },
+                { "width": 20},
+            ],
+            "args2": [],
+            "execute": true,
+            "label": "Label",
+            "method": "update",
+            "name": "Name",
+            "templateitemname": "Template",
+            "visible": true,
+        });
+
+        assert_eq!(to_value(button).unwrap(), expected);
+    }
+
+    #[test]
+    fn test_button_builder() {
+        let expected = json!({
+            "args": [
+                { "visible": [true, false] },
+                { "title": {"text": "Hello"}, "width": 20},
+            ],
+            "label": "Label",
+            "method": "update",
+            "name": "Name",
+            "templateitemname": "Template",
+            "visible": true,
+        });
+
+        let button = ButtonBuilder::new()
+            .label("Label")
+            .name("Name")
+            .template_item_name("Template")
+            .visible(true)
+            .push_restyle(crate::Bar::<i32, i32>::modify_visible(vec![
+                Visible::True,
+                Visible::False,
+            ]))
+            .push_relayout(Layout::modify_title(Title::new("Hello")))
+            .push_relayout(Layout::modify_width(20))
+            .build();
+
+        assert_eq!(to_value(button).unwrap(), expected);
+    }
+}

--- a/plotly/src/lib.rs
+++ b/plotly/src/lib.rs
@@ -19,7 +19,6 @@ pub mod plot;
 pub mod traces;
 
 pub use common::color;
-use common::Dim;
 pub use configuration::Configuration;
 pub use layout::Layout;
 pub use plot::{ImageFormat, Plot, Trace};

--- a/plotly/src/lib.rs
+++ b/plotly/src/lib.rs
@@ -19,6 +19,7 @@ pub mod plot;
 mod traces;
 
 pub use common::color;
+use common::Dim;
 pub use configuration::Configuration;
 pub use layout::Layout;
 pub use plot::{ImageFormat, Plot, Trace};
@@ -33,6 +34,18 @@ pub use traces::{box_plot, contour, histogram, sankey, surface};
 
 #[cfg(feature = "plotly_ndarray")]
 pub use crate::ndarray::ArrayTraces;
+
+pub trait GetInner {
+    type Inner;
+}
+
+impl<T> GetInner for Option<T> {
+    type Inner = T;
+}
+
+impl<T: serde::Serialize> GetInner for Dim<T> {
+    type Inner = T;
+}
 
 // Not public API.
 #[doc(hidden)]

--- a/plotly/src/lib.rs
+++ b/plotly/src/lib.rs
@@ -16,7 +16,7 @@ pub mod common;
 pub mod configuration;
 pub mod layout;
 pub mod plot;
-mod traces;
+pub mod traces;
 
 pub use common::color;
 use common::Dim;
@@ -34,6 +34,9 @@ pub use traces::{box_plot, contour, histogram, sankey, surface};
 
 #[cfg(feature = "plotly_ndarray")]
 pub use crate::ndarray::ArrayTraces;
+
+pub trait Restyle: serde::Serialize {}
+pub trait Relayout {}
 
 pub trait GetInner {
     type Inner;

--- a/plotly/src/lib.rs
+++ b/plotly/src/lib.rs
@@ -38,18 +38,6 @@ pub use crate::ndarray::ArrayTraces;
 pub trait Restyle: serde::Serialize {}
 pub trait Relayout {}
 
-pub trait GetInner {
-    type Inner;
-}
-
-impl<T> GetInner for Option<T> {
-    type Inner = T;
-}
-
-impl<T: serde::Serialize> GetInner for Dim<T> {
-    type Inner = T;
-}
-
 // Not public API.
 #[doc(hidden)]
 mod private;

--- a/plotly/src/traces/bar.rs
+++ b/plotly/src/traces/bar.rs
@@ -35,6 +35,7 @@ use crate::{
 /// ```
 #[serde_with::skip_serializing_none]
 #[derive(Serialize, Debug, Clone, FieldSetter)]
+#[field_setter(box_self, kind = "trace")]
 pub struct Bar<X, Y>
 where
     X: Serialize + Clone,

--- a/plotly/src/traces/bar.rs
+++ b/plotly/src/traces/bar.rs
@@ -1,5 +1,6 @@
 //! Bar trace
 
+use plotly_derive::FieldSetter;
 use serde::Serialize;
 
 use crate::{
@@ -7,7 +8,7 @@ use crate::{
         Calendar, ConstrainText, Dim, ErrorData, Font, HoverInfo, Label, Marker, Orientation,
         PlotType, TextAnchor, TextPosition, Visible,
     },
-    private, Trace,
+    Trace,
 };
 
 /// Construct a bar trace.
@@ -33,12 +34,13 @@ use crate::{
 /// assert_eq!(serde_json::to_value(trace).unwrap(), expected);
 /// ```
 #[serde_with::skip_serializing_none]
-#[derive(Serialize, Debug, Clone)]
+#[derive(Serialize, Debug, Clone, FieldSetter)]
 pub struct Bar<X, Y>
 where
     X: Serialize + Clone,
     Y: Serialize + Clone,
 {
+    #[field_setter(default = "PlotType::Bar")]
     r#type: PlotType,
     x: Option<Vec<X>>,
     y: Option<Vec<Y>>,
@@ -97,52 +99,6 @@ where
     y_calendar: Option<Calendar>,
 }
 
-impl<X, Y> Default for Bar<X, Y>
-where
-    X: Serialize + Clone,
-    Y: Serialize + Clone,
-{
-    fn default() -> Self {
-        Self {
-            r#type: PlotType::Bar,
-            x: None,
-            y: None,
-            name: None,
-            visible: None,
-            show_legend: None,
-            legend_group: None,
-            opacity: None,
-            ids: None,
-            width: None,
-            offset: None,
-            text: None,
-            text_position: None,
-            text_template: None,
-            hover_text: None,
-            hover_info: None,
-            hover_template: None,
-            x_axis: None,
-            y_axis: None,
-            orientation: None,
-            alignment_group: None,
-            offset_group: None,
-            marker: None,
-            text_angle: None,
-            text_font: None,
-            error_x: None,
-            error_y: None,
-            clip_on_axis: None,
-            constrain_text: None,
-            hover_label: None,
-            inside_text_anchor: None,
-            inside_text_font: None,
-            outside_text_font: None,
-            x_calendar: None,
-            y_calendar: None,
-        }
-    }
-}
-
 impl<X, Y> Bar<X, Y>
 where
     X: Serialize + Clone,
@@ -154,199 +110,6 @@ where
             y: Some(y),
             ..Default::default()
         })
-    }
-
-    pub fn alignment_group(mut self, alignment_group: &str) -> Box<Self> {
-        self.alignment_group = Some(alignment_group.to_owned());
-        Box::new(self)
-    }
-
-    pub fn clip_on_axis(mut self, clip_on_axis: bool) -> Box<Self> {
-        self.clip_on_axis = Some(clip_on_axis);
-        Box::new(self)
-    }
-
-    pub fn constrain_text(mut self, constrain_text: ConstrainText) -> Box<Self> {
-        self.constrain_text = Some(constrain_text);
-        Box::new(self)
-    }
-
-    pub fn error_x(mut self, error_x: ErrorData) -> Box<Self> {
-        self.error_x = Some(error_x);
-        Box::new(self)
-    }
-
-    pub fn error_y(mut self, error_y: ErrorData) -> Box<Self> {
-        self.error_y = Some(error_y);
-        Box::new(self)
-    }
-
-    pub fn hover_info(mut self, hover_info: HoverInfo) -> Box<Self> {
-        self.hover_info = Some(hover_info);
-        Box::new(self)
-    }
-
-    pub fn hover_label(mut self, hover_label: Label) -> Box<Self> {
-        self.hover_label = Some(hover_label);
-        Box::new(self)
-    }
-
-    pub fn hover_template(mut self, hover_template: &str) -> Box<Self> {
-        self.hover_template = Some(Dim::Scalar(hover_template.to_owned()));
-        Box::new(self)
-    }
-
-    pub fn hover_template_array<S: AsRef<str>>(mut self, hover_template: Vec<S>) -> Box<Self> {
-        let hover_template = private::owned_string_vector(hover_template);
-        self.hover_template = Some(Dim::Vector(hover_template));
-        Box::new(self)
-    }
-
-    pub fn hover_text(mut self, hover_text: &str) -> Box<Self> {
-        self.hover_text = Some(Dim::Scalar(hover_text.to_owned()));
-        Box::new(self)
-    }
-
-    pub fn hover_text_array<S: AsRef<str>>(mut self, hover_text: Vec<S>) -> Box<Self> {
-        let hover_text = private::owned_string_vector(hover_text);
-        self.hover_text = Some(Dim::Vector(hover_text));
-        Box::new(self)
-    }
-
-    pub fn ids<S: AsRef<str>>(mut self, ids: Vec<S>) -> Box<Self> {
-        let ids = private::owned_string_vector(ids);
-        self.ids = Some(ids);
-        Box::new(self)
-    }
-
-    pub fn inside_text_anchor(mut self, inside_text_anchor: TextAnchor) -> Box<Self> {
-        self.inside_text_anchor = Some(inside_text_anchor);
-        Box::new(self)
-    }
-
-    pub fn inside_text_font(mut self, inside_text_font: Font) -> Box<Self> {
-        self.inside_text_font = Some(inside_text_font);
-        Box::new(self)
-    }
-
-    pub fn legend_group(mut self, legend_group: &str) -> Box<Self> {
-        self.legend_group = Some(legend_group.to_owned());
-        Box::new(self)
-    }
-
-    pub fn marker(mut self, marker: Marker) -> Box<Self> {
-        self.marker = Some(marker);
-        Box::new(self)
-    }
-
-    pub fn name(mut self, name: &str) -> Box<Self> {
-        self.name = Some(name.to_owned());
-        Box::new(self)
-    }
-    pub fn show_legend(mut self, show_legend: bool) -> Box<Self> {
-        self.show_legend = Some(show_legend);
-        Box::new(self)
-    }
-
-    pub fn text(mut self, text: &str) -> Box<Self> {
-        self.text = Some(Dim::Scalar(text.to_owned()));
-        Box::new(self)
-    }
-
-    pub fn text_array<S: AsRef<str>>(mut self, text: Vec<S>) -> Box<Self> {
-        let text = private::owned_string_vector(text);
-        self.text = Some(Dim::Vector(text));
-        Box::new(self)
-    }
-
-    pub fn text_angle(mut self, text_angle: f64) -> Box<Self> {
-        self.text_angle = Some(text_angle);
-        Box::new(self)
-    }
-
-    pub fn text_position(mut self, text_position: TextPosition) -> Box<Self> {
-        self.text_position = Some(Dim::Scalar(text_position));
-        Box::new(self)
-    }
-
-    pub fn text_position_array(mut self, text_position: Vec<TextPosition>) -> Box<Self> {
-        self.text_position = Some(Dim::Vector(text_position));
-        Box::new(self)
-    }
-
-    pub fn text_template(mut self, text_template: &str) -> Box<Self> {
-        self.text_template = Some(Dim::Scalar(text_template.to_owned()));
-        Box::new(self)
-    }
-
-    pub fn text_template_array<S: AsRef<str>>(mut self, text_template: Vec<S>) -> Box<Self> {
-        let text_template = private::owned_string_vector(text_template);
-        self.text_template = Some(Dim::Vector(text_template));
-        Box::new(self)
-    }
-
-    pub fn offset(mut self, offset: usize) -> Box<Self> {
-        self.offset = Some(Dim::Scalar(offset));
-        Box::new(self)
-    }
-
-    pub fn offset_array(mut self, offset: Vec<usize>) -> Box<Self> {
-        self.offset = Some(Dim::Vector(offset));
-        Box::new(self)
-    }
-
-    pub fn offset_group(mut self, offset_group: &str) -> Box<Self> {
-        self.offset_group = Some(offset_group.to_owned());
-        Box::new(self)
-    }
-
-    pub fn opacity(mut self, opacity: f64) -> Box<Self> {
-        self.opacity = Some(opacity);
-        Box::new(self)
-    }
-
-    pub fn orientation(mut self, orientation: Orientation) -> Box<Self> {
-        self.orientation = Some(orientation);
-        Box::new(self)
-    }
-
-    pub fn outside_text_font(mut self, outside_text_font: Font) -> Box<Self> {
-        self.outside_text_font = Some(outside_text_font);
-        Box::new(self)
-    }
-
-    pub fn text_font(mut self, text_font: Font) -> Box<Self> {
-        self.text_font = Some(text_font);
-        Box::new(self)
-    }
-
-    pub fn visible(mut self, visible: Visible) -> Box<Self> {
-        self.visible = Some(visible);
-        Box::new(self)
-    }
-
-    pub fn width(mut self, width: usize) -> Box<Self> {
-        self.width = Some(width);
-        Box::new(self)
-    }
-
-    pub fn x_axis(mut self, axis: &str) -> Box<Self> {
-        self.x_axis = Some(axis.to_owned());
-        Box::new(self)
-    }
-
-    pub fn x_calendar(mut self, x_calendar: Calendar) -> Box<Self> {
-        self.x_calendar = Some(x_calendar);
-        Box::new(self)
-    }
-    pub fn y_axis(mut self, axis: &str) -> Box<Self> {
-        self.y_axis = Some(axis.to_owned());
-        Box::new(self)
-    }
-
-    pub fn y_calendar(mut self, y_calendar: Calendar) -> Box<Self> {
-        self.y_calendar = Some(y_calendar);
-        Box::new(self)
     }
 }
 

--- a/plotly/src/traces/box_plot.rs
+++ b/plotly/src/traces/box_plot.rs
@@ -92,6 +92,7 @@ pub enum HoverOn {
 /// ```
 #[serde_with::skip_serializing_none]
 #[derive(Serialize, Debug, Clone, FieldSetter)]
+#[field_setter(box_self, kind = "trace")]
 pub struct BoxPlot<X, Y>
 where
     X: Serialize + Clone,

--- a/plotly/src/traces/box_plot.rs
+++ b/plotly/src/traces/box_plot.rs
@@ -1,11 +1,12 @@
 //! Box trace
 
+use plotly_derive::FieldSetter;
 use serde::{Serialize, Serializer};
 
 use crate::{
     color::Color,
     common::{Calendar, Dim, HoverInfo, Label, Line, Marker, Orientation, PlotType, Visible},
-    private, Trace,
+    Trace,
 };
 
 #[derive(Debug, Clone)]
@@ -90,12 +91,13 @@ pub enum HoverOn {
 /// assert_eq!(serde_json::to_value(trace).unwrap(), expected);
 /// ```
 #[serde_with::skip_serializing_none]
-#[derive(Serialize, Debug, Clone)]
+#[derive(Serialize, Debug, Clone, FieldSetter)]
 pub struct BoxPlot<X, Y>
 where
     X: Serialize + Clone,
     Y: Serialize + Clone,
 {
+    #[field_setter(default = "PlotType::Box")]
     r#type: PlotType,
     x: Option<Vec<X>>,
     y: Option<Vec<Y>>,
@@ -164,59 +166,6 @@ where
     y_calendar: Option<Calendar>,
 }
 
-impl<X, Y> Default for BoxPlot<X, Y>
-where
-    X: Serialize + Clone,
-    Y: Serialize + Clone,
-{
-    fn default() -> Self {
-        Self {
-            r#type: PlotType::Box,
-            x: None,
-            y: None,
-            name: None,
-            visible: None,
-            show_legend: None,
-            legend_group: None,
-            opacity: None,
-            ids: None,
-            width: None,
-            text: None,
-            hover_text: None,
-            hover_info: None,
-            hover_template: None,
-            x_axis: None,
-            y_axis: None,
-            orientation: None,
-            alignment_group: None,
-            offset_group: None,
-            marker: None,
-            line: None,
-            box_mean: None,
-            box_points: None,
-            notched: None,
-            notch_width: None,
-            whisker_width: None,
-            q1: None,
-            median: None,
-            q3: None,
-            upper_fence: None,
-            lower_fence: None,
-            notch_span: None,
-            mean: None,
-            standard_deviation: None,
-            quartile_method: None,
-            fill_color: None,
-            hover_label: None,
-            hover_on: None,
-            point_pos: None,
-            jitter: None,
-            x_calendar: None,
-            y_calendar: None,
-        }
-    }
-}
-
 impl<Y> BoxPlot<f64, Y>
 where
     Y: Serialize + Clone,
@@ -240,219 +189,6 @@ where
             y: Some(y),
             ..Default::default()
         })
-    }
-
-    pub fn alignment_group(mut self, alignment_group: &str) -> Box<Self> {
-        self.alignment_group = Some(alignment_group.to_string());
-        Box::new(self)
-    }
-
-    pub fn box_mean(mut self, box_mean: BoxMean) -> Box<Self> {
-        self.box_mean = Some(box_mean);
-        Box::new(self)
-    }
-
-    pub fn box_points(mut self, box_points: BoxPoints) -> Box<Self> {
-        self.box_points = Some(box_points);
-        Box::new(self)
-    }
-
-    pub fn fill_color<C: Color>(mut self, fill_color: C) -> Box<Self> {
-        self.fill_color = Some(Box::new(fill_color));
-        Box::new(self)
-    }
-
-    pub fn hover_info(mut self, hover_info: HoverInfo) -> Box<Self> {
-        self.hover_info = Some(hover_info);
-        Box::new(self)
-    }
-
-    pub fn hover_label(mut self, hover_label: Label) -> Box<Self> {
-        self.hover_label = Some(hover_label);
-        Box::new(self)
-    }
-
-    pub fn hover_on(mut self, hover_on: HoverOn) -> Box<Self> {
-        self.hover_on = Some(hover_on);
-        Box::new(self)
-    }
-
-    pub fn hover_text(mut self, hover_text: &str) -> Box<Self> {
-        self.hover_text = Some(Dim::Scalar(hover_text.to_string()));
-        Box::new(self)
-    }
-
-    pub fn hover_text_array<S: AsRef<str>>(mut self, hover_text: Vec<S>) -> Box<Self> {
-        let hover_text = private::owned_string_vector(hover_text);
-        self.hover_text = Some(Dim::Vector(hover_text));
-        Box::new(self)
-    }
-
-    pub fn hover_template(mut self, hover_template: &str) -> Box<Self> {
-        self.hover_template = Some(Dim::Scalar(hover_template.to_string()));
-        Box::new(self)
-    }
-
-    pub fn hover_template_array<S: AsRef<str>>(mut self, hover_template: Vec<S>) -> Box<Self> {
-        let hover_template = private::owned_string_vector(hover_template);
-        self.hover_template = Some(Dim::Vector(hover_template));
-        Box::new(self)
-    }
-
-    pub fn ids<S: AsRef<str>>(mut self, ids: Vec<S>) -> Box<Self> {
-        let ids = private::owned_string_vector(ids);
-        self.ids = Some(ids);
-        Box::new(self)
-    }
-
-    pub fn jitter(mut self, jitter: f64) -> Box<Self> {
-        self.jitter = Some(jitter);
-        Box::new(self)
-    }
-
-    pub fn legend_group(mut self, legend_group: &str) -> Box<Self> {
-        self.legend_group = Some(legend_group.to_string());
-        Box::new(self)
-    }
-    pub fn line(mut self, line: Line) -> Box<Self> {
-        self.line = Some(line);
-        Box::new(self)
-    }
-
-    pub fn lower_fence(mut self, lower_fence: Vec<f64>) -> Box<Self> {
-        self.lower_fence = Some(lower_fence);
-        Box::new(self)
-    }
-
-    pub fn marker(mut self, marker: Marker) -> Box<Self> {
-        self.marker = Some(marker);
-        Box::new(self)
-    }
-
-    pub fn mean(mut self, mean: Vec<f64>) -> Box<Self> {
-        self.mean = Some(mean);
-        Box::new(self)
-    }
-
-    pub fn median(mut self, median: Vec<f64>) -> Box<Self> {
-        self.median = Some(median);
-        Box::new(self)
-    }
-
-    pub fn name(mut self, name: &str) -> Box<Self> {
-        self.name = Some(name.to_string());
-        Box::new(self)
-    }
-
-    pub fn notch_span(mut self, notch_span: Vec<f64>) -> Box<Self> {
-        self.notch_span = Some(notch_span);
-        Box::new(self)
-    }
-
-    pub fn notch_width(mut self, notch_width: f64) -> Box<Self> {
-        self.notch_width = Some(notch_width);
-        Box::new(self)
-    }
-
-    pub fn notched(mut self, notched: bool) -> Box<Self> {
-        self.notched = Some(notched);
-        Box::new(self)
-    }
-
-    pub fn offset_group(mut self, offset_group: &str) -> Box<Self> {
-        self.offset_group = Some(offset_group.to_string());
-        Box::new(self)
-    }
-
-    pub fn opacity(mut self, opacity: f64) -> Box<Self> {
-        self.opacity = Some(opacity);
-        Box::new(self)
-    }
-
-    pub fn orientation(mut self, orientation: Orientation) -> Box<Self> {
-        self.orientation = Some(orientation);
-        Box::new(self)
-    }
-
-    pub fn point_pos(mut self, point_pos: f64) -> Box<Self> {
-        self.point_pos = Some(point_pos);
-        Box::new(self)
-    }
-
-    pub fn q1(mut self, q1: Vec<f64>) -> Box<Self> {
-        self.q1 = Some(q1);
-        Box::new(self)
-    }
-
-    pub fn q3(mut self, q3: Vec<f64>) -> Box<Self> {
-        self.q3 = Some(q3);
-        Box::new(self)
-    }
-
-    pub fn quartile_method(mut self, quartile_method: QuartileMethod) -> Box<Self> {
-        self.quartile_method = Some(quartile_method);
-        Box::new(self)
-    }
-
-    pub fn show_legend(mut self, show_legend: bool) -> Box<Self> {
-        self.show_legend = Some(show_legend);
-        Box::new(self)
-    }
-
-    pub fn standard_deviation(mut self, standard_deviation: Vec<f64>) -> Box<Self> {
-        self.standard_deviation = Some(standard_deviation);
-        Box::new(self)
-    }
-
-    pub fn text(mut self, text: &str) -> Box<Self> {
-        self.text = Some(Dim::Scalar(text.to_string()));
-        Box::new(self)
-    }
-
-    pub fn text_array<S: AsRef<str>>(mut self, text: Vec<S>) -> Box<Self> {
-        let text = private::owned_string_vector(text);
-        self.text = Some(Dim::Vector(text));
-        Box::new(self)
-    }
-
-    pub fn upper_fence(mut self, upper_fence: Vec<f64>) -> Box<Self> {
-        self.upper_fence = Some(upper_fence);
-        Box::new(self)
-    }
-
-    pub fn visible(mut self, visible: Visible) -> Box<Self> {
-        self.visible = Some(visible);
-        Box::new(self)
-    }
-
-    pub fn whisker_width(mut self, whisker_width: f64) -> Box<Self> {
-        self.whisker_width = Some(whisker_width);
-        Box::new(self)
-    }
-
-    pub fn width(mut self, width: usize) -> Box<Self> {
-        self.width = Some(width);
-        Box::new(self)
-    }
-
-    pub fn x_axis(mut self, axis: &str) -> Box<Self> {
-        self.x_axis = Some(axis.to_string());
-        Box::new(self)
-    }
-
-    pub fn x_calendar(mut self, x_calendar: Calendar) -> Box<Self> {
-        self.x_calendar = Some(x_calendar);
-        Box::new(self)
-    }
-
-    pub fn y_axis(mut self, axis: &str) -> Box<Self> {
-        self.y_axis = Some(axis.to_string());
-        Box::new(self)
-    }
-
-    pub fn y_calendar(mut self, y_calendar: Calendar) -> Box<Self> {
-        self.y_calendar = Some(y_calendar);
-        Box::new(self)
     }
 }
 

--- a/plotly/src/traces/candlestick.rs
+++ b/plotly/src/traces/candlestick.rs
@@ -1,11 +1,12 @@
 //! Candlestick trace
 
+use plotly_derive::FieldSetter;
 use serde::Serialize;
 
 use crate::{
     color::NamedColor,
     common::{Calendar, Dim, Direction, HoverInfo, Label, Line, PlotType, Visible},
-    private, Trace,
+    Trace,
 };
 
 /// Construct a candlestick trace.
@@ -41,12 +42,13 @@ use crate::{
 /// assert_eq!(serde_json::to_value(trace).unwrap(), expected);
 /// ```
 #[serde_with::skip_serializing_none]
-#[derive(Serialize, Debug, Clone)]
+#[derive(Serialize, Debug, Clone, FieldSetter)]
 pub struct Candlestick<T, O>
 where
     T: Serialize + Clone,
     O: Serialize + Clone,
 {
+    #[field_setter(default = "PlotType::Candlestick")]
     r#type: PlotType,
     x: Option<Vec<T>>,
     open: Option<Vec<O>>,
@@ -80,39 +82,6 @@ where
     x_calendar: Option<Calendar>,
 }
 
-impl<T, O> Default for Candlestick<T, O>
-where
-    T: Serialize + Clone,
-    O: Serialize + Clone,
-{
-    fn default() -> Self {
-        Self {
-            r#type: PlotType::Candlestick,
-            x: None,
-            open: None,
-            high: None,
-            low: None,
-            close: None,
-            name: None,
-            visible: None,
-            show_legend: None,
-            legend_group: None,
-            opacity: None,
-            text: None,
-            hover_text: None,
-            hover_info: None,
-            x_axis: None,
-            y_axis: None,
-            line: None,
-            whisker_width: None,
-            increasing: None,
-            decreasing: None,
-            hover_label: None,
-            x_calendar: None,
-        }
-    }
-}
-
 impl<T, O> Candlestick<T, O>
 where
     T: Serialize + Clone,
@@ -131,97 +100,6 @@ where
             decreasing: Some(Direction::Decreasing { line: dline }),
             ..Default::default()
         })
-    }
-
-    pub fn decreasing(mut self, decreasing: Direction) -> Box<Self> {
-        self.decreasing = Some(decreasing);
-        Box::new(self)
-    }
-
-    pub fn hover_info(mut self, hover_info: HoverInfo) -> Box<Self> {
-        self.hover_info = Some(hover_info);
-        Box::new(self)
-    }
-
-    pub fn hover_label(mut self, hover_label: Label) -> Box<Self> {
-        self.hover_label = Some(hover_label);
-        Box::new(self)
-    }
-
-    pub fn hover_text(mut self, hover_text: &str) -> Box<Self> {
-        self.hover_text = Some(Dim::Scalar(hover_text.to_string()));
-        Box::new(self)
-    }
-
-    pub fn hover_text_array<S: AsRef<str>>(mut self, hover_text: Vec<S>) -> Box<Self> {
-        let hover_text = private::owned_string_vector(hover_text);
-        self.hover_text = Some(Dim::Vector(hover_text));
-        Box::new(self)
-    }
-
-    pub fn increasing(mut self, increasing: Direction) -> Box<Self> {
-        self.increasing = Some(increasing);
-        Box::new(self)
-    }
-
-    pub fn legend_group(mut self, legend_group: &str) -> Box<Self> {
-        self.legend_group = Some(legend_group.to_string());
-        Box::new(self)
-    }
-
-    pub fn line(mut self, line: Line) -> Box<Self> {
-        self.line = Some(line);
-        Box::new(self)
-    }
-
-    pub fn name(mut self, name: &str) -> Box<Self> {
-        self.name = Some(name.to_string());
-        Box::new(self)
-    }
-
-    pub fn opacity(mut self, opacity: f64) -> Box<Self> {
-        self.opacity = Some(opacity);
-        Box::new(self)
-    }
-
-    pub fn show_legend(mut self, show_legend: bool) -> Box<Self> {
-        self.show_legend = Some(show_legend);
-        Box::new(self)
-    }
-
-    pub fn text(mut self, text: &str) -> Box<Self> {
-        self.text = Some(Dim::Scalar(text.to_string()));
-        Box::new(self)
-    }
-
-    pub fn text_array<S: AsRef<str>>(mut self, text: Vec<S>) -> Box<Self> {
-        let text = private::owned_string_vector(text);
-        self.text = Some(Dim::Vector(text));
-        Box::new(self)
-    }
-
-    pub fn visible(mut self, visible: Visible) -> Box<Self> {
-        self.visible = Some(visible);
-        Box::new(self)
-    }
-
-    pub fn whisker_width(mut self, whisker_width: f64) -> Box<Self> {
-        self.whisker_width = Some(whisker_width);
-        Box::new(self)
-    }
-    pub fn x_axis(mut self, axis: &str) -> Box<Self> {
-        self.x_axis = Some(axis.to_string());
-        Box::new(self)
-    }
-
-    pub fn x_calendar(mut self, x_calendar: Calendar) -> Box<Self> {
-        self.x_calendar = Some(x_calendar);
-        Box::new(self)
-    }
-
-    pub fn y_axis(mut self, axis: &str) -> Box<Self> {
-        self.y_axis = Some(axis.to_string());
-        Box::new(self)
     }
 }
 

--- a/plotly/src/traces/contour.rs
+++ b/plotly/src/traces/contour.rs
@@ -47,7 +47,6 @@ pub enum Operation {
 
 #[serde_with::skip_serializing_none]
 #[derive(Serialize, Debug, Clone, FieldSetter)]
-#[field_setter(no_box)]
 pub struct Contours {
     #[field_setter(skip)]
     r#type: Option<ContoursType>,

--- a/plotly/src/traces/contour.rs
+++ b/plotly/src/traces/contour.rs
@@ -1,5 +1,6 @@
 //! Contour trace
 
+use plotly_derive::FieldSetter;
 use serde::Serialize;
 
 use crate::{
@@ -45,8 +46,10 @@ pub enum Operation {
 }
 
 #[serde_with::skip_serializing_none]
-#[derive(Serialize, Debug, Default, Clone)]
+#[derive(Serialize, Debug, Clone, FieldSetter)]
+#[field_setter(no_box)]
 pub struct Contours {
+    #[field_setter(skip)]
     r#type: Option<ContoursType>,
     start: Option<f64>,
     end: Option<f64>,
@@ -69,58 +72,8 @@ impl Contours {
         Default::default()
     }
 
-    pub fn coloring(mut self, coloring: Coloring) -> Self {
-        self.coloring = Some(coloring);
-        self
-    }
-
-    pub fn end(mut self, end: f64) -> Self {
-        self.end = Some(end);
-        self
-    }
-
-    pub fn label_font(mut self, label_font: Font) -> Self {
-        self.label_font = Some(label_font);
-        self
-    }
-
-    pub fn label_format(mut self, label_format: &str) -> Self {
-        self.label_format = Some(label_format.to_string());
-        self
-    }
-
-    pub fn operation(mut self, operation: Operation) -> Self {
-        self.operation = Some(operation);
-        self
-    }
-
-    pub fn show_labels(mut self, show_labels: bool) -> Self {
-        self.show_labels = Some(show_labels);
-        self
-    }
-
-    pub fn show_lines(mut self, show_lines: bool) -> Self {
-        self.show_lines = Some(show_lines);
-        self
-    }
-
-    pub fn size(mut self, size: usize) -> Self {
-        self.size = Some(size);
-        self
-    }
-
-    pub fn start(mut self, start: f64) -> Self {
-        self.start = Some(start);
-        self
-    }
-
     pub fn type_(mut self, t: ContoursType) -> Self {
         self.r#type = Some(t);
-        self
-    }
-
-    pub fn value(mut self, value: f64) -> Self {
-        self.value = Some(value);
         self
     }
 }

--- a/plotly/src/traces/heat_map.rs
+++ b/plotly/src/traces/heat_map.rs
@@ -1,10 +1,11 @@
 //! Heat map trace
 
+use plotly_derive::FieldSetter;
 use serde::Serialize;
 
 use crate::{
     common::{Calendar, ColorBar, ColorScale, Dim, HoverInfo, Label, PlotType, Visible},
-    private, Trace,
+    Trace,
 };
 
 #[derive(Debug, Clone)]
@@ -50,13 +51,14 @@ impl Serialize for Smoothing {
 /// assert_eq!(serde_json::to_value(trace).unwrap(), expected);
 /// ```
 #[serde_with::skip_serializing_none]
-#[derive(Serialize, Debug, Clone)]
+#[derive(Serialize, Debug, Clone, FieldSetter)]
 pub struct HeatMap<X, Y, Z>
 where
     X: Serialize + Clone,
     Y: Serialize + Clone,
     Z: Serialize + Clone,
 {
+    #[field_setter(default = "PlotType::HeatMap")]
     r#type: PlotType,
     #[serde(rename = "autocolorscale")]
     auto_color_scale: Option<bool>,
@@ -109,50 +111,6 @@ where
     zsmooth: Option<Smoothing>,
 }
 
-impl<X, Y, Z> Default for HeatMap<X, Y, Z>
-where
-    X: Serialize + Clone,
-    Y: Serialize + Clone,
-    Z: Serialize + Clone,
-{
-    fn default() -> Self {
-        Self {
-            r#type: PlotType::HeatMap,
-            auto_color_scale: None,
-            color_bar: None,
-            color_scale: None,
-            connect_gaps: None,
-            hover_info: None,
-            hover_label: None,
-            hover_on_gaps: None,
-            hover_template: None,
-            hover_text: None,
-            legend_group: None,
-            name: None,
-            opacity: None,
-            reverse_scale: None,
-            show_legend: None,
-            show_scale: None,
-            text: None,
-            transpose: None,
-            visible: None,
-            x: None,
-            x_axis: None,
-            x_calendar: None,
-            y: None,
-            y_axis: None,
-            y_calendar: None,
-            z: None,
-            zauto: None,
-            zhover_format: None,
-            zmax: None,
-            zmid: None,
-            zmin: None,
-            zsmooth: None,
-        }
-    }
-}
-
 impl<Z> HeatMap<f64, f64, Z>
 where
     Z: Serialize + Clone,
@@ -178,152 +136,6 @@ where
             z: Some(z),
             ..Default::default()
         })
-    }
-
-    pub fn auto_color_scale(mut self, auto_color_scale: bool) -> Box<Self> {
-        self.auto_color_scale = Some(auto_color_scale);
-        Box::new(self)
-    }
-
-    pub fn color_bar(mut self, color_bar: ColorBar) -> Box<Self> {
-        self.color_bar = Some(color_bar);
-        Box::new(self)
-    }
-
-    pub fn color_scale(mut self, color_scale: ColorScale) -> Box<Self> {
-        self.color_scale = Some(color_scale);
-        Box::new(self)
-    }
-
-    pub fn connect_gaps(mut self, connect_gaps: bool) -> Box<Self> {
-        self.connect_gaps = Some(connect_gaps);
-        Box::new(self)
-    }
-
-    pub fn hover_info(mut self, hover_info: HoverInfo) -> Box<Self> {
-        self.hover_info = Some(hover_info);
-        Box::new(self)
-    }
-
-    pub fn hover_label(mut self, hover_label: Label) -> Box<Self> {
-        self.hover_label = Some(hover_label);
-        Box::new(self)
-    }
-
-    pub fn hover_on_gaps(mut self, hover_on_gaps: bool) -> Box<Self> {
-        self.hover_on_gaps = Some(hover_on_gaps);
-        Box::new(self)
-    }
-
-    pub fn hover_template(mut self, hover_template: &str) -> Box<Self> {
-        self.hover_template = Some(Dim::Scalar(hover_template.to_string()));
-        Box::new(self)
-    }
-
-    pub fn hover_template_array<S: AsRef<str>>(mut self, hover_template: Vec<S>) -> Box<Self> {
-        let hover_template = private::owned_string_vector(hover_template);
-        self.hover_template = Some(Dim::Vector(hover_template));
-        Box::new(self)
-    }
-
-    pub fn hover_text<S: AsRef<str>>(mut self, hover_text: Vec<S>) -> Box<Self> {
-        let hover_text = private::owned_string_vector(hover_text);
-        self.hover_text = Some(hover_text);
-        Box::new(self)
-    }
-
-    pub fn legend_group(mut self, legend_group: &str) -> Box<Self> {
-        self.legend_group = Some(legend_group.to_string());
-        Box::new(self)
-    }
-
-    pub fn name(mut self, name: &str) -> Box<Self> {
-        self.name = Some(name.to_string());
-        Box::new(self)
-    }
-
-    pub fn opacity(mut self, opacity: f64) -> Box<Self> {
-        self.opacity = Some(opacity);
-        Box::new(self)
-    }
-
-    pub fn reverse_scale(mut self, reverse_scale: bool) -> Box<Self> {
-        self.reverse_scale = Some(reverse_scale);
-        Box::new(self)
-    }
-    pub fn show_legend(mut self, show_legend: bool) -> Box<Self> {
-        self.show_legend = Some(show_legend);
-        Box::new(self)
-    }
-
-    pub fn show_scale(mut self, show_scale: bool) -> Box<Self> {
-        self.show_scale = Some(show_scale);
-        Box::new(self)
-    }
-
-    pub fn text<S: AsRef<str>>(mut self, text: Vec<S>) -> Box<Self> {
-        let text = private::owned_string_vector(text);
-        self.text = Some(text);
-        Box::new(self)
-    }
-
-    pub fn transpose(mut self, transpose: bool) -> Box<Self> {
-        self.transpose = Some(transpose);
-        Box::new(self)
-    }
-
-    pub fn visible(mut self, visible: Visible) -> Box<Self> {
-        self.visible = Some(visible);
-        Box::new(self)
-    }
-
-    pub fn x_axis(mut self, axis: &str) -> Box<Self> {
-        self.x_axis = Some(axis.to_string());
-        Box::new(self)
-    }
-
-    pub fn x_calendar(mut self, calendar: Calendar) -> Box<Self> {
-        self.x_calendar = Some(calendar);
-        Box::new(self)
-    }
-
-    pub fn y_axis(mut self, axis: &str) -> Box<Self> {
-        self.y_axis = Some(axis.to_string());
-        Box::new(self)
-    }
-
-    pub fn y_calendar(mut self, calendar: Calendar) -> Box<Self> {
-        self.y_calendar = Some(calendar);
-        Box::new(self)
-    }
-    pub fn zauto(mut self, zauto: bool) -> Box<Self> {
-        self.zauto = Some(zauto);
-        Box::new(self)
-    }
-
-    pub fn zhover_format(mut self, zhover_format: &str) -> Box<Self> {
-        self.zhover_format = Some(zhover_format.to_string());
-        Box::new(self)
-    }
-
-    pub fn zmax(mut self, zmax: Z) -> Box<Self> {
-        self.zmax = Some(zmax);
-        Box::new(self)
-    }
-
-    pub fn zmid(mut self, zmid: Z) -> Box<Self> {
-        self.zmid = Some(zmid);
-        Box::new(self)
-    }
-
-    pub fn zmin(mut self, zmin: Z) -> Box<Self> {
-        self.zmin = Some(zmin);
-        Box::new(self)
-    }
-
-    pub fn zsmooth(mut self, zsmooth: Smoothing) -> Box<Self> {
-        self.zsmooth = Some(zsmooth);
-        Box::new(self)
     }
 }
 

--- a/plotly/src/traces/heat_map.rs
+++ b/plotly/src/traces/heat_map.rs
@@ -52,6 +52,7 @@ impl Serialize for Smoothing {
 /// ```
 #[serde_with::skip_serializing_none]
 #[derive(Serialize, Debug, Clone, FieldSetter)]
+#[field_setter(box_self, kind = "trace")]
 pub struct HeatMap<X, Y, Z>
 where
     X: Serialize + Clone,

--- a/plotly/src/traces/histogram.rs
+++ b/plotly/src/traces/histogram.rs
@@ -2,13 +2,14 @@
 
 #[cfg(feature = "plotly_ndarray")]
 use ndarray::{Array, Ix1, Ix2};
+use plotly_derive::FieldSetter;
 use serde::Serialize;
 
 #[cfg(feature = "plotly_ndarray")]
 use crate::ndarray::ArrayTraces;
 use crate::{
     common::{Calendar, Dim, ErrorData, HoverInfo, Label, Marker, Orientation, PlotType, Visible},
-    private, Trace,
+    Trace,
 };
 
 #[derive(Serialize, Clone, Debug)]
@@ -25,7 +26,8 @@ impl Bins {
 }
 
 #[serde_with::skip_serializing_none]
-#[derive(Serialize, Clone, Debug, Default)]
+#[derive(Serialize, Clone, Debug, FieldSetter)]
+#[field_setter(no_box)]
 pub struct Cumulative {
     enabled: Option<bool>,
     direction: Option<HistDirection>,
@@ -36,21 +38,6 @@ pub struct Cumulative {
 impl Cumulative {
     pub fn new() -> Self {
         Default::default()
-    }
-
-    pub fn enabled(mut self, enabled: bool) -> Self {
-        self.enabled = Some(enabled);
-        self
-    }
-
-    pub fn direction(mut self, direction: HistDirection) -> Self {
-        self.direction = Some(direction);
-        self
-    }
-
-    pub fn current_bin(mut self, current_bin: CurrentBin) -> Self {
-        self.current_bin = Some(current_bin);
-        self
     }
 }
 
@@ -115,11 +102,12 @@ pub enum HistNorm {
 /// assert_eq!(serde_json::to_value(trace).unwrap(), expected);
 /// ```
 #[serde_with::skip_serializing_none]
-#[derive(Serialize, Clone, Debug)]
+#[derive(Serialize, Clone, Debug, FieldSetter)]
 pub struct Histogram<H>
 where
     H: Serialize + Clone,
 {
+    #[field_setter(default = "PlotType::Histogram")]
     r#type: PlotType,
     #[serde(rename = "alignmentgroup")]
     alignment_group: Option<String>,
@@ -174,49 +162,6 @@ where
     y_bins: Option<Bins>,
     #[serde(rename = "ycalendar")]
     y_calendar: Option<Calendar>,
-}
-
-impl<H> Default for Histogram<H>
-where
-    H: Serialize + Clone,
-{
-    fn default() -> Self {
-        Self {
-            r#type: PlotType::Histogram,
-            alignment_group: None,
-            auto_bin_x: None,
-            auto_bin_y: None,
-            cumulative: None,
-            bin_group: None,
-            error_x: None,
-            error_y: None,
-            hist_func: None,
-            hist_norm: None,
-            hover_info: None,
-            hover_label: None,
-            hover_template: None,
-            hover_text: None,
-            legend_group: None,
-            marker: None,
-            n_bins_x: None,
-            n_bins_y: None,
-            name: None,
-            offset_group: None,
-            opacity: None,
-            orientation: None,
-            show_legend: None,
-            text: None,
-            visible: None,
-            x: None,
-            x_axis: None,
-            x_bins: None,
-            x_calendar: None,
-            y: None,
-            y_axis: None,
-            y_bins: None,
-            y_calendar: None,
-        }
-    }
 }
 
 impl<H> Histogram<H>
@@ -323,174 +268,6 @@ where
             x: Some(x.to_vec()),
             ..Default::default()
         })
-    }
-
-    pub fn alignment_group(mut self, alignment_group: &str) -> Box<Self> {
-        self.alignment_group = Some(alignment_group.to_string());
-        Box::new(self)
-    }
-
-    pub fn auto_bin_x(mut self, auto_bin_x: bool) -> Box<Self> {
-        self.auto_bin_x = Some(auto_bin_x);
-        Box::new(self)
-    }
-
-    pub fn auto_bin_y(mut self, auto_bin_y: bool) -> Box<Self> {
-        self.auto_bin_y = Some(auto_bin_y);
-        Box::new(self)
-    }
-
-    pub fn bin_group(mut self, bin_group: &str) -> Box<Self> {
-        self.bin_group = Some(bin_group.to_string());
-        Box::new(self)
-    }
-
-    pub fn cumulative(mut self, cumulative: Cumulative) -> Box<Self> {
-        self.cumulative = Some(cumulative);
-        Box::new(self)
-    }
-
-    pub fn error_x(mut self, error_x: ErrorData) -> Box<Self> {
-        self.error_x = Some(error_x);
-        Box::new(self)
-    }
-
-    pub fn error_y(mut self, error_y: ErrorData) -> Box<Self> {
-        self.error_y = Some(error_y);
-        Box::new(self)
-    }
-
-    pub fn hist_func(mut self, hist_func: HistFunc) -> Box<Self> {
-        self.hist_func = Some(hist_func);
-        Box::new(self)
-    }
-
-    pub fn hist_norm(mut self, hist_norm: HistNorm) -> Box<Self> {
-        self.hist_norm = Some(hist_norm);
-        Box::new(self)
-    }
-
-    pub fn hover_info(mut self, hover_info: HoverInfo) -> Box<Self> {
-        self.hover_info = Some(hover_info);
-        Box::new(self)
-    }
-
-    pub fn hover_label(mut self, hover_label: Label) -> Box<Self> {
-        self.hover_label = Some(hover_label);
-        Box::new(self)
-    }
-
-    pub fn hover_template(mut self, hover_template: &str) -> Box<Self> {
-        self.hover_template = Some(Dim::Scalar(hover_template.to_string()));
-        Box::new(self)
-    }
-
-    pub fn hover_template_array<S: AsRef<str>>(mut self, hover_template: Vec<S>) -> Box<Self> {
-        let hover_template = private::owned_string_vector(hover_template);
-        self.hover_template = Some(Dim::Vector(hover_template));
-        Box::new(self)
-    }
-
-    pub fn hover_text(mut self, hover_text: &str) -> Box<Self> {
-        self.hover_text = Some(Dim::Scalar(hover_text.to_string()));
-        Box::new(self)
-    }
-
-    pub fn hover_text_array<S: AsRef<str>>(mut self, hover_text: Vec<S>) -> Box<Self> {
-        let hover_text = private::owned_string_vector(hover_text);
-        self.hover_text = Some(Dim::Vector(hover_text));
-        Box::new(self)
-    }
-
-    pub fn legend_group(mut self, legend_group: &str) -> Box<Self> {
-        self.legend_group = Some(legend_group.to_string());
-        Box::new(self)
-    }
-
-    pub fn marker(mut self, marker: Marker) -> Box<Self> {
-        self.marker = Some(marker);
-        Box::new(self)
-    }
-
-    pub fn n_bins_x(mut self, n_bins_x: usize) -> Box<Self> {
-        self.n_bins_x = Some(n_bins_x);
-        Box::new(self)
-    }
-
-    pub fn n_bins_y(mut self, n_bins_y: usize) -> Box<Self> {
-        self.n_bins_y = Some(n_bins_y);
-        Box::new(self)
-    }
-
-    pub fn name(mut self, name: &str) -> Box<Self> {
-        self.name = Some(name.to_string());
-        Box::new(self)
-    }
-
-    pub fn offset_group(mut self, offset_group: &str) -> Box<Self> {
-        self.offset_group = Some(offset_group.to_string());
-        Box::new(self)
-    }
-
-    pub fn opacity(mut self, opacity: f64) -> Box<Self> {
-        self.opacity = Some(opacity);
-        Box::new(self)
-    }
-
-    pub fn orientation(mut self, orientation: Orientation) -> Box<Self> {
-        self.orientation = Some(orientation);
-        Box::new(self)
-    }
-
-    pub fn show_legend(mut self, show_legend: bool) -> Box<Self> {
-        self.show_legend = Some(show_legend);
-        Box::new(self)
-    }
-
-    pub fn text(mut self, text: &str) -> Box<Self> {
-        self.text = Some(Dim::Scalar(text.to_string()));
-        Box::new(self)
-    }
-
-    pub fn text_array<S: AsRef<str>>(mut self, text: Vec<S>) -> Box<Self> {
-        let text = private::owned_string_vector(text);
-        self.text = Some(Dim::Vector(text));
-        Box::new(self)
-    }
-
-    pub fn visible(mut self, visible: Visible) -> Box<Self> {
-        self.visible = Some(visible);
-        Box::new(self)
-    }
-
-    pub fn x_axis(mut self, axis: &str) -> Box<Self> {
-        self.x_axis = Some(axis.to_string());
-        Box::new(self)
-    }
-
-    pub fn x_bins(mut self, x_bins: Bins) -> Box<Self> {
-        self.x_bins = Some(x_bins);
-        Box::new(self)
-    }
-
-    pub fn x_calendar(mut self, x_calendar: Calendar) -> Box<Self> {
-        self.x_calendar = Some(x_calendar);
-        Box::new(self)
-    }
-
-    pub fn y_axis(mut self, axis: &str) -> Box<Self> {
-        self.y_axis = Some(axis.to_string());
-        Box::new(self)
-    }
-
-    pub fn y_bins(mut self, y_bins: Bins) -> Box<Self> {
-        self.y_bins = Some(y_bins);
-        Box::new(self)
-    }
-
-    pub fn y_calendar(mut self, y_calendar: Calendar) -> Box<Self> {
-        self.y_calendar = Some(y_calendar);
-        Box::new(self)
     }
 }
 

--- a/plotly/src/traces/histogram.rs
+++ b/plotly/src/traces/histogram.rs
@@ -27,7 +27,6 @@ impl Bins {
 
 #[serde_with::skip_serializing_none]
 #[derive(Serialize, Clone, Debug, FieldSetter)]
-#[field_setter(no_box)]
 pub struct Cumulative {
     enabled: Option<bool>,
     direction: Option<HistDirection>,
@@ -103,6 +102,7 @@ pub enum HistNorm {
 /// ```
 #[serde_with::skip_serializing_none]
 #[derive(Serialize, Clone, Debug, FieldSetter)]
+#[field_setter(box_self, kind = "trace")]
 pub struct Histogram<H>
 where
     H: Serialize + Clone,

--- a/plotly/src/traces/histogram.rs
+++ b/plotly/src/traces/histogram.rs
@@ -248,7 +248,7 @@ where
         array_traces: ArrayTraces,
     ) -> Vec<Box<dyn Trace>> {
         let mut traces: Vec<Box<dyn Trace>> = Vec::new();
-        let mut trace_vectors = private::trace_vectors_from(traces_matrix, array_traces);
+        let mut trace_vectors = crate::private::trace_vectors_from(traces_matrix, array_traces);
         trace_vectors.reverse();
         while !trace_vectors.is_empty() {
             let mut sc = Box::new(self.clone());

--- a/plotly/src/traces/mod.rs
+++ b/plotly/src/traces/mod.rs
@@ -1,6 +1,6 @@
 //! The various supported traces
 
-mod bar;
+pub mod bar;
 pub mod box_plot;
 mod candlestick;
 pub mod contour;

--- a/plotly/src/traces/ohlc.rs
+++ b/plotly/src/traces/ohlc.rs
@@ -1,10 +1,11 @@
 //! Open-high-low-close (OHLC) trace
 
+use plotly_derive::FieldSetter;
 use serde::Serialize;
 
 use crate::{
     common::{Calendar, Dim, Direction, HoverInfo, Label, Line, PlotType, Visible},
-    private, Trace,
+    Trace,
 };
 
 /// Construct an OHLC trace.
@@ -34,12 +35,13 @@ use crate::{
 /// assert_eq!(serde_json::to_value(trace).unwrap(), expected);
 /// ```
 #[serde_with::skip_serializing_none]
-#[derive(Serialize, Debug, Clone)]
+#[derive(Serialize, Debug, Clone, FieldSetter)]
 pub struct Ohlc<X, O>
 where
     X: Serialize + Clone,
     O: Serialize + Clone,
 {
+    #[field_setter(default = "PlotType::Ohlc")]
     r#type: PlotType,
     x: Option<Vec<X>>,
     open: Option<Vec<O>>,
@@ -69,37 +71,6 @@ where
     x_calendar: Option<Calendar>,
 }
 
-impl<X, O> Default for Ohlc<X, O>
-where
-    X: Serialize + Clone,
-    O: Serialize + Clone,
-{
-    fn default() -> Self {
-        Self {
-            r#type: PlotType::Ohlc,
-            x: None,
-            open: None,
-            high: None,
-            low: None,
-            close: None,
-            decreasing: None,
-            hover_info: None,
-            hover_label: None,
-            hover_text: None,
-            increasing: None,
-            legend_group: None,
-            line: None,
-            name: None,
-            opacity: None,
-            show_legend: None,
-            text: None,
-            tick_width: None,
-            visible: None,
-            x_calendar: None,
-        }
-    }
-}
-
 impl<X, O> Ohlc<X, O>
 where
     X: Serialize + Clone,
@@ -115,88 +86,6 @@ where
             close: Some(close),
             ..Default::default()
         })
-    }
-
-    pub fn decreasing(mut self, decreasing: Direction) -> Box<Self> {
-        self.decreasing = Some(decreasing);
-        Box::new(self)
-    }
-
-    pub fn hover_info(mut self, hover_info: HoverInfo) -> Box<Self> {
-        self.hover_info = Some(hover_info);
-        Box::new(self)
-    }
-
-    pub fn hover_label(mut self, hover_label: Label) -> Box<Self> {
-        self.hover_label = Some(hover_label);
-        Box::new(self)
-    }
-
-    pub fn hover_text(mut self, hover_text: &str) -> Box<Self> {
-        self.hover_text = Some(Dim::Scalar(hover_text.to_owned()));
-        Box::new(self)
-    }
-
-    pub fn hover_text_array<S: AsRef<str>>(mut self, hover_text: Vec<S>) -> Box<Self> {
-        let hover_text = private::owned_string_vector(hover_text);
-        self.hover_text = Some(Dim::Vector(hover_text));
-        Box::new(self)
-    }
-
-    pub fn increasing(mut self, increasing: Direction) -> Box<Self> {
-        self.increasing = Some(increasing);
-        Box::new(self)
-    }
-
-    pub fn legend_group(mut self, legend_group: &str) -> Box<Self> {
-        self.legend_group = Some(legend_group.to_owned());
-        Box::new(self)
-    }
-
-    pub fn line(mut self, line: Line) -> Box<Self> {
-        self.line = Some(line);
-        Box::new(self)
-    }
-
-    pub fn name(mut self, name: &str) -> Box<Self> {
-        self.name = Some(name.to_owned());
-        Box::new(self)
-    }
-
-    pub fn opacity(mut self, opacity: f64) -> Box<Self> {
-        self.opacity = Some(opacity);
-        Box::new(self)
-    }
-
-    pub fn show_legend(mut self, show_legend: bool) -> Box<Self> {
-        self.show_legend = Some(show_legend);
-        Box::new(self)
-    }
-
-    pub fn text(mut self, text: &str) -> Box<Self> {
-        self.text = Some(Dim::Scalar(text.to_owned()));
-        Box::new(self)
-    }
-
-    pub fn text_array<S: AsRef<str>>(mut self, text: Vec<S>) -> Box<Self> {
-        let text = private::owned_string_vector(text);
-        self.text = Some(Dim::Vector(text));
-        Box::new(self)
-    }
-
-    pub fn tick_width(mut self, tick_width: f64) -> Box<Self> {
-        self.tick_width = Some(tick_width);
-        Box::new(self)
-    }
-
-    pub fn visible(mut self, visible: Visible) -> Box<Self> {
-        self.visible = Some(visible);
-        Box::new(self)
-    }
-
-    pub fn x_calendar(mut self, x_calendar: Calendar) -> Box<Self> {
-        self.x_calendar = Some(x_calendar);
-        Box::new(self)
     }
 }
 

--- a/plotly/src/traces/sankey.rs
+++ b/plotly/src/traces/sankey.rs
@@ -1,5 +1,6 @@
 //! Sankey trace
 
+use plotly_derive::FieldSetter;
 use serde::Serialize;
 
 use crate::{
@@ -270,64 +271,66 @@ where
 /// assert_eq!(serde_json::to_value(trace).unwrap(), expected);
 /// ```
 #[serde_with::skip_serializing_none]
-#[derive(Serialize, Clone)]
+#[derive(Serialize, Clone, FieldSetter)]
 pub struct Sankey<V>
 where
     V: Serialize + Clone,
 {
     // Missing: meta, customdata, uirevision
+    #[field_setter(default = "PlotType::Sankey")]
     r#type: PlotType,
+    /// If value is `snap` (the default), the node arrangement is assisted by automatic snapping of elements
+    /// to preserve space between nodes specified via `nodepad`. If value is `perpendicular`, the nodes can
+    /// only move along a line perpendicular to the flow. If value is `freeform`, the nodes can freely move
+    /// on the plane. If value is `fixed`, the nodes are stationary.
     arrangement: Option<Arrangement>,
+    /// Sets the domain within which the Sankey diagram will be drawn.
     domain: Option<Domain>,
+    /// Assigns id labels to each datum. These ids are for object constancy of data points during animation.
     ids: Option<Vec<String>>,
+    /// Determines which trace information appear on hover. If `none` or `skip` are set, no information is displayed
+    /// upon hovering. But, if `none` is set, click and hover events are still fired. Note that this attribute
+    /// is superseded by `node.hover_info` and `link.hover_info` for nodes and links respectively.
     #[serde(rename = "hoverinfo")]
     hover_info: Option<HoverInfo>,
+    /// Sets the hover label for this trace.
     #[serde(rename = "hoverlabel")]
     hover_label: Option<Label>,
+    /// Set and style the title to appear for the legend group
     #[serde(rename = "legendgrouptitle")]
     legend_group_title: Option<LegendGroupTitle>,
+    /// Sets the legend rank for this trace. Items and groups with smaller ranks are presented on top/left
+    /// side while with `"reversed" `legend.trace_order` they are on bottom/right side. The default legendrank
+    /// is 1000, so that you can use ranks less than 1000 to place certain items before all unranked items,
+    /// and ranks greater than 1000 to go after all unranked items.
     #[serde(rename = "legendrank")]
     legend_rank: Option<usize>,
+    /// The links of the Sankey diagram.
     link: Option<Link<V>>,
+    /// Sets the trace name. The trace name appears as the legend item and on hover.
     name: Option<String>,
+    /// The nodes of the Sankey diagram.
     node: Option<Node>,
+    /// Sets the orientation of the Sankey diagram.
     orientation: Option<Orientation>,
+    /// Vector containing integer indices of selected points. Has an effect only for traces that support
+    /// selections. Note that an empty vector means an empty selection where the `unselected` are turned
+    /// on for all points.
     #[serde(rename = "selectedpoints")]
     selected_points: Option<Vec<usize>>,
+    /// Sets the font for node labels.
     #[serde(rename = "textfont")]
     text_font: Option<Font>,
+    /// Sets the value formatting rule using d3 formatting mini-languages which are very similar to those in
+    /// Python. For numbers, see: https://github.com/d3/d3-format/tree/v1.4.5#d3-format.
     #[serde(rename = "valueformat")]
     value_format: Option<String>,
+    /// Adds a unit to follow the value in the hover tooltip. Add a space if a separation is necessary from the value.
     #[serde(rename = "valuesuffix")]
     value_suffix: Option<String>,
+    /// Determines whether or not this trace is visible. If "legendonly", the trace
+    /// is not drawn, but can appear as a legend item (provided that the legend itself is visible).
     visible: Option<bool>,
-}
-
-impl<V> Default for Sankey<V>
-where
-    V: Serialize + Clone,
-{
-    fn default() -> Self {
-        Self {
-            r#type: PlotType::Sankey,
-            arrangement: None,
-            domain: None,
-            ids: None,
-            hover_info: None,
-            hover_label: None,
-            legend_group_title: None,
-            legend_rank: None,
-            link: None,
-            name: None,
-            node: None,
-            orientation: None,
-            selected_points: None,
-            text_font: None,
-            value_format: None,
-            value_suffix: None,
-            visible: None,
-        }
-    }
 }
 
 impl<V> Sankey<V>
@@ -337,114 +340,6 @@ where
     /// Creates a new empty Sankey diagram.
     pub fn new() -> Box<Self> {
         Box::new(Default::default())
-    }
-
-    /// Sets the trace name. The trace name appears as the legend item and on hover.
-    pub fn name(mut self, name: &str) -> Box<Self> {
-        self.name = Some(name.to_string());
-        Box::new(self)
-    }
-
-    /// Determines whether or not this trace is visible. If "legendonly", the trace
-    /// is not drawn, but can appear as a legend item (provided that the legend itself is visible).
-    pub fn visible(mut self, visible: bool) -> Box<Self> {
-        self.visible = Some(visible);
-        Box::new(self)
-    }
-
-    /// Sets the legend rank for this trace. Items and groups with smaller ranks are presented on top/left
-    /// side while with `"reversed" `legend.trace_order` they are on bottom/right side. The default legendrank
-    /// is 1000, so that you can use ranks less than 1000 to place certain items before all unranked items,
-    /// and ranks greater than 1000 to go after all unranked items.
-    pub fn legend_rank(mut self, legend_rank: usize) -> Box<Self> {
-        self.legend_rank = Some(legend_rank);
-        Box::new(self)
-    }
-
-    /// Set and style the title to appear for the legend group
-    pub fn legend_group_title(mut self, legend_group_title: LegendGroupTitle) -> Box<Self> {
-        self.legend_group_title = Some(legend_group_title);
-        Box::new(self)
-    }
-
-    /// Assigns id labels to each datum. These ids are for object constancy of data points during animation.
-    pub fn ids(mut self, ids: Vec<&str>) -> Box<Self> {
-        self.ids = Some(ids.iter().map(|&id| id.to_string()).collect());
-        Box::new(self)
-    }
-
-    /// Determines which trace information appear on hover. If `none` or `skip` are set, no information is displayed
-    /// upon hovering. But, if `none` is set, click and hover events are still fired. Note that this attribute
-    /// is superseded by `node.hover_info` and `link.hover_info` for nodes and links respectively.
-    pub fn hover_info(mut self, hover_info: HoverInfo) -> Box<Self> {
-        self.hover_info = Some(hover_info);
-        Box::new(self)
-    }
-
-    /// Sets the hover label for this trace.
-    pub fn hover_label(mut self, hover_label: Label) -> Box<Self> {
-        self.hover_label = Some(hover_label);
-        Box::new(self)
-    }
-
-    /// Sets the font for node labels.
-    pub fn text_font(mut self, text_font: Font) -> Box<Self> {
-        self.text_font = Some(text_font);
-        Box::new(self)
-    }
-
-    /// Sets the domain within which the Sankey diagram will be drawn.
-    pub fn domain(mut self, domain: Domain) -> Box<Self> {
-        self.domain = Some(domain);
-        Box::new(self)
-    }
-
-    /// Sets the orientation of the Sankey diagram.
-    pub fn orientation(mut self, orientation: Orientation) -> Box<Self> {
-        self.orientation = Some(orientation);
-        Box::new(self)
-    }
-
-    /// The nodes of the Sankey diagram.
-    pub fn node(mut self, node: Node) -> Box<Self> {
-        self.node = Some(node);
-        Box::new(self)
-    }
-
-    /// The links of the Sankey diagram.
-    pub fn link(mut self, link: Link<V>) -> Box<Self> {
-        self.link = Some(link);
-        Box::new(self)
-    }
-
-    /// Vector containing integer indices of selected points. Has an effect only for traces that support
-    /// selections. Note that an empty vector means an empty selection where the `unselected` are turned
-    /// on for all points.
-    pub fn selected_points(mut self, selected_points: Vec<usize>) -> Box<Self> {
-        self.selected_points = Some(selected_points);
-        Box::new(self)
-    }
-
-    /// If value is `snap` (the default), the node arrangement is assisted by automatic snapping of elements
-    /// to preserve space between nodes specified via `nodepad`. If value is `perpendicular`, the nodes can
-    /// only move along a line perpendicular to the flow. If value is `freeform`, the nodes can freely move
-    /// on the plane. If value is `fixed`, the nodes are stationary.
-    pub fn arrangement(mut self, arrangement: Arrangement) -> Box<Self> {
-        self.arrangement = Some(arrangement);
-        Box::new(self)
-    }
-
-    /// Sets the value formatting rule using d3 formatting mini-languages which are very similar to those in
-    /// Python. For numbers, see: https://github.com/d3/d3-format/tree/v1.4.5#d3-format.
-    pub fn value_format(mut self, value_format: &str) -> Box<Self> {
-        self.value_format = Some(value_format.to_string());
-        Box::new(self)
-    }
-
-    /// Adds a unit to follow the value in the hover tooltip. Add a space if a separation is necessary from the value.
-    pub fn value_suffix(mut self, value_suffix: &str) -> Box<Self> {
-        self.value_suffix = Some(value_suffix.to_string());
-        Box::new(self)
     }
 }
 

--- a/plotly/src/traces/sankey.rs
+++ b/plotly/src/traces/sankey.rs
@@ -272,6 +272,7 @@ where
 /// ```
 #[serde_with::skip_serializing_none]
 #[derive(Serialize, Clone, FieldSetter)]
+#[field_setter(box_self, kind = "trace")]
 pub struct Sankey<V>
 where
     V: Serialize + Clone,

--- a/plotly/src/traces/scatter.rs
+++ b/plotly/src/traces/scatter.rs
@@ -2,6 +2,7 @@
 
 #[cfg(feature = "plotly_ndarray")]
 use ndarray::{Array, Ix1, Ix2};
+use plotly_derive::FieldSetter;
 use serde::Serialize;
 
 #[cfg(feature = "plotly_ndarray")]
@@ -12,7 +13,8 @@ use crate::{
         Calendar, Dim, ErrorData, Fill, Font, HoverInfo, HoverOn, Label, Line, Marker, Mode,
         Orientation, PlotType, Position, Visible,
     },
-    private, Trace,
+    private::{NumOrString, NumOrStringCollection},
+    Trace,
 };
 
 #[derive(Serialize, Clone, Debug)]
@@ -50,132 +52,207 @@ pub enum StackGaps {
 /// assert_eq!(serde_json::to_value(trace).unwrap(), expected);
 /// ```
 #[serde_with::skip_serializing_none]
-#[derive(Serialize, Clone, Debug)]
+#[derive(Serialize, Clone, Debug, FieldSetter)]
 pub struct Scatter<X, Y>
 where
     X: Serialize + Clone + 'static,
     Y: Serialize + Clone + 'static,
 {
+    #[field_setter(default = "PlotType::Scatter")]
     r#type: PlotType,
+    /// Sets the trace name. The trace name appear as the legend item and on hover.
     name: Option<String>,
+    /// Determines whether or not this trace is visible. If `Visible::LegendOnly`, the trace is not
+    /// drawn, but can appear as a legend item (provided that the legend itself is visible).
     visible: Option<Visible>,
+    /// Determines whether or not an item corresponding to this trace is shown in the legend.
     #[serde(rename = "showlegend")]
     show_legend: Option<bool>,
+    /// Sets the legend group for this trace. Traces part of the same legend group hide/show at the
+    /// same time when toggling legend items.
     #[serde(rename = "legendgroup")]
     legend_group: Option<String>,
+    /// Sets the opacity of the trace.
     opacity: Option<f64>,
+    /// Determines the drawing mode for this scatter trace. If the provided `Mode` includes
+    /// "Text" then the `text` elements appear at the coordinates. Otherwise, the `text` elements
+    /// appear on hover. If there are less than 20 points and the trace is not stacked then the
+    /// default is `Mode::LinesMarkers`, otherwise it is `Mode::Lines`.
     mode: Option<Mode>,
+    /// Assigns id labels to each datum. These ids for object constancy of data points during
+    /// animation. Should be an array of strings, not numbers or any other type.
     ids: Option<Vec<String>>,
+    #[field_setter(skip)]
     x: Option<Vec<X>>,
-
-    x0: Option<private::NumOrString>,
+    /// Alternate to `x`. Builds a linear space of x coordinates. Use with `dx` where `x0` is the
+    /// starting coordinate and `dx` the step.
+    x0: Option<NumOrString>,
+    /// Sets the x coordinate step. See `x0` for more info.
     dx: Option<f64>,
 
+    #[field_setter(skip)]
     y: Option<Vec<Y>>,
 
-    y0: Option<private::NumOrString>,
+    /// Alternate to `y`. Builds a linear space of y coordinates. Use with `dy` where `y0` is the
+    /// starting coordinate and `dy` the step.
+    y0: Option<NumOrString>,
+    /// Sets the y coordinate step. See `y0` for more info.
     dy: Option<f64>,
 
+    /// Sets text elements associated with each (x,y) pair. If a single string, the same string
+    /// appears over all the data points. If an array of string, the items are mapped in order to
+    /// the this trace's (x,y) coordinates. If the trace `HoverInfo` contains a "text" flag and
+    /// `hover_text` is not set, these elements will be seen in the hover labels.
     text: Option<Dim<String>>,
+    /// Sets the positions of the `text` elements with respects to the (x,y) coordinates.
     #[serde(rename = "textposition")]
     text_position: Option<Dim<Position>>,
+    /// Template string used for rendering the information text that appear on points. Note that
+    /// this will override `textinfo`. Variables are inserted using %{variable}, for example
+    /// "y: %{y}". Numbers are formatted using d3-format's syntax %{variable:d3-format}, for example
+    /// "Price: %{y:$.2f}". See [format](https://github.com/d3/d3-3.x-api-reference/blob/master/Formatting.md#d3)
+    /// for details on the formatting syntax. Dates are formatted using d3-time-format's syntax
+    /// %{variable|d3-time-format}, for example "Day: %{2019-01-01|%A}".
+    /// See [format](https://github.com/d3/d3-3.x-api-reference/blob/master/Time-Formatting.md#format) for details
+    /// on the date formatting syntax. Every attributes that can be specified per-point (the ones
+    /// that are `arrayOk: true`) are available.
     #[serde(rename = "texttemplate")]
     text_template: Option<Dim<String>>,
+    /// Sets hover text elements associated with each (x,y) pair. If a single string, the same
+    /// string appears over all the data points. If an array of string, the items are mapped in
+    /// order to the this trace's (x,y) coordinates. To be seen, trace `HoverInfo` must contain a
+    /// "Text" flag.
     #[serde(rename = "hovertext")]
     hover_text: Option<Dim<String>>,
+    /// Determines which trace information appear on hover. If `HoverInfo::None` or `HoverInfo::Skip`
+    /// are set, no information is displayed upon hovering. But, if `HoverInfo::None` is set, click
+    /// and hover events are still fired.
     #[serde(rename = "hoverinfo")]
     hover_info: Option<HoverInfo>,
+    /// Template string used for rendering the information that appear on hover box. Note that this
+    /// will override `HoverInfo`. Variables are inserted using %{variable}, for example "y: %{y}".
+    /// Numbers are formatted using d3-format's syntax %{variable:d3-format}, for example
+    /// "Price: %{y:$.2f}".
+    /// https://github.com/d3/d3-3.x-api-reference/blob/master/Formatting.md#d3_format for details
+    /// on the formatting syntax. Dates are formatted using d3-time-format's syntax
+    /// %{variable|d3-time-format}, for example "Day: %{2019-01-01|%A}".
+    /// https://github.com/d3/d3-3.x-api-reference/blob/master/Time-Formatting.md#format for details
+    /// on the date formatting syntax. The variables available in `hovertemplate` are the ones
+    /// emitted as event data described at this link https://plotly.com/javascript/plotlyjs-events/#event-data.
+    /// Additionally, every attributes that can be specified per-point (the ones that are
+    /// `arrayOk: true`) are available. Anything contained in tag `<extra>` is displayed in the
+    /// secondary box, for example "<extra>{fullData.name}</extra>". To hide the secondary box
+    /// completely, use an empty tag `<extra></extra>`.
     #[serde(rename = "hovertemplate")]
     hover_template: Option<Dim<String>>,
-
-    meta: Option<private::NumOrString>,
+    /// Assigns extra meta information associated with this trace that can be used in various text
+    /// attributes. Attributes such as trace `name`, graph, axis and colorbar `title.text`,
+    /// annotation `text` `rangeselector`, `updatemenues` and `sliders` `label` text all support
+    /// `meta`. To access the trace `meta` values in an attribute in the same trace, simply use
+    /// `%{meta[i]}` where `i` is the index or key of the `meta` item in question. To access trace
+    /// `meta` in layout attributes, use `%{data[n[.meta[i]}` where `i` is the index or key of the
+    /// `meta` and `n` is the trace index.
+    meta: Option<NumOrString>,
+    /// Assigns extra data each datum. This may be useful when listening to hover, click and
+    /// selection events. Note that, "scatter" traces also appends customdata items in the markers
+    /// DOM elements
     #[serde(rename = "customdata")]
-    custom_data: Option<private::NumOrStringCollection>,
+    custom_data: Option<NumOrStringCollection>,
 
+    /// Sets a reference between this trace's x coordinates and a 2D cartesian x axis. If "x" (
+    /// the default value), the x coordinates refer to `Layout::x_axis`. If "x2", the x coordinates
+    /// refer to `Layout::x_axis2`, and so on.
     #[serde(rename = "xaxis")]
     x_axis: Option<String>,
+    /// Sets a reference between this trace's y coordinates and a 2D cartesian y axis. If "y"
+    /// (the default value), the y coordinates refer to `Layout::y_axis`. If "y2", the y coordinates
+    /// refer to `Layout::y_axis2`, and so on.
     #[serde(rename = "yaxis")]
     y_axis: Option<String>,
+    /// Only relevant when `stackgroup` is used, and only the first `orientation` found in the
+    /// `stackgroup` will be used - including if `visible` is "legendonly" but not if it is `false`.
+    /// Sets the stacking direction. With "v" ("h"), the y (x) values of subsequent traces are
+    /// added. Also affects the default value of `fill`.
     orientation: Option<Orientation>,
+    /// Only relevant when `stackgroup` is used, and only the first `groupnorm` found in the
+    /// `stackgroup` will be used - including if `visible` is "legendonly" but not if it is `false`.
+    /// Sets the normalization for the sum of this `stackgroup`. With "fraction", the value of each
+    /// trace at each location is divided by the sum of all trace values at that location. "percent"
+    /// is the same but multiplied by 100 to show percentages. If there are multiple subplots, or
+    /// multiple `stackgroup`s on one subplot, each will be normalized within its own set.
     #[serde(rename = "groupnorm")]
     group_norm: Option<GroupNorm>,
+    /// Set several scatter traces (on the same subplot) to the same stackgroup in order to add
+    /// their y values (or their x values if `orientation` is "h"). If blank or omitted this trace
+    /// will not be stacked. Stacking also turns `fill` on by default, using "tonexty" ("tonextx")
+    /// if `orientation` is "h" ("v") and sets the default `mode` to "lines" irrespective of point
+    /// count. You can only stack on a numeric (linear or log) axis. Traces in a `stackgroup` will
+    /// only fill to (or be filled to) other traces in the same group. With multiple `stackgroup`s
+    /// or some traces stacked and some not, if fill-linked traces are not already consecutive, the
+    /// later ones will be pushed down in the drawing order.
     #[serde(rename = "stackgroup")]
     stack_group: Option<String>,
+    /// Determines how points are displayed and joined.
     marker: Option<Marker>,
+    /// Line display properties.
     line: Option<Line>,
+    /// Sets the text font.
     #[serde(rename = "textfont")]
     text_font: Option<Font>,
+    /// x-axis error display properties
     error_x: Option<ErrorData>,
+    /// y-axis error display properties.
     error_y: Option<ErrorData>,
+    /// Determines whether or not markers and text nodes are clipped about the subplot axes. To show
+    /// markers and text nodes above axis lines and tick labels, make sure to set `xaxis.layer` and
+    /// `yaxis.layer` to "below traces".
     #[serde(rename = "cliponaxis")]
     clip_on_axis: Option<bool>,
+    /// Determines whether or not gaps (i.e. {nan} or missing values) in the provided data arrays
+    /// are connected.
     #[serde(rename = "connectgaps")]
     connect_gaps: Option<bool>,
+    /// Sets the area to fill with a solid color. Defaults to "none" unless this trace is stacked,
+    /// then it gets "tonexty" ("tonextx") if `orientation` is "v" ("h") Use with `fillcolor` if not
+    /// "none". "tozerox" and "tozeroy" fill to x=0 and y=0 respectively. "tonextx" and "tonexty"
+    /// fill between the endpoints of this trace and the endpoints of the trace before it,
+    /// connecting those endpoints with straight lines (to make a stacked area graph); if there is
+    /// no trace before it, they behave like "tozerox" and "tozeroy". "toself" connects the
+    /// endpoints of the trace (or each segment of the trace if it has gaps) into a closed shape.
+    /// "tonext" fills the space between two traces if one completely encloses the other
+    /// (eg consecutive contour lines), and behaves like "toself" if there is no trace before it.
+    /// "tonext" should not be used if one trace does not enclose the other. Traces in a
+    /// `stackgroup` will only fill to (or be filled to) other traces in the same group. With
+    /// multiple `stackgroup`s or some traces stacked and some not, if fill-linked traces are not
+    /// already consecutive, the later ones will be pushed down in the drawing order.
     fill: Option<Fill>,
+    /// Sets the fill color. Defaults to a half-transparent variant of the line color, marker color,
+    /// or marker line color, whichever is available.
     #[serde(rename = "fillcolor")]
     fill_color: Option<Box<dyn Color>>,
+    /// Properties of label displayed on mouse hover.
     #[serde(rename = "hoverlabel")]
     hover_label: Option<Label>,
+    /// Do the hover effects highlight individual points (markers or line points) or do they
+    /// highlight filled regions? If the fill is "toself" or "tonext" and there are no markers or
+    /// text, then the default is "fills", otherwise it is "points".
     #[serde(rename = "hoveron")]
     hover_on: Option<HoverOn>,
+    /// Only relevant when `stack_group` is used, and only the first `stack_gaps` found in the
+    /// `stackgroup` will be used - including if `visible` is set to `Visible::LegendOnly` but not
+    /// if it is set to `Visible::False`.
+    /// Determines how we handle locations at which other traces in this group have data but this
+    /// one does not. With "infer zero" we insert a zero at these locations. With "interpolate" we
+    /// linearly interpolate between existing values, and extrapolate a constant beyond the existing
+    /// values.
     #[serde(rename = "stackgaps")]
     stack_gaps: Option<StackGaps>,
+    /// Sets the calendar system to use with `x` date data.
     #[serde(rename = "xcalendar")]
     x_calendar: Option<Calendar>,
+    /// Sets the calendar system to use with `y` date data.
     #[serde(rename = "ycalendar")]
     y_calendar: Option<Calendar>,
-}
-
-impl<X, Y> Default for Scatter<X, Y>
-where
-    X: Serialize + Clone + 'static,
-    Y: Serialize + Clone + 'static,
-{
-    fn default() -> Self {
-        Scatter {
-            r#type: PlotType::Scatter,
-            name: None,
-            visible: None,
-            show_legend: None,
-            legend_group: None,
-            opacity: None,
-            mode: None,
-            ids: None,
-            x: None,
-            x0: None,
-            dx: None,
-            y: None,
-            y0: None,
-            dy: None,
-            text: None,
-            text_position: None,
-            text_template: None,
-            hover_text: None,
-            hover_info: None,
-            hover_template: None,
-            meta: None,
-            custom_data: None,
-            x_axis: None,
-            y_axis: None,
-            orientation: None,
-            group_norm: None,
-            stack_group: None,
-            marker: None,
-            line: None,
-            text_font: None,
-            error_x: None,
-            error_y: None,
-            clip_on_axis: None,
-            connect_gaps: None,
-            fill: None,
-            fill_color: None,
-            hover_label: None,
-            hover_on: None,
-            stack_gaps: None,
-            x_calendar: None,
-            y_calendar: None,
-        }
-    }
 }
 
 impl<X, Y> Scatter<X, Y>
@@ -272,387 +349,6 @@ where
         } else {
             PlotType::Scatter
         };
-        Box::new(self)
-    }
-
-    /// Sets the trace name. The trace name appear as the legend item and on hover.
-    pub fn name(mut self, name: &str) -> Box<Self> {
-        self.name = Some(name.to_string());
-        Box::new(self)
-    }
-
-    /// Determines whether or not this trace is visible. If `Visible::LegendOnly`, the trace is not
-    /// drawn, but can appear as a legend item (provided that the legend itself is visible).
-    pub fn visible(mut self, visible: Visible) -> Box<Self> {
-        self.visible = Some(visible);
-        Box::new(self)
-    }
-
-    /// Determines whether or not an item corresponding to this trace is shown in the legend.
-    pub fn show_legend(mut self, show_legend: bool) -> Box<Self> {
-        self.show_legend = Some(show_legend);
-        Box::new(self)
-    }
-
-    /// Sets the legend group for this trace. Traces part of the same legend group hide/show at the
-    /// same time when toggling legend items.
-    pub fn legend_group(mut self, legend_group: &str) -> Box<Self> {
-        self.legend_group = Some(legend_group.to_string());
-        Box::new(self)
-    }
-
-    /// Sets the opacity of the trace.
-    pub fn opacity(mut self, opacity: f64) -> Box<Self> {
-        self.opacity = Some(opacity);
-        Box::new(self)
-    }
-
-    /// Determines the drawing mode for this scatter trace. If the provided `Mode` includes
-    /// "Text" then the `text` elements appear at the coordinates. Otherwise, the `text` elements
-    /// appear on hover. If there are less than 20 points and the trace is not stacked then the
-    /// default is `Mode::LinesMarkers`, otherwise it is `Mode::Lines`.
-    pub fn mode(mut self, mode: Mode) -> Box<Self> {
-        self.mode = Some(mode);
-        Box::new(self)
-    }
-
-    /// Assigns id labels to each datum. These ids for object constancy of data points during
-    /// animation. Should be an array of strings, not numbers or any other type.
-    pub fn ids<S: AsRef<str>>(mut self, ids: Vec<S>) -> Box<Self> {
-        let ids = private::owned_string_vector(ids);
-        self.ids = Some(ids);
-        Box::new(self)
-    }
-
-    /// Alternate to `x`. Builds a linear space of x coordinates. Use with `dx` where `x0` is the
-    /// starting coordinate and `dx` the step.
-    pub fn x0<V: Into<private::NumOrString>>(mut self, x0: V) -> Box<Self> {
-        self.x0 = Some(x0.into());
-        Box::new(self)
-    }
-
-    /// Sets the x coordinate step. See `x0` for more info.
-    pub fn dx(mut self, dx: f64) -> Box<Self> {
-        self.dx = Some(dx);
-        Box::new(self)
-    }
-
-    /// Alternate to `y`. Builds a linear space of y coordinates. Use with `dy` where `y0` is the
-    /// starting coordinate and `dy` the step.
-    pub fn y0<V: Into<private::NumOrString>>(mut self, y0: V) -> Box<Self> {
-        self.y0 = Some(y0.into());
-        Box::new(self)
-    }
-
-    /// Sets the y coordinate step. See `y0` for more info.
-    pub fn dy(mut self, dy: f64) -> Box<Self> {
-        self.dy = Some(dy);
-        Box::new(self)
-    }
-
-    /// Sets text elements associated with each (x,y) pair. If a single string, the same string
-    /// appears over all the data points. If an array of string, the items are mapped in order to
-    /// the this trace's (x,y) coordinates. If the trace `HoverInfo` contains a "text" flag and
-    /// `hover_text` is not set, these elements will be seen in the hover labels.
-    pub fn text(mut self, text: &str) -> Box<Self> {
-        self.text = Some(Dim::Scalar(text.to_string()));
-        Box::new(self)
-    }
-
-    /// Sets text elements associated with each (x,y) pair. If a single string, the same string
-    /// appears over all the data points. If an array of string, the items are mapped in order to
-    /// the this trace's (x,y) coordinates. If trace `HoverInfo` contains a "text" flag and
-    /// `hover_text` is not set, these elements will be seen in the hover labels.
-    pub fn text_array<S: AsRef<str>>(mut self, text: Vec<S>) -> Box<Self> {
-        let text = private::owned_string_vector(text);
-        self.text = Some(Dim::Vector(text));
-        Box::new(self)
-    }
-
-    /// Sets the positions of the `text` elements with respects to the (x,y) coordinates.
-    pub fn text_position(mut self, text_position: Position) -> Box<Self> {
-        self.text_position = Some(Dim::Scalar(text_position));
-        Box::new(self)
-    }
-
-    /// Sets the positions of the `text` elements with respects to the (x,y) coordinates.
-    pub fn text_position_array(mut self, text_position: Vec<Position>) -> Box<Self> {
-        self.text_position = Some(Dim::Vector(text_position));
-        Box::new(self)
-    }
-
-    /// Template string used for rendering the information text that appear on points. Note that
-    /// this will override `textinfo`. Variables are inserted using %{variable}, for example
-    /// "y: %{y}". Numbers are formatted using d3-format's syntax %{variable:d3-format}, for example
-    /// "Price: %{y:$.2f}". See [format](https://github.com/d3/d3-3.x-api-reference/blob/master/Formatting.md#d3)
-    /// for details on the formatting syntax. Dates are formatted using d3-time-format's syntax
-    /// %{variable|d3-time-format}, for example "Day: %{2019-01-01|%A}".
-    /// See [format](https://github.com/d3/d3-3.x-api-reference/blob/master/Time-Formatting.md#format) for details
-    /// on the date formatting syntax. Every attributes that can be specified per-point (the ones
-    /// that are `arrayOk: true`) are available.
-    pub fn text_template(mut self, text_template: &str) -> Box<Self> {
-        self.text_template = Some(Dim::Scalar(text_template.to_string()));
-        Box::new(self)
-    }
-
-    /// Template string used for rendering the information text that appear on points. Note that
-    /// this will override `textinfo`. Variables are inserted using %{variable}, for example
-    /// "y: %{y}". Numbers are formatted using d3-format's syntax %{variable:d3-format}, for example
-    /// "Price: %{y:$.2f}". See [format](https://github.com/d3/d3-3.x-api-reference/blob/master/Formatting.md#d3)
-    /// for details on the formatting syntax. Dates are formatted using d3-time-format's syntax
-    /// %{variable|d3-time-format}, for example "Day: %{2019-01-01|%A}".
-    /// See [format](https://github.com/d3/d3-3.x-api-reference/blob/master/Time-Formatting.md#format) for details
-    /// on the date formatting syntax. Every attributes that can be specified per-point (the ones
-    /// that are `arrayOk: true`) are available.
-    pub fn text_template_array<S: AsRef<str>>(mut self, text_template: Vec<S>) -> Box<Self> {
-        let text_template = private::owned_string_vector(text_template);
-        self.text_template = Some(Dim::Vector(text_template));
-        Box::new(self)
-    }
-
-    /// Sets hover text elements associated with each (x,y) pair. If a single string, the same
-    /// string appears over all the data points. If an array of string, the items are mapped in
-    /// order to the this trace's (x,y) coordinates. To be seen, trace `HoverInfo` must contain a
-    /// "Text" flag.
-    pub fn hover_text(mut self, hover_text: &str) -> Box<Self> {
-        self.hover_text = Some(Dim::Scalar(hover_text.to_string()));
-        Box::new(self)
-    }
-
-    /// Sets hover text elements associated with each (x,y) pair. If a single string, the same
-    /// string appears over all the data points. If an array of string, the items are mapped in
-    /// order to the this trace's (x,y) coordinates. To be seen, trace `HoverInfo` must contain a
-    /// "Text" flag.
-    pub fn hover_text_array<S: AsRef<str>>(mut self, hover_text: Vec<S>) -> Box<Self> {
-        let hover_text = private::owned_string_vector(hover_text);
-        self.hover_text = Some(Dim::Vector(hover_text));
-        Box::new(self)
-    }
-
-    /// Determines which trace information appear on hover. If `HoverInfo::None` or `HoverInfo::Skip`
-    /// are set, no information is displayed upon hovering. But, if `HoverInfo::None` is set, click
-    /// and hover events are still fired.
-    pub fn hover_info(mut self, hover_info: HoverInfo) -> Box<Self> {
-        self.hover_info = Some(hover_info);
-        Box::new(self)
-    }
-
-    /// Template string used for rendering the information that appear on hover box. Note that this
-    /// will override `HoverInfo`. Variables are inserted using %{variable}, for example "y: %{y}".
-    /// Numbers are formatted using d3-format's syntax %{variable:d3-format}, for example
-    /// "Price: %{y:$.2f}".
-    /// https://github.com/d3/d3-3.x-api-reference/blob/master/Formatting.md#d3_format for details
-    /// on the formatting syntax. Dates are formatted using d3-time-format's syntax
-    /// %{variable|d3-time-format}, for example "Day: %{2019-01-01|%A}".
-    /// https://github.com/d3/d3-3.x-api-reference/blob/master/Time-Formatting.md#format for details
-    /// on the date formatting syntax. The variables available in `hovertemplate` are the ones
-    /// emitted as event data described at this link https://plotly.com/javascript/plotlyjs-events/#event-data.
-    /// Additionally, every attributes that can be specified per-point (the ones that are
-    /// `arrayOk: true`) are available. Anything contained in tag `<extra>` is displayed in the
-    /// secondary box, for example "<extra>{fullData.name}</extra>". To hide the secondary box
-    /// completely, use an empty tag `<extra></extra>`.
-    pub fn hover_template(mut self, hover_template: &str) -> Box<Self> {
-        self.hover_template = Some(Dim::Scalar(hover_template.to_string()));
-        Box::new(self)
-    }
-
-    /// Template string used for rendering the information that appear on hover box. Note that this
-    /// will override `HoverInfo`. Variables are inserted using %{variable}, for example "y: %{y}".
-    /// Numbers are formatted using d3-format's syntax %{variable:d3-format}, for example
-    /// "Price: %{y:$.2f}".
-    /// https://github.com/d3/d3-3.x-api-reference/blob/master/Formatting.md#d3_format for details
-    /// on the formatting syntax. Dates are formatted using d3-time-format's syntax
-    /// %{variable|d3-time-format}, for example "Day: %{2019-01-01|%A}".
-    /// https://github.com/d3/d3-3.x-api-reference/blob/master/Time-Formatting.md#format for details
-    /// on the date formatting syntax. The variables available in `hovertemplate` are the ones
-    /// emitted as event data described at this link https://plotly.com/javascript/plotlyjs-events/#event-data.
-    /// Additionally, every attributes that can be specified per-point (the ones that are
-    /// `arrayOk: true`) are available. Anything contained in tag `<extra>` is displayed in the
-    /// secondary box, for example "<extra>{fullData.name}</extra>". To hide the secondary box
-    /// completely, use an empty tag `<extra></extra>`.
-    pub fn hover_template_array<S: AsRef<str>>(mut self, hover_template: Vec<S>) -> Box<Self> {
-        let hover_template = private::owned_string_vector(hover_template);
-        self.hover_template = Some(Dim::Vector(hover_template));
-        Box::new(self)
-    }
-
-    /// Assigns extra meta information associated with this trace that can be used in various text
-    /// attributes. Attributes such as trace `name`, graph, axis and colorbar `title.text`,
-    /// annotation `text` `rangeselector`, `updatemenues` and `sliders` `label` text all support
-    /// `meta`. To access the trace `meta` values in an attribute in the same trace, simply use
-    /// `%{meta[i]}` where `i` is the index or key of the `meta` item in question. To access trace
-    /// `meta` in layout attributes, use `%{data[n[.meta[i]}` where `i` is the index or key of the
-    /// `meta` and `n` is the trace index.
-    pub fn meta<V: Into<private::NumOrString>>(mut self, meta: V) -> Box<Self> {
-        self.meta = Some(meta.into());
-        Box::new(self)
-    }
-
-    /// Assigns extra data each datum. This may be useful when listening to hover, click and
-    /// selection events. Note that, "scatter" traces also appends customdata items in the markers
-    /// DOM elements
-    pub fn custom_data<V: Into<private::NumOrString> + Clone>(
-        mut self,
-        custom_data: Vec<V>,
-    ) -> Box<Self> {
-        self.custom_data = Some(custom_data.into());
-        Box::new(self)
-    }
-
-    /// Sets a reference between this trace's x coordinates and a 2D cartesian x axis. If "x" (
-    /// the default value), the x coordinates refer to `Layout::x_axis`. If "x2", the x coordinates
-    /// refer to `Layout::x_axis2`, and so on.
-    pub fn x_axis(mut self, axis: &str) -> Box<Self> {
-        self.x_axis = Some(axis.to_string());
-        Box::new(self)
-    }
-
-    /// Sets a reference between this trace's y coordinates and a 2D cartesian y axis. If "y"
-    /// (the default value), the y coordinates refer to `Layout::y_axis`. If "y2", the y coordinates
-    /// refer to `Layout::y_axis2`, and so on.
-    pub fn y_axis(mut self, axis: &str) -> Box<Self> {
-        self.y_axis = Some(axis.to_string());
-        Box::new(self)
-    }
-
-    /// Only relevant when `stackgroup` is used, and only the first `orientation` found in the
-    /// `stackgroup` will be used - including if `visible` is "legendonly" but not if it is `false`.
-    /// Sets the stacking direction. With "v" ("h"), the y (x) values of subsequent traces are
-    /// added. Also affects the default value of `fill`.
-    pub fn orientation(mut self, orientation: Orientation) -> Box<Self> {
-        self.orientation = Some(orientation);
-        Box::new(self)
-    }
-
-    /// Only relevant when `stackgroup` is used, and only the first `groupnorm` found in the
-    /// `stackgroup` will be used - including if `visible` is "legendonly" but not if it is `false`.
-    /// Sets the normalization for the sum of this `stackgroup`. With "fraction", the value of each
-    /// trace at each location is divided by the sum of all trace values at that location. "percent"
-    /// is the same but multiplied by 100 to show percentages. If there are multiple subplots, or
-    /// multiple `stackgroup`s on one subplot, each will be normalized within its own set.
-    pub fn group_norm(mut self, group_norm: GroupNorm) -> Box<Self> {
-        self.group_norm = Some(group_norm);
-        Box::new(self)
-    }
-
-    /// Set several scatter traces (on the same subplot) to the same stackgroup in order to add
-    /// their y values (or their x values if `orientation` is "h"). If blank or omitted this trace
-    /// will not be stacked. Stacking also turns `fill` on by default, using "tonexty" ("tonextx")
-    /// if `orientation` is "h" ("v") and sets the default `mode` to "lines" irrespective of point
-    /// count. You can only stack on a numeric (linear or log) axis. Traces in a `stackgroup` will
-    /// only fill to (or be filled to) other traces in the same group. With multiple `stackgroup`s
-    /// or some traces stacked and some not, if fill-linked traces are not already consecutive, the
-    /// later ones will be pushed down in the drawing order.
-    pub fn stack_group(mut self, stack_group: &str) -> Box<Self> {
-        self.stack_group = Some(stack_group.to_string());
-        Box::new(self)
-    }
-
-    /// Determines how points are displayed and joined.
-    pub fn marker(mut self, marker: Marker) -> Box<Self> {
-        self.marker = Some(marker);
-        Box::new(self)
-    }
-
-    /// Line display properties.
-    pub fn line(mut self, line: Line) -> Box<Self> {
-        self.line = Some(line);
-        Box::new(self)
-    }
-
-    /// Sets the text font.
-    pub fn text_font(mut self, text_font: Font) -> Box<Self> {
-        self.text_font = Some(text_font);
-        Box::new(self)
-    }
-
-    /// x-axis error display properties.
-    pub fn error_x(mut self, error_x: ErrorData) -> Box<Self> {
-        self.error_x = Some(error_x);
-        Box::new(self)
-    }
-
-    /// y-axis error display properties.
-    pub fn error_y(mut self, error_y: ErrorData) -> Box<Self> {
-        self.error_y = Some(error_y);
-        Box::new(self)
-    }
-
-    /// Determines whether or not markers and text nodes are clipped about the subplot axes. To show
-    /// markers and text nodes above axis lines and tick labels, make sure to set `xaxis.layer` and
-    /// `yaxis.layer` to "below traces".
-    pub fn clip_on_axis(mut self, clip_on_axis: bool) -> Box<Self> {
-        self.clip_on_axis = Some(clip_on_axis);
-        Box::new(self)
-    }
-
-    /// Determines whether or not gaps (i.e. {nan} or missing values) in the provided data arrays
-    /// are connected.
-    pub fn connect_gaps(mut self, connect_gaps: bool) -> Box<Self> {
-        self.connect_gaps = Some(connect_gaps);
-        Box::new(self)
-    }
-
-    /// Sets the area to fill with a solid color. Defaults to "none" unless this trace is stacked,
-    /// then it gets "tonexty" ("tonextx") if `orientation` is "v" ("h") Use with `fillcolor` if not
-    /// "none". "tozerox" and "tozeroy" fill to x=0 and y=0 respectively. "tonextx" and "tonexty"
-    /// fill between the endpoints of this trace and the endpoints of the trace before it,
-    /// connecting those endpoints with straight lines (to make a stacked area graph); if there is
-    /// no trace before it, they behave like "tozerox" and "tozeroy". "toself" connects the
-    /// endpoints of the trace (or each segment of the trace if it has gaps) into a closed shape.
-    /// "tonext" fills the space between two traces if one completely encloses the other
-    /// (eg consecutive contour lines), and behaves like "toself" if there is no trace before it.
-    /// "tonext" should not be used if one trace does not enclose the other. Traces in a
-    /// `stackgroup` will only fill to (or be filled to) other traces in the same group. With
-    /// multiple `stackgroup`s or some traces stacked and some not, if fill-linked traces are not
-    /// already consecutive, the later ones will be pushed down in the drawing order.
-    pub fn fill(mut self, fill: Fill) -> Box<Self> {
-        self.fill = Some(fill);
-        Box::new(self)
-    }
-
-    /// Sets the fill color. Defaults to a half-transparent variant of the line color, marker color,
-    /// or marker line color, whichever is available.
-    pub fn fill_color<C: Color>(mut self, fill_color: C) -> Box<Self> {
-        self.fill_color = Some(Box::new(fill_color));
-        Box::new(self)
-    }
-
-    /// Properties of label displayed on mouse hover.
-    pub fn hover_label(mut self, hover_label: Label) -> Box<Self> {
-        self.hover_label = Some(hover_label);
-        Box::new(self)
-    }
-
-    /// Do the hover effects highlight individual points (markers or line points) or do they
-    /// highlight filled regions? If the fill is "toself" or "tonext" and there are no markers or
-    /// text, then the default is "fills", otherwise it is "points".
-    pub fn hover_on(mut self, hover_on: HoverOn) -> Box<Self> {
-        self.hover_on = Some(hover_on);
-        Box::new(self)
-    }
-
-    /// Only relevant when `stack_group` is used, and only the first `stack_gaps` found in the
-    /// `stackgroup` will be used - including if `visible` is set to `Visible::LegendOnly` but not
-    /// if it is set to `Visible::False`.
-    /// Determines how we handle locations at which other traces in this group have data but this
-    /// one does not. With "infer zero" we insert a zero at these locations. With "interpolate" we
-    /// linearly interpolate between existing values, and extrapolate a constant beyond the existing
-    /// values.
-    pub fn stack_gaps(mut self, stack_gaps: StackGaps) -> Box<Self> {
-        self.stack_gaps = Some(stack_gaps);
-        Box::new(self)
-    }
-
-    /// Sets the calendar system to use with `x` date data.
-    pub fn x_calendar(mut self, x_calendar: Calendar) -> Box<Self> {
-        self.x_calendar = Some(x_calendar);
-        Box::new(self)
-    }
-
-    /// Sets the calendar system to use with `y` date data.
-    pub fn y_calendar(mut self, y_calendar: Calendar) -> Box<Self> {
-        self.y_calendar = Some(y_calendar);
         Box::new(self)
     }
 }

--- a/plotly/src/traces/scatter.rs
+++ b/plotly/src/traces/scatter.rs
@@ -53,6 +53,7 @@ pub enum StackGaps {
 /// ```
 #[serde_with::skip_serializing_none]
 #[derive(Serialize, Clone, Debug, FieldSetter)]
+#[field_setter(box_self, kind = "trace")]
 pub struct Scatter<X, Y>
 where
     X: Serialize + Clone + 'static,
@@ -82,7 +83,6 @@ where
     /// Assigns id labels to each datum. These ids for object constancy of data points during
     /// animation. Should be an array of strings, not numbers or any other type.
     ids: Option<Vec<String>>,
-    #[field_setter(skip)]
     x: Option<Vec<X>>,
     /// Alternate to `x`. Builds a linear space of x coordinates. Use with `dx` where `x0` is the
     /// starting coordinate and `dx` the step.
@@ -90,7 +90,6 @@ where
     /// Sets the x coordinate step. See `x0` for more info.
     dx: Option<f64>,
 
-    #[field_setter(skip)]
     y: Option<Vec<Y>>,
 
     /// Alternate to `y`. Builds a linear space of y coordinates. Use with `dy` where `y0` is the

--- a/plotly/src/traces/scatter.rs
+++ b/plotly/src/traces/scatter.rs
@@ -326,7 +326,7 @@ where
         array_traces: ArrayTraces,
     ) -> Vec<Box<dyn Trace>> {
         let mut traces: Vec<Box<dyn Trace>> = Vec::new();
-        let mut trace_vectors = private::trace_vectors_from(traces_matrix, array_traces);
+        let mut trace_vectors = crate::private::trace_vectors_from(traces_matrix, array_traces);
         trace_vectors.reverse();
         while !trace_vectors.is_empty() {
             let mut sc = Box::new(self.clone());

--- a/plotly/src/traces/scatter3d.rs
+++ b/plotly/src/traces/scatter3d.rs
@@ -16,7 +16,6 @@ use crate::{
 
 #[serde_with::skip_serializing_none]
 #[derive(Debug, FieldSetter, Clone, Serialize)]
-#[field_setter(no_box)]
 pub struct ProjectionCoord {
     opacity: Option<f64>,
     scale: Option<f64>,
@@ -31,7 +30,6 @@ impl ProjectionCoord {
 
 #[serde_with::skip_serializing_none]
 #[derive(Debug, FieldSetter, Clone, Serialize)]
-#[field_setter(no_box)]
 pub struct Projection {
     x: Option<ProjectionCoord>,
     y: Option<ProjectionCoord>,
@@ -81,6 +79,7 @@ pub enum SurfaceAxis {
 /// ```
 #[serde_with::skip_serializing_none]
 #[derive(Serialize, Clone, Debug, FieldSetter)]
+#[field_setter(box_self, kind = "trace")]
 pub struct Scatter3D<X, Y, Z>
 where
     X: Serialize + Clone,
@@ -122,11 +121,8 @@ where
     /// animation. Should be an array of strings, not numbers or any other type.
     ids: Option<Vec<String>>,
 
-    #[field_setter(skip)]
     x: Option<Vec<X>>,
-    #[field_setter(skip)]
     y: Option<Vec<Y>>,
-    #[field_setter(skip)]
     z: Option<Vec<Z>>,
 
     /// Sets the surface fill color.

--- a/plotly/src/traces/scatter3d.rs
+++ b/plotly/src/traces/scatter3d.rs
@@ -2,6 +2,7 @@
 
 #[cfg(feature = "plotly_ndarray")]
 use ndarray::{Array, Ix1};
+use plotly_derive::FieldSetter;
 use serde::Serialize;
 
 use crate::{
@@ -14,7 +15,8 @@ use crate::{
 };
 
 #[serde_with::skip_serializing_none]
-#[derive(Debug, Default, Clone, Serialize)]
+#[derive(Debug, FieldSetter, Clone, Serialize)]
+#[field_setter(no_box)]
 pub struct ProjectionCoord {
     opacity: Option<f64>,
     scale: Option<f64>,
@@ -25,28 +27,11 @@ impl ProjectionCoord {
     pub fn new() -> Self {
         Default::default()
     }
-
-    /// Sets the projection opacity.
-    pub fn opacity(mut self, opacity: f64) -> Self {
-        self.opacity = Some(opacity);
-        self
-    }
-
-    /// Sets the scale factor determining the size of the projection marker points.
-    pub fn scale(mut self, scale: f64) -> Self {
-        self.scale = Some(scale);
-        self
-    }
-
-    /// Sets whether or not projections are shown along the current axis.
-    pub fn show(mut self, show: bool) -> Self {
-        self.show = Some(show);
-        self
-    }
 }
 
 #[serde_with::skip_serializing_none]
-#[derive(Debug, Default, Clone, Serialize)]
+#[derive(Debug, FieldSetter, Clone, Serialize)]
+#[field_setter(no_box)]
 pub struct Projection {
     x: Option<ProjectionCoord>,
     y: Option<ProjectionCoord>,
@@ -56,21 +41,6 @@ pub struct Projection {
 impl Projection {
     pub fn new() -> Self {
         Default::default()
-    }
-
-    pub fn x(mut self, x: ProjectionCoord) -> Self {
-        self.x = Some(x);
-        self
-    }
-
-    pub fn y(mut self, y: ProjectionCoord) -> Self {
-        self.y = Some(y);
-        self
-    }
-
-    pub fn z(mut self, z: ProjectionCoord) -> Self {
-        self.z = Some(z);
-        self
     }
 }
 
@@ -110,124 +80,175 @@ pub enum SurfaceAxis {
 /// assert_eq!(serde_json::to_value(trace).unwrap(), expected);
 /// ```
 #[serde_with::skip_serializing_none]
-#[derive(Serialize, Clone, Debug)]
+#[derive(Serialize, Clone, Debug, FieldSetter)]
 pub struct Scatter3D<X, Y, Z>
 where
     X: Serialize + Clone,
     Y: Serialize + Clone,
     Z: Serialize + Clone,
 {
+    #[field_setter(default = "PlotType::Scatter3D")]
     r#type: PlotType,
+    /// Sets the trace name. The trace name is used as the label for the trace in the legend, as well
+    /// as when the trace is hovered hover.
     name: Option<String>,
+    /// Determines whether or not this trace is visible. If `Visible::LegendOnly`, the trace is not
+    /// drawn, but can appear as a legend item (provided that the legend itself is visible).
     visible: Option<Visible>,
+    /// Determines whether or not an item corresponding to this trace is shown in the legend.
     #[serde(rename = "showlegend")]
     show_legend: Option<bool>,
+    /// Sets the legend group for this trace. Traces part of the same legend group show/hide at the
+    /// same time when toggling legend items.
     #[serde(rename = "legendgroup")]
     legend_group: Option<String>,
+    /// Sets the legend rank for this trace. Items and groups with smaller ranks are presented on top/left side while with
+    /// `"reversed" `legend.traceorder` they are on bottom/right side. The default legendrank is 1000, so that you
+    /// can use ranks less than 1000 to place certain items before all unranked items, and ranks greater than 1000 to
+    /// go after all unranked items.
     #[serde(rename = "legendrank")]
     legend_rank: Option<usize>,
+    /// Sets the `LegendGroupTitle` object for the trace.
     #[serde(rename = "legendgrouptitle")]
     legend_group_title: Option<LegendGroupTitle>,
+    /// Sets the opacity of the trace.
     opacity: Option<f64>,
+    /// Determines the drawing mode for this scatter trace. If the provided `Mode` includes
+    /// "Text" then the `text` elements appear at the coordinates. Otherwise, the `text` elements
+    /// appear on hover. If there are less than 20 points and the trace is not stacked then the
+    /// default is `Mode::LinesMarkers`, otherwise it is `Mode::Lines`.
     mode: Option<Mode>,
+    /// Assigns id labels to each datum. These ids for object constancy of data points during
+    /// animation. Should be an array of strings, not numbers or any other type.
     ids: Option<Vec<String>>,
 
+    #[field_setter(skip)]
     x: Option<Vec<X>>,
+    #[field_setter(skip)]
     y: Option<Vec<Y>>,
+    #[field_setter(skip)]
     z: Option<Vec<Z>>,
 
+    /// Sets the surface fill color.
     #[serde(rename = "surfacecolor")]
     surface_color: Option<Box<dyn Color>>,
+    /// Sets text element associated with each (x, y, z) triplet. The same tet will be applied to each data
+    /// point. If the trace `HoverInfo` contains a "text" flag and `hover_text` is not set, these elements
+    /// will be seen in the hover labels.
     text: Option<Dim<String>>,
+    /// Sets the positions of the `text` elements with respects to the (x, y) coordinates.
     #[serde(rename = "textposition")]
     text_position: Option<Dim<Position>>,
+    /// Template string used for rendering the information text that appear on points. Note that
+    /// this will override `textinfo`. Variables are inserted using %{variable}, for example
+    /// "y: %{y}". Numbers are formatted using d3-format's syntax %{variable:d3-format}, for example
+    /// "Price: %{y:$.2f}". See [format](https://github.com/d3/d3-3.x-api-reference/blob/master/Formatting.md#d3)
+    /// for details on the formatting syntax. Dates are formatted using d3-time-format's syntax
+    /// %{variable|d3-time-format}, for example "Day: %{2019-01-01|%A}".
+    /// See [format](https://github.com/d3/d3-3.x-api-reference/blob/master/Time-Formatting.md#format) for details
+    /// on the date formatting syntax. Every attributes that can be specified per-point (the ones
+    /// that are `arrayOk: true`) are available.
     #[serde(rename = "texttemplate")]
     text_template: Option<Dim<String>>,
+    /// Sets hover text elements associated with each (x, y, z) triplet. The same text will be associated
+    /// with all datas points. To be seen, the trace `hover_info` must contain a "Text" flag.
     #[serde(rename = "hovertext")]
     hover_text: Option<Dim<String>>,
+    /// Determines which trace information appears on hover. If `HoverInfo::None` or `HoverInfo::Skip`
+    /// are set, no information is displayed upon hovering. But, if `HoverInfo::None` is set, click
+    /// and hover events are still fired.
     #[serde(rename = "hoverinfo")]
     hover_info: Option<HoverInfo>,
+    /// Template string used for rendering the information that appear on hover box. Note that this
+    /// will override `HoverInfo`. Variables are inserted using %{variable}, for example "y: %{y}".
+    /// Numbers are formatted using d3-format's syntax %{variable:d3-format}, for example
+    /// "Price: %{y:$.2f}".
+    /// https://github.com/d3/d3-3.x-api-reference/blob/master/Formatting.md#d3_format for details
+    /// on the formatting syntax. Dates are formatted using d3-time-format's syntax
+    /// %{variable|d3-time-format}, for example "Day: %{2019-01-01|%A}".
+    /// https://github.com/d3/d3-3.x-api-reference/blob/master/Time-Formatting.md#format for details
+    /// on the date formatting syntax. The variables available in `hovertemplate` are the ones
+    /// emitted as event data described at this link https://plotly.com/javascript/plotlyjs-events/#event-data.
+    /// Additionally, every attributes that can be specified per-point (the ones that are
+    /// `arrayOk: true`) are available. Anything contained in tag `<extra>` is displayed in the
+    /// secondary box, for example "<extra>{fullData.name}</extra>". To hide the secondary box
+    /// completely, use an empty tag `<extra></extra>`.
     #[serde(rename = "hovertemplate")]
     hover_template: Option<Dim<String>>,
+    /// Sets the hover text formatting rulefor `x` using d3 formatting mini-languages which are very similar
+    /// to those in Python. For numbers, see: https://github.com/d3/d3-format/tree/v1.4.5#d3-format. And for
+    /// dates see: https://github.com/d3/d3-time-format/tree/v2.2.3#locale_format. We add two items to d3's
+    /// date formatter: "%h" for half of the year as a decimal number as well as "%{n}f" for fractional seconds
+    /// with n digits. For example, "2016-10-13 09:15:23.456" with tickformat "%H~%M~%S.%2f" would display
+    /// "09~15~23.46". By default the values are formatted using `x_axis.hover_format`.
     #[serde(rename = "xhoverformat")]
     x_hover_format: Option<String>,
+    /// Sets the hover text formatting rulefor `y` using d3 formatting mini-languages which are very similar
+    /// to those in Python. For numbers, see: https://github.com/d3/d3-format/tree/v1.4.5#d3-format. And for
+    /// dates see: https://github.com/d3/d3-time-format/tree/v2.2.3#locale_format. We add two items to d3's
+    /// date formatter: "%h" for half of the year as a decimal number as well as "%{n}f" for fractional seconds
+    /// with n digits. For example, "2016-10-13 09:15:23.456" with tickformat "%H~%M~%S.%2f" would display
+    /// "09~15~23.46". By default the values are formatted using `y_axis.hover_format`.
     #[serde(rename = "yhoverformat")]
     y_hover_format: Option<String>,
+    /// Sets the hover text formatting rulefor `z` using d3 formatting mini-languages which are very similar
+    /// to those in Python. For numbers, see: https://github.com/d3/d3-format/tree/v1.4.5#d3-format. And for
+    /// dates see: https://github.com/d3/d3-time-format/tree/v2.2.3#locale_format. We add two items to d3's
+    /// date formatter: "%h" for half of the year as a decimal number as well as "%{n}f" for fractional seconds
+    /// with n digits. For example, "2016-10-13 09:15:23.456" with tickformat "%H~%M~%S.%2f" would display
+    /// "09~15~23.46". By default the values are formatted using `z_axis.hover_format`.
     #[serde(rename = "zhoverformat")]
     z_hover_format: Option<String>,
 
+    /// Assigns extra meta information associated with this trace that can be used in various text
+    /// attributes. Attributes such as trace `name`, graph, axis and colorbar `title.text`,
+    /// annotation `text` `rangeselector`, `updatemenues` and `sliders` `label` text all support
+    /// `meta`. To access the trace `meta` values in an attribute in the same trace, simply use
+    /// `%{meta[i]}` where `i` is the index or key of the `meta` item in question. To access trace
+    /// `meta` in layout attributes, use `%{data[n[.meta[i]}` where `i` is the index or key of the
+    /// `meta` and `n` is the trace index.
     meta: Option<private::NumOrString>,
+    /// Assigns extra data each datum. This may be useful when listening to hover, click and
+    /// selection events. Note that, "scatter" traces also appends customdata items in the markers
+    /// DOM elements.
     #[serde(rename = "customdata")]
     custom_data: Option<private::NumOrStringCollection>,
+    /// Sets a reference between this trace's 3D coordinate system and a 3D scene. If "scene" (the
+    /// default value), the (x,y,z) coordinates refer to `layout.scene`. If "scene2", the (x, y, z)
+    /// coordinates refer to `layout.scene2`, and so on.
     scene: Option<String>,
+    /// Determines how points are displayed and joined.
     marker: Option<Marker>,
+    /// Line display properties.
     line: Option<Line>,
+    /// x-axis error display properties.
     error_x: Option<ErrorData>,
+    /// y-axis error display properties.
     error_y: Option<ErrorData>,
+    /// z-axis error display properties.
     error_z: Option<ErrorData>,
+    /// Determines whether or not gaps (i.e. {nan} or missing values) in the provided data arrays
+    /// are connected.
     #[serde(rename = "connectgaps")]
     connect_gaps: Option<bool>,
+    /// Properties of label displayed on mouse hover.
     #[serde(rename = "hoverlabel")]
     hover_label: Option<Label>,
+    /// Configure the projection for each axis.
     projection: Option<Projection>,
+    /// If `SurfaceAxis::MinusOne`, the scatter points are not filled with a surface. If one of the remaining
+    /// three variants, the scatter points are filled with a Delaunay surface about the x, y, z respectively.
     #[serde(rename = "surfaceaxis")]
     surface_axis: Option<SurfaceAxis>,
+    /// Sets the calendar system to use with `x` date data.
     #[serde(rename = "xcalendar")]
     x_calendar: Option<Calendar>,
+    /// Sets the calendar system to use with `y` date data.
     #[serde(rename = "ycalendar")]
     y_calendar: Option<Calendar>,
+    /// Sets the calendar system to use with `z` date data.
     #[serde(rename = "zcalendar")]
     z_calendar: Option<Calendar>,
-}
-
-impl<X, Y, Z> Default for Scatter3D<X, Y, Z>
-where
-    X: Serialize + Default + Clone,
-    Y: Serialize + Default + Clone,
-    Z: Serialize + Default + Clone,
-{
-    fn default() -> Self {
-        Self {
-            r#type: PlotType::Scatter3D,
-            name: None,
-            visible: None,
-            show_legend: None,
-            legend_group: None,
-            legend_rank: None,
-            legend_group_title: None,
-            opacity: None,
-            mode: None,
-            ids: None,
-            x: None,
-            y: None,
-            z: None,
-            surface_color: None,
-            text: None,
-            text_position: None,
-            text_template: None,
-            hover_text: None,
-            hover_info: None,
-            hover_template: None,
-            x_hover_format: None,
-            y_hover_format: None,
-            z_hover_format: None,
-            meta: None,
-            custom_data: None,
-            scene: None,
-            marker: None,
-            line: None,
-            error_x: None,
-            error_y: None,
-            error_z: None,
-            connect_gaps: None,
-            hover_label: None,
-            projection: None,
-            surface_axis: None,
-            x_calendar: None,
-            y_calendar: None,
-            z_calendar: None,
-        }
-    }
 }
 
 impl<X, Y, Z> Scatter3D<X, Y, Z>
@@ -255,335 +276,6 @@ where
             z: Some(z.to_vec()),
             ..Default::default()
         })
-    }
-
-    /// Sets the trace name. The trace name is used as the label for the trace in the legend, as well
-    /// as when the trace is hovered hover.
-    pub fn name(mut self, name: &str) -> Box<Self> {
-        self.name = Some(name.to_string());
-        Box::new(self)
-    }
-
-    /// Determines whether or not this trace is visible. If `Visible::LegendOnly`, the trace is not
-    /// drawn, but can appear as a legend item (provided that the legend itself is visible).
-    pub fn visible(mut self, visible: Visible) -> Box<Self> {
-        self.visible = Some(visible);
-        Box::new(self)
-    }
-
-    /// Determines whether or not an item corresponding to this trace is shown in the legend.
-    pub fn show_legend(mut self, show_legend: bool) -> Box<Self> {
-        self.show_legend = Some(show_legend);
-        Box::new(self)
-    }
-
-    /// Sets the legend group for this trace. Traces part of the same legend group show/hide at the
-    /// same time when toggling legend items.
-    pub fn legend_group(mut self, legend_group: &str) -> Box<Self> {
-        self.legend_group = Some(legend_group.to_string());
-        Box::new(self)
-    }
-
-    /// Sets the `LegendGroupTitle` object for the trace.
-    pub fn legend_group_title(mut self, legend_group_title: LegendGroupTitle) -> Box<Self> {
-        self.legend_group_title = Some(legend_group_title);
-        Box::new(self)
-    }
-
-    /// Sets the legend rank for this trace. Items and groups with smaller ranks are presented on top/left side while with
-    /// `"reversed" `legend.traceorder` they are on bottom/right side. The default legendrank is 1000, so that you
-    /// can use ranks less than 1000 to place certain items before all unranked items, and ranks greater than 1000 to
-    /// go after all unranked items.
-    pub fn legend_rank(mut self, legend_rank: usize) -> Box<Self> {
-        self.legend_rank = Some(legend_rank);
-        Box::new(self)
-    }
-
-    /// Sets the opacity of the trace.
-    pub fn opacity(mut self, opacity: f64) -> Box<Self> {
-        self.opacity = Some(opacity);
-        Box::new(self)
-    }
-
-    /// Determines the drawing mode for this scatter trace. If the provided `Mode` includes
-    /// "Text" then the `text` elements appear at the coordinates. Otherwise, the `text` elements
-    /// appear on hover. If there are less than 20 points and the trace is not stacked then the
-    /// default is `Mode::LinesMarkers`, otherwise it is `Mode::Lines`.
-    pub fn mode(mut self, mode: Mode) -> Box<Self> {
-        self.mode = Some(mode);
-        Box::new(self)
-    }
-
-    /// Assigns id labels to each datum. These ids for object constancy of data points during
-    /// animation. Should be an array of strings, not numbers or any other type.
-    pub fn ids<S: AsRef<str>>(mut self, ids: Vec<S>) -> Box<Self> {
-        let ids = private::owned_string_vector(ids);
-        self.ids = Some(ids);
-        Box::new(self)
-    }
-
-    /// Sets the surface fill color.
-    pub fn surface_color<C: Color>(mut self, color: C) -> Box<Self> {
-        self.surface_color = Some(Box::new(color));
-        Box::new(self)
-    }
-
-    /// Sets text element associated with each (x, y, z) triplet. The same tet will be applied to each data
-    /// point. If the trace `HoverInfo` contains a "text" flag and `hover_text` is not set, these elements
-    /// will be seen in the hover labels.
-    pub fn text(mut self, text: &str) -> Box<Self> {
-        self.text = Some(Dim::Scalar(text.to_string()));
-        Box::new(self)
-    }
-
-    /// Sets text elements associated with each (x, y, z) triplet. The items are mapped sequentially to
-    /// this trace's (x, y, z) coordinates. If trace `HoverInfo` contains a "text" flag and
-    /// `hover_text` is not set, these elements will be seen in the hover labels.
-    pub fn text_array<S: AsRef<str>>(mut self, text: Vec<S>) -> Box<Self> {
-        let text = private::owned_string_vector(text);
-        self.text = Some(Dim::Vector(text));
-        Box::new(self)
-    }
-
-    /// Sets the positions of the `text` elements with respects to the (x, y) coordinates.
-    pub fn text_position(mut self, text_position: Position) -> Box<Self> {
-        self.text_position = Some(Dim::Scalar(text_position));
-        Box::new(self)
-    }
-
-    /// Sets the positions of the `text` elements with respects to the (x, y) coordinates.
-    pub fn text_position_array(mut self, text_position: Vec<Position>) -> Box<Self> {
-        self.text_position = Some(Dim::Vector(text_position));
-        Box::new(self)
-    }
-
-    /// Template string used for rendering the information text that appear on points. Note that
-    /// this will override `textinfo`. Variables are inserted using %{variable}, for example
-    /// "y: %{y}". Numbers are formatted using d3-format's syntax %{variable:d3-format}, for example
-    /// "Price: %{y:$.2f}". See [format](https://github.com/d3/d3-3.x-api-reference/blob/master/Formatting.md#d3)
-    /// for details on the formatting syntax. Dates are formatted using d3-time-format's syntax
-    /// %{variable|d3-time-format}, for example "Day: %{2019-01-01|%A}".
-    /// See [format](https://github.com/d3/d3-3.x-api-reference/blob/master/Time-Formatting.md#format) for details
-    /// on the date formatting syntax. Every attributes that can be specified per-point (the ones
-    /// that are `arrayOk: true`) are available.
-    pub fn text_template(mut self, text_template: &str) -> Box<Self> {
-        self.text_template = Some(Dim::Scalar(text_template.to_string()));
-        Box::new(self)
-    }
-
-    /// Template string used for rendering the information text that appear on points. Note that
-    /// this will override `textinfo`. Variables are inserted using %{variable}, for example
-    /// "y: %{y}". Numbers are formatted using d3-format's syntax %{variable:d3-format}, for example
-    /// "Price: %{y:$.2f}". See [format](https://github.com/d3/d3-3.x-api-reference/blob/master/Formatting.md#d3)
-    /// for details on the formatting syntax. Dates are formatted using d3-time-format's syntax
-    /// %{variable|d3-time-format}, for example "Day: %{2019-01-01|%A}".
-    /// See [format](https://github.com/d3/d3-3.x-api-reference/blob/master/Time-Formatting.md#format) for details
-    /// on the date formatting syntax. Every attributes that can be specified per-point (the ones
-    /// that are `arrayOk: true`) are available.
-    pub fn text_template_array<S: AsRef<str>>(mut self, text_template: Vec<S>) -> Box<Self> {
-        let text_template = private::owned_string_vector(text_template);
-        self.text_template = Some(Dim::Vector(text_template));
-        Box::new(self)
-    }
-
-    /// Sets hover text elements associated with each (x, y, z) triplet. The same text will be associated
-    /// with all datas points. To be seen, the trace `hover_info` must contain a "Text" flag.
-    pub fn hover_text(mut self, hover_text: &str) -> Box<Self> {
-        self.hover_text = Some(Dim::Scalar(hover_text.to_string()));
-        Box::new(self)
-    }
-
-    /// Sets hover text elements associated with each (x, y, z) triplet. The items are mapped sequentially across
-    /// this trace's (x,y) coordinates. To be seen, the trace `hover_info` must contain a "Text" flag.
-    pub fn hover_text_array<S: AsRef<str>>(mut self, hover_text: Vec<S>) -> Box<Self> {
-        let hover_text = private::owned_string_vector(hover_text);
-        self.hover_text = Some(Dim::Vector(hover_text));
-        Box::new(self)
-    }
-
-    /// Determines which trace information appears on hover. If `HoverInfo::None` or `HoverInfo::Skip`
-    /// are set, no information is displayed upon hovering. But, if `HoverInfo::None` is set, click
-    /// and hover events are still fired.
-    pub fn hover_info(mut self, hover_info: HoverInfo) -> Box<Self> {
-        self.hover_info = Some(hover_info);
-        Box::new(self)
-    }
-
-    /// Template string used for rendering the information that appear on hover box. Note that this
-    /// will override `HoverInfo`. Variables are inserted using %{variable}, for example "y: %{y}".
-    /// Numbers are formatted using d3-format's syntax %{variable:d3-format}, for example
-    /// "Price: %{y:$.2f}".
-    /// https://github.com/d3/d3-3.x-api-reference/blob/master/Formatting.md#d3_format for details
-    /// on the formatting syntax. Dates are formatted using d3-time-format's syntax
-    /// %{variable|d3-time-format}, for example "Day: %{2019-01-01|%A}".
-    /// https://github.com/d3/d3-3.x-api-reference/blob/master/Time-Formatting.md#format for details
-    /// on the date formatting syntax. The variables available in `hovertemplate` are the ones
-    /// emitted as event data described at this link https://plotly.com/javascript/plotlyjs-events/#event-data.
-    /// Additionally, every attributes that can be specified per-point (the ones that are
-    /// `arrayOk: true`) are available. Anything contained in tag `<extra>` is displayed in the
-    /// secondary box, for example "<extra>{fullData.name}</extra>". To hide the secondary box
-    /// completely, use an empty tag `<extra></extra>`.
-    pub fn hover_template(mut self, hover_template: &str) -> Box<Self> {
-        self.hover_template = Some(Dim::Scalar(hover_template.to_string()));
-        Box::new(self)
-    }
-
-    /// Template string used for rendering the information that appear on hover box. Note that this
-    /// will override `HoverInfo`. Variables are inserted using %{variable}, for example "y: %{y}".
-    /// Numbers are formatted using d3-format's syntax %{variable:d3-format}, for example
-    /// "Price: %{y:$.2f}".
-    /// https://github.com/d3/d3-3.x-api-reference/blob/master/Formatting.md#d3_format for details
-    /// on the formatting syntax. Dates are formatted using d3-time-format's syntax
-    /// %{variable|d3-time-format}, for example "Day: %{2019-01-01|%A}".
-    /// https://github.com/d3/d3-3.x-api-reference/blob/master/Time-Formatting.md#format for details
-    /// on the date formatting syntax. The variables available in `hovertemplate` are the ones
-    /// emitted as event data described at this link https://plotly.com/javascript/plotlyjs-events/#event-data.
-    /// Additionally, every attributes that can be specified per-point (the ones that are
-    /// `arrayOk: true`) are available. Anything contained in tag `<extra>` is displayed in the
-    /// secondary box, for example "<extra>{fullData.name}</extra>". To hide the secondary box
-    /// completely, use an empty tag `<extra></extra>`.
-    pub fn hover_template_array<S: AsRef<str>>(mut self, hover_template: Vec<S>) -> Box<Self> {
-        let hover_template = private::owned_string_vector(hover_template);
-        self.hover_template = Some(Dim::Vector(hover_template));
-        Box::new(self)
-    }
-
-    /// Sets the hover text formatting rulefor `x` using d3 formatting mini-languages which are very similar
-    /// to those in Python. For numbers, see: https://github.com/d3/d3-format/tree/v1.4.5#d3-format. And for
-    /// dates see: https://github.com/d3/d3-time-format/tree/v2.2.3#locale_format. We add two items to d3's
-    /// date formatter: "%h" for half of the year as a decimal number as well as "%{n}f" for fractional seconds
-    /// with n digits. For example, "2016-10-13 09:15:23.456" with tickformat "%H~%M~%S.%2f" would display
-    /// "09~15~23.46". By default the values are formatted using `x_axis.hover_format`.
-    pub fn x_hover_format(mut self, hover_format: &str) -> Box<Self> {
-        self.x_hover_format = Some(hover_format.to_string());
-        Box::new(self)
-    }
-
-    /// Sets the hover text formatting rulefor `y` using d3 formatting mini-languages which are very similar
-    /// to those in Python. For numbers, see: https://github.com/d3/d3-format/tree/v1.4.5#d3-format. And for
-    /// dates see: https://github.com/d3/d3-time-format/tree/v2.2.3#locale_format. We add two items to d3's
-    /// date formatter: "%h" for half of the year as a decimal number as well as "%{n}f" for fractional seconds
-    /// with n digits. For example, "2016-10-13 09:15:23.456" with tickformat "%H~%M~%S.%2f" would display
-    /// "09~15~23.46". By default the values are formatted using `y_axis.hover_format`.
-    pub fn y_hover_format(mut self, hover_format: &str) -> Box<Self> {
-        self.y_hover_format = Some(hover_format.to_string());
-        Box::new(self)
-    }
-
-    /// Sets the hover text formatting rulefor `z` using d3 formatting mini-languages which are very similar
-    /// to those in Python. For numbers, see: https://github.com/d3/d3-format/tree/v1.4.5#d3-format. And for
-    /// dates see: https://github.com/d3/d3-time-format/tree/v2.2.3#locale_format. We add two items to d3's
-    /// date formatter: "%h" for half of the year as a decimal number as well as "%{n}f" for fractional seconds
-    /// with n digits. For example, "2016-10-13 09:15:23.456" with tickformat "%H~%M~%S.%2f" would display
-    /// "09~15~23.46". By default the values are formatted using `z_axis.hover_format`.
-    pub fn z_hover_format(mut self, hover_format: &str) -> Box<Self> {
-        self.z_hover_format = Some(hover_format.to_string());
-        Box::new(self)
-    }
-
-    /// Assigns extra meta information associated with this trace that can be used in various text
-    /// attributes. Attributes such as trace `name`, graph, axis and colorbar `title.text`,
-    /// annotation `text` `rangeselector`, `updatemenues` and `sliders` `label` text all support
-    /// `meta`. To access the trace `meta` values in an attribute in the same trace, simply use
-    /// `%{meta[i]}` where `i` is the index or key of the `meta` item in question. To access trace
-    /// `meta` in layout attributes, use `%{data[n[.meta[i]}` where `i` is the index or key of the
-    /// `meta` and `n` is the trace index.
-    pub fn meta<V: Into<private::NumOrString>>(mut self, meta: V) -> Box<Self> {
-        self.meta = Some(meta.into());
-        Box::new(self)
-    }
-
-    /// Assigns extra data each datum. This may be useful when listening to hover, click and
-    /// selection events. Note that, "scatter" traces also appends customdata items in the markers
-    /// DOM elements.
-    pub fn custom_data<V: Into<private::NumOrString> + Clone>(
-        mut self,
-        custom_data: Vec<V>,
-    ) -> Box<Self> {
-        self.custom_data = Some(custom_data.into());
-        Box::new(self)
-    }
-
-    /// Sets a reference between this trace's 3D coordinate system and a 3D scene. If "scene" (the
-    /// default value), the (x,y,z) coordinates refer to `layout.scene`. If "scene2", the (x, y, z)
-    /// coordinates refer to `layout.scene2`, and so on.
-    pub fn scene(mut self, scene: &str) -> Box<Self> {
-        self.scene = Some(scene.to_string());
-        Box::new(self)
-    }
-
-    /// Configure the projection for each axis.
-    pub fn projection(mut self, projection: Projection) -> Box<Self> {
-        self.projection = Some(projection);
-        Box::new(self)
-    }
-
-    /// Determines how points are displayed and joined.
-    pub fn marker(mut self, marker: Marker) -> Box<Self> {
-        self.marker = Some(marker);
-        Box::new(self)
-    }
-
-    /// Line display properties.
-    pub fn line(mut self, line: Line) -> Box<Self> {
-        self.line = Some(line);
-        Box::new(self)
-    }
-
-    /// x-axis error display properties.
-    pub fn error_x(mut self, error_x: ErrorData) -> Box<Self> {
-        self.error_x = Some(error_x);
-        Box::new(self)
-    }
-
-    /// y-axis error display properties.
-    pub fn error_y(mut self, error_y: ErrorData) -> Box<Self> {
-        self.error_y = Some(error_y);
-        Box::new(self)
-    }
-
-    /// z-axis error display properties.
-    pub fn error_z(mut self, error_z: ErrorData) -> Box<Self> {
-        self.error_z = Some(error_z);
-        Box::new(self)
-    }
-
-    /// Determines whether or not gaps (i.e. {nan} or missing values) in the provided data arrays
-    /// are connected.
-    pub fn connect_gaps(mut self, connect_gaps: bool) -> Box<Self> {
-        self.connect_gaps = Some(connect_gaps);
-        Box::new(self)
-    }
-
-    /// Properties of label displayed on mouse hover.
-    pub fn hover_label(mut self, hover_label: Label) -> Box<Self> {
-        self.hover_label = Some(hover_label);
-        Box::new(self)
-    }
-
-    /// If `SurfaceAxis::MinusOne`, the scatter points are not filled with a surface. If one of the remaining
-    /// three variants, the scatter points are filled with a Delaunay surface about the x, y, z respectively.
-    pub fn surface_axis(mut self, surface_axis: SurfaceAxis) -> Box<Self> {
-        self.surface_axis = Some(surface_axis);
-        Box::new(self)
-    }
-
-    /// Sets the calendar system to use with `x` date data.
-    pub fn x_calendar(mut self, x_calendar: Calendar) -> Box<Self> {
-        self.x_calendar = Some(x_calendar);
-        Box::new(self)
-    }
-
-    /// Sets the calendar system to use with `y` date data.
-    pub fn y_calendar(mut self, y_calendar: Calendar) -> Box<Self> {
-        self.y_calendar = Some(y_calendar);
-        Box::new(self)
-    }
-
-    /// Sets the calendar system to use with `z` date data.
-    pub fn z_calendar(mut self, z_calendar: Calendar) -> Box<Self> {
-        self.z_calendar = Some(z_calendar);
-        Box::new(self)
     }
 }
 

--- a/plotly/src/traces/scatter_polar.rs
+++ b/plotly/src/traces/scatter_polar.rs
@@ -35,6 +35,7 @@ use crate::{
 /// ```
 #[serde_with::skip_serializing_none]
 #[derive(Serialize, Clone, Debug, FieldSetter)]
+#[field_setter(box_self, kind = "trace")]
 pub struct ScatterPolar<Theta, R>
 where
     Theta: Serialize + Clone + 'static,

--- a/plotly/src/traces/scatter_polar.rs
+++ b/plotly/src/traces/scatter_polar.rs
@@ -264,7 +264,7 @@ where
         array_traces: ArrayTraces,
     ) -> Vec<Box<dyn Trace>> {
         let mut traces: Vec<Box<dyn Trace>> = Vec::new();
-        let mut trace_vectors = private::trace_vectors_from(traces_matrix, array_traces);
+        let mut trace_vectors = crate::private::trace_vectors_from(traces_matrix, array_traces);
         trace_vectors.reverse();
         while !trace_vectors.is_empty() {
             let mut sc = Box::new(self.clone());

--- a/plotly/src/traces/scatter_polar.rs
+++ b/plotly/src/traces/scatter_polar.rs
@@ -2,6 +2,7 @@
 
 #[cfg(feature = "plotly_ndarray")]
 use ndarray::{Array, Ix1, Ix2};
+use plotly_derive::FieldSetter;
 use serde::Serialize;
 
 #[cfg(feature = "plotly_ndarray")]
@@ -11,7 +12,7 @@ use crate::{
     common::{
         Dim, Fill, Font, HoverInfo, HoverOn, Label, Line, Marker, Mode, PlotType, Position, Visible,
     },
-    private::{self, NumOrString, NumOrStringCollection},
+    private::{NumOrString, NumOrStringCollection},
     Trace,
 };
 
@@ -33,109 +34,161 @@ use crate::{
 /// assert_eq!(serde_json::to_value(trace).unwrap(), expected);
 /// ```
 #[serde_with::skip_serializing_none]
-#[derive(Serialize, Clone, Debug)]
+#[derive(Serialize, Clone, Debug, FieldSetter)]
 pub struct ScatterPolar<Theta, R>
 where
     Theta: Serialize + Clone + 'static,
     R: Serialize + Clone + 'static,
 {
+    #[field_setter(default = "PlotType::ScatterPolar")]
     r#type: PlotType,
+    /// Sets the trace name. The trace name appear as the legend item and on hover.
     name: Option<String>,
+    /// Determines whether or not this trace is visible. If `Visible::LegendOnly`, the trace is not
+    /// drawn, but can appear as a legend item (provided that the legend itself is visible).
     visible: Option<Visible>,
+    /// Determines whether or not an item corresponding to this trace is shown in the legend.
     #[serde(rename = "showlegend")]
     show_legend: Option<bool>,
+    /// Sets the legend group for this trace. Traces part of the same legend group hide/show at the
+    /// same time when toggling legend items.
     #[serde(rename = "legendgroup")]
     legend_group: Option<String>,
+    /// Sets the opacity of the trace.
     opacity: Option<f64>,
+    /// Determines the drawing mode for this scatter trace. If the provided `Mode` includes
+    /// "Text" then the `text` elements appear at the coordinates. Otherwise, the `text` elements
+    /// appear on hover. If there are less than 20 points and the trace is not stacked then the
+    /// default is `Mode::LinesMarkers`, otherwise it is `Mode::Lines`.
     mode: Option<Mode>,
+    /// Assigns id labels to each datum. These ids for object constancy of data points during
+    /// animation. Should be an array of strings, not numbers or any other type.
     ids: Option<Vec<String>>,
+    /// Sets the theta coordinate step. See `theta0` for more info.
     theta: Option<Vec<Theta>>,
+    /// Alternate to `theta`. Builds a linear space of theta coordinates. Use with `dtheta` where `theta0` is the
+    /// starting coordinate and `dtheta` the step.
     theta0: Option<NumOrString>,
     dtheta: Option<f64>,
 
     r: Option<Vec<R>>,
+    /// Alternate to `r`. Builds a linear space of r coordinates. Use with `dr` where `r0` is the
+    /// starting coordinate and `dr` the step.
     r0: Option<NumOrString>,
+    /// Sets the r coordinate step. See `r0` for more info.
     dr: Option<f64>,
 
+    /// Sets a reference between this trace's data coordinates and a polar subplot. If "polar"
+    /// (the default value), the data refer to `layout.polar`. If "polar2", the data refer to
+    /// `layout.polar2`, and so on.
     subplot: Option<String>,
-
+    /// Sets text elements associated with each (x,y) pair. If a single string, the same string
+    /// appears over all the data points. If an array of string, the items are mapped in order to
+    /// the this trace's (x,y) coordinates. If trace `HoverInfo` contains a "text" flag and
+    /// `hover_text` is not set, these elements will be seen in the hover labels.
     text: Option<Dim<String>>,
+    /// Sets the positions of the `text` elements with respects to the (x,y) coordinates.
     #[serde(rename = "textposition")]
     text_position: Option<Dim<Position>>,
+    /// Template string used for rendering the information text that appear on points. Note that
+    /// this will override `textinfo`. Variables are inserted using %{variable}, for example
+    /// "y: %{y}". Numbers are formatted using d3-format's syntax %{variable:d3-format}, for example
+    /// "Price: %{y:$.2f}". See [format](https://github.com/d3/d3-3.x-api-reference/blob/master/Formatting.md#d3)
+    /// for details on the formatting syntax. Dates are formatted using d3-time-format's syntax
+    /// %{variable|d3-time-format}, for example "Day: %{2019-01-01|%A}".
+    /// See [format](https://github.com/d3/d3-3.x-api-reference/blob/master/Time-Formatting.md#format) for details
+    /// on the date formatting syntax. Every attributes that can be specified per-point (the ones
+    /// that are `arrayOk: true`) are available.
     #[serde(rename = "texttemplate")]
     text_template: Option<Dim<String>>,
+    /// Sets hover text elements associated with each (x,y) pair. If a single string, the same
+    /// string appears over all the data points. If an array of string, the items are mapped in
+    /// order to the this trace's (x,y) coordinates. To be seen, trace `HoverInfo` must contain a
+    /// "Text" flag.
     #[serde(rename = "hovertext")]
     hover_text: Option<Dim<String>>,
+    /// Determines which trace information appear on hover. If `HoverInfo::None` or `HoverInfo::Skip`
+    /// are set, no information is displayed upon hovering. But, if `HoverInfo::None` is set, click
+    /// and hover events are still fired.
     #[serde(rename = "hoverinfo")]
     hover_info: Option<HoverInfo>,
+    /// Template string used for rendering the information that appear on hover box. Note that this
+    /// will override `HoverInfo`. Variables are inserted using %{variable}, for example "y: %{y}".
+    /// Numbers are formatted using d3-format's syntax %{variable:d3-format}, for example
+    /// "Price: %{y:$.2f}".
+    /// https://github.com/d3/d3-3.x-api-reference/blob/master/Formatting.md#d3_format for details
+    /// on the formatting syntax. Dates are formatted using d3-time-format's syntax
+    /// %{variable|d3-time-format}, for example "Day: %{2019-01-01|%A}".
+    /// https://github.com/d3/d3-3.x-api-reference/blob/master/Time-Formatting.md#format for details
+    /// on the date formatting syntax. The variables available in `hovertemplate` are the ones
+    /// emitted as event data described at this link https://plotly.com/javascript/plotlyjs-events/#event-data.
+    /// Additionally, every attributes that can be specified per-point (the ones that are
+    /// `arrayOk: true`) are available. Anything contained in tag `<extra>` is displayed in the
+    /// secondary box, for example "<extra>{fullData.name}</extra>". To hide the secondary box
+    /// completely, use an empty tag `<extra></extra>`.
     #[serde(rename = "hovertemplate")]
     hover_template: Option<Dim<String>>,
-
+    /// Assigns extra meta information associated with this trace that can be used in various text
+    /// attributes. Attributes such as trace `name`, graph, axis and colorbar `title.text`,
+    /// annotation `text` `rangeselector`, `updatemenues` and `sliders` `label` text all support
+    /// `meta`. To access the trace `meta` values in an attribute in the same trace, simply use
+    /// `%{meta[i]}` where `i` is the index or key of the `meta` item in question. To access trace
+    /// `meta` in layout attributes, use `%{data[n[.meta[i]}` where `i` is the index or key of the
+    /// `meta` and `n` is the trace index.
     meta: Option<NumOrString>,
+    /// Assigns extra data each datum. This may be useful when listening to hover, click and
+    /// selection events. Note that, "scatter" traces also appends customdata items in the markers
+    /// DOM elements
     #[serde(rename = "customdata")]
     custom_data: Option<NumOrStringCollection>,
-
+    /// Array containing integer indices of selected points. Has an effect only for traces that
+    /// support selections. Note that an empty array means an empty selection where the
+    /// `unselected` are turned on for all points, whereas, any other non-array values means no
+    /// selection all where the `selected` and `unselected` styles have no effect.
     #[serde(rename = "selectedpoints")]
     selected_points: Option<Vec<u32>>,
+    /// Determines how points are displayed and joined.
     marker: Option<Marker>,
+    /// Line display properties.
     line: Option<Line>,
+    /// Sets the text font.
     #[serde(rename = "textfont")]
     text_font: Option<Font>,
+    /// Determines whether or not markers and text nodes are clipped about the subplot axes. To show
+    /// markers and text nodes above axis lines and tick labels, make sure to set `xaxis.layer` and
+    /// `yaxis.layer` to "below traces".
     #[serde(rename = "cliponaxis")]
     clip_on_axis: Option<bool>,
+    /// Determines whether or not gaps (i.e. {nan} or missing values) in the provided data arrays
+    /// are connected.
     #[serde(rename = "connectgaps")]
     connect_gaps: Option<bool>,
+    /// Sets the area to fill with a solid color. Defaults to "none" unless this trace is stacked,
+    /// then it gets "tonexty" ("tonextx") if `orientation` is "v" ("h") Use with `fillcolor` if not
+    /// "none". "tozerox" and "tozeroy" fill to x=0 and y=0 respectively. "tonextx" and "tonexty"
+    /// fill between the endpoints of this trace and the endpoints of the trace before it,
+    /// connecting those endpoints with straight lines (to make a stacked area graph); if there is
+    /// no trace before it, they behave like "tozerox" and "tozeroy". "toself" connects the
+    /// endpoints of the trace (or each segment of the trace if it has gaps) into a closed shape.
+    /// "tonext" fills the space between two traces if one completely encloses the other
+    /// (eg consecutive contour lines), and behaves like "toself" if there is no trace before it.
+    /// "tonext" should not be used if one trace does not enclose the other. Traces in a
+    /// `stackgroup` will only fill to (or be filled to) other traces in the same group. With
+    /// multiple `stackgroup`s or some traces stacked and some not, if fill-linked traces are not
+    /// already consecutive, the later ones will be pushed down in the drawing order.
     fill: Option<Fill>,
+    /// Sets the fill color. Defaults to a half-transparent variant of the line color, marker color,
+    /// or marker line color, whichever is available.
     #[serde(rename = "fillcolor")]
     fill_color: Option<Box<dyn Color>>,
+    /// Properties of label displayed on mouse hover.
     #[serde(rename = "hoverlabel")]
     hover_label: Option<Label>,
+    /// Do the hover effects highlight individual points (markers or line points) or do they
+    /// highlight filled regions? If the fill is "toself" or "tonext" and there are no markers or
+    /// text, then the default is "fills", otherwise it is "points".
     #[serde(rename = "hoveron")]
     hover_on: Option<HoverOn>,
-}
-
-impl<Theta, R> Default for ScatterPolar<Theta, R>
-where
-    Theta: Serialize + Clone + 'static,
-    R: Serialize + Clone + 'static,
-{
-    fn default() -> Self {
-        Self {
-            r#type: PlotType::ScatterPolar,
-            name: None,
-            visible: None,
-            show_legend: None,
-            legend_group: None,
-            opacity: None,
-            mode: None,
-            ids: None,
-            theta: None,
-            theta0: None,
-            dtheta: None,
-            r: None,
-            r0: None,
-            dr: None,
-            subplot: None,
-            text: None,
-            text_position: None,
-            text_template: None,
-            hover_text: None,
-            hover_info: None,
-            hover_template: None,
-            meta: None,
-            custom_data: None,
-            selected_points: None,
-            marker: None,
-            line: None,
-            text_font: None,
-            clip_on_axis: None,
-            connect_gaps: None,
-            fill: None,
-            fill_color: None,
-            hover_label: None,
-            hover_on: None,
-        }
-    }
 }
 
 impl<Theta, R> ScatterPolar<Theta, R>
@@ -232,316 +285,6 @@ where
         } else {
             PlotType::ScatterPolar
         };
-        Box::new(self)
-    }
-
-    /// Sets the trace name. The trace name appear as the legend item and on hover.
-    pub fn name(mut self, name: &str) -> Box<Self> {
-        self.name = Some(name.to_string());
-        Box::new(self)
-    }
-
-    /// Determines whether or not this trace is visible. If `Visible::LegendOnly`, the trace is not
-    /// drawn, but can appear as a legend item (provided that the legend itself is visible).
-    pub fn visible(mut self, visible: Visible) -> Box<Self> {
-        self.visible = Some(visible);
-        Box::new(self)
-    }
-
-    /// Determines whether or not an item corresponding to this trace is shown in the legend.
-    pub fn show_legend(mut self, show_legend: bool) -> Box<Self> {
-        self.show_legend = Some(show_legend);
-        Box::new(self)
-    }
-
-    /// Sets the legend group for this trace. Traces part of the same legend group hide/show at the
-    /// same time when toggling legend items.
-    pub fn legend_group(mut self, legend_group: &str) -> Box<Self> {
-        self.legend_group = Some(legend_group.to_string());
-        Box::new(self)
-    }
-
-    /// Sets the opacity of the trace.
-    pub fn opacity(mut self, opacity: f64) -> Box<Self> {
-        self.opacity = Some(opacity);
-        Box::new(self)
-    }
-
-    /// Determines the drawing mode for this scatter trace. If the provided `Mode` includes
-    /// "Text" then the `text` elements appear at the coordinates. Otherwise, the `text` elements
-    /// appear on hover. If there are less than 20 points and the trace is not stacked then the
-    /// default is `Mode::LinesMarkers`, otherwise it is `Mode::Lines`.
-    pub fn mode(mut self, mode: Mode) -> Box<Self> {
-        self.mode = Some(mode);
-        Box::new(self)
-    }
-
-    /// Assigns id labels to each datum. These ids for object constancy of data points during
-    /// animation. Should be an array of strings, not numbers or any other type.
-    pub fn ids<S: AsRef<str>>(mut self, ids: Vec<S>) -> Box<Self> {
-        let ids = private::owned_string_vector(ids);
-        self.ids = Some(ids);
-        Box::new(self)
-    }
-
-    /// Alternate to `theta`. Builds a linear space of theta coordinates. Use with `dtheta` where `theta0` is the
-    /// starting coordinate and `dtheta` the step.
-    pub fn theta0<V: Into<NumOrString>>(mut self, theta0: V) -> Box<Self> {
-        self.theta0 = Some(theta0.into());
-        Box::new(self)
-    }
-
-    /// Sets the theta coordinate step. See `theta0` for more info.
-    pub fn dtheta(mut self, dtheta: f64) -> Box<Self> {
-        self.dtheta = Some(dtheta);
-        Box::new(self)
-    }
-
-    /// Alternate to `r`. Builds a linear space of r coordinates. Use with `dr` where `r0` is the
-    /// starting coordinate and `dr` the step.
-    pub fn r0<V: Into<NumOrString>>(mut self, r0: V) -> Box<Self> {
-        self.r0 = Some(r0.into());
-        Box::new(self)
-    }
-
-    /// Sets the r coordinate step. See `r0` for more info.
-    pub fn dr(mut self, dr: f64) -> Box<Self> {
-        self.dr = Some(dr);
-        Box::new(self)
-    }
-
-    /// Sets a reference between this trace's data coordinates and a polar subplot. If "polar"
-    /// (the default value), the data refer to `layout.polar`. If "polar2", the data refer to
-    /// `layout.polar2`, and so on.
-    pub fn subplot(mut self, subplot: &str) -> Box<Self> {
-        self.subplot = Some(subplot.to_string());
-        Box::new(self)
-    }
-
-    /// Sets text elements associated with each (x,y) pair. If a single string, the same string
-    /// appears over all the data points. If an array of string, the items are mapped in order to
-    /// the this trace's (x,y) coordinates. If the trace `HoverInfo` contains a "text" flag and
-    /// `hover_text` is not set, these elements will be seen in the hover labels.
-    pub fn text(mut self, text: &str) -> Box<Self> {
-        self.text = Some(Dim::Scalar(text.to_string()));
-        Box::new(self)
-    }
-
-    /// Sets text elements associated with each (x,y) pair. If a single string, the same string
-    /// appears over all the data points. If an array of string, the items are mapped in order to
-    /// the this trace's (x,y) coordinates. If trace `HoverInfo` contains a "text" flag and
-    /// `hover_text` is not set, these elements will be seen in the hover labels.
-    pub fn text_array<S: AsRef<str>>(mut self, text: Vec<S>) -> Box<Self> {
-        let text = private::owned_string_vector(text);
-        self.text = Some(Dim::Vector(text));
-        Box::new(self)
-    }
-
-    /// Sets the positions of the `text` elements with respects to the (x,y) coordinates.
-    pub fn text_position(mut self, text_position: Position) -> Box<Self> {
-        self.text_position = Some(Dim::Scalar(text_position));
-        Box::new(self)
-    }
-
-    /// Sets the positions of the `text` elements with respects to the (x,y) coordinates.
-    pub fn text_position_array(mut self, text_position: Vec<Position>) -> Box<Self> {
-        self.text_position = Some(Dim::Vector(text_position));
-        Box::new(self)
-    }
-
-    /// Template string used for rendering the information text that appear on points. Note that
-    /// this will override `textinfo`. Variables are inserted using %{variable}, for example
-    /// "y: %{y}". Numbers are formatted using d3-format's syntax %{variable:d3-format}, for example
-    /// "Price: %{y:$.2f}". See [format](https://github.com/d3/d3-3.x-api-reference/blob/master/Formatting.md#d3)
-    /// for details on the formatting syntax. Dates are formatted using d3-time-format's syntax
-    /// %{variable|d3-time-format}, for example "Day: %{2019-01-01|%A}".
-    /// See [format](https://github.com/d3/d3-3.x-api-reference/blob/master/Time-Formatting.md#format) for details
-    /// on the date formatting syntax. Every attributes that can be specified per-point (the ones
-    /// that are `arrayOk: true`) are available.
-    pub fn text_template(mut self, text_template: &str) -> Box<Self> {
-        self.text_template = Some(Dim::Scalar(text_template.to_string()));
-        Box::new(self)
-    }
-
-    /// Template string used for rendering the information text that appear on points. Note that
-    /// this will override `textinfo`. Variables are inserted using %{variable}, for example
-    /// "y: %{y}". Numbers are formatted using d3-format's syntax %{variable:d3-format}, for example
-    /// "Price: %{y:$.2f}". See [format](https://github.com/d3/d3-3.x-api-reference/blob/master/Formatting.md#d3)
-    /// for details on the formatting syntax. Dates are formatted using d3-time-format's syntax
-    /// %{variable|d3-time-format}, for example "Day: %{2019-01-01|%A}".
-    /// See [format](https://github.com/d3/d3-3.x-api-reference/blob/master/Time-Formatting.md#format) for details
-    /// on the date formatting syntax. Every attributes that can be specified per-point (the ones
-    /// that are `arrayOk: true`) are available.
-    pub fn text_template_array<S: AsRef<str>>(mut self, text_template: Vec<S>) -> Box<Self> {
-        let text_template = private::owned_string_vector(text_template);
-        self.text_template = Some(Dim::Vector(text_template));
-        Box::new(self)
-    }
-
-    /// Sets hover text elements associated with each (x,y) pair. If a single string, the same
-    /// string appears over all the data points. If an array of string, the items are mapped in
-    /// order to the this trace's (x,y) coordinates. To be seen, trace `HoverInfo` must contain a
-    /// "Text" flag.
-    pub fn hover_text(mut self, hover_text: &str) -> Box<Self> {
-        self.hover_text = Some(Dim::Scalar(hover_text.to_string()));
-        Box::new(self)
-    }
-
-    /// Sets hover text elements associated with each (x,y) pair. If a single string, the same
-    /// string appears over all the data points. If an array of string, the items are mapped in
-    /// order to the this trace's (x,y) coordinates. To be seen, trace `HoverInfo` must contain a
-    /// "Text" flag.
-    pub fn hover_text_array<S: AsRef<str>>(mut self, hover_text: Vec<S>) -> Box<Self> {
-        let hover_text = private::owned_string_vector(hover_text);
-        self.hover_text = Some(Dim::Vector(hover_text));
-        Box::new(self)
-    }
-
-    /// Determines which trace information appear on hover. If `HoverInfo::None` or `HoverInfo::Skip`
-    /// are set, no information is displayed upon hovering. But, if `HoverInfo::None` is set, click
-    /// and hover events are still fired.
-    pub fn hover_info(mut self, hover_info: HoverInfo) -> Box<Self> {
-        self.hover_info = Some(hover_info);
-        Box::new(self)
-    }
-
-    /// Template string used for rendering the information that appear on hover box. Note that this
-    /// will override `HoverInfo`. Variables are inserted using %{variable}, for example "y: %{y}".
-    /// Numbers are formatted using d3-format's syntax %{variable:d3-format}, for example
-    /// "Price: %{y:$.2f}".
-    /// https://github.com/d3/d3-3.x-api-reference/blob/master/Formatting.md#d3_format for details
-    /// on the formatting syntax. Dates are formatted using d3-time-format's syntax
-    /// %{variable|d3-time-format}, for example "Day: %{2019-01-01|%A}".
-    /// https://github.com/d3/d3-3.x-api-reference/blob/master/Time-Formatting.md#format for details
-    /// on the date formatting syntax. The variables available in `hovertemplate` are the ones
-    /// emitted as event data described at this link https://plotly.com/javascript/plotlyjs-events/#event-data.
-    /// Additionally, every attributes that can be specified per-point (the ones that are
-    /// `arrayOk: true`) are available. Anything contained in tag `<extra>` is displayed in the
-    /// secondary box, for example "<extra>{fullData.name}</extra>". To hide the secondary box
-    /// completely, use an empty tag `<extra></extra>`.
-    pub fn hover_template(mut self, hover_template: &str) -> Box<Self> {
-        self.hover_template = Some(Dim::Scalar(hover_template.to_string()));
-        Box::new(self)
-    }
-
-    /// Template string used for rendering the information that appear on hover box. Note that this
-    /// will override `HoverInfo`. Variables are inserted using %{variable}, for example "y: %{y}".
-    /// Numbers are formatted using d3-format's syntax %{variable:d3-format}, for example
-    /// "Price: %{y:$.2f}".
-    /// https://github.com/d3/d3-3.x-api-reference/blob/master/Formatting.md#d3_format for details
-    /// on the formatting syntax. Dates are formatted using d3-time-format's syntax
-    /// %{variable|d3-time-format}, for example "Day: %{2019-01-01|%A}".
-    /// https://github.com/d3/d3-3.x-api-reference/blob/master/Time-Formatting.md#format for details
-    /// on the date formatting syntax. The variables available in `hovertemplate` are the ones
-    /// emitted as event data described at this link https://plotly.com/javascript/plotlyjs-events/#event-data.
-    /// Additionally, every attributes that can be specified per-point (the ones that are
-    /// `arrayOk: true`) are available. Anything contained in tag `<extra>` is displayed in the
-    /// secondary box, for example "<extra>{fullData.name}</extra>". To hide the secondary box
-    /// completely, use an empty tag `<extra></extra>`.
-    pub fn hover_template_array<S: AsRef<str>>(mut self, hover_template: Vec<S>) -> Box<Self> {
-        let hover_template = private::owned_string_vector(hover_template);
-        self.hover_template = Some(Dim::Vector(hover_template));
-        Box::new(self)
-    }
-
-    /// Assigns extra meta information associated with this trace that can be used in various text
-    /// attributes. Attributes such as trace `name`, graph, axis and colorbar `title.text`,
-    /// annotation `text` `rangeselector`, `updatemenues` and `sliders` `label` text all support
-    /// `meta`. To access the trace `meta` values in an attribute in the same trace, simply use
-    /// `%{meta[i]}` where `i` is the index or key of the `meta` item in question. To access trace
-    /// `meta` in layout attributes, use `%{data[n[.meta[i]}` where `i` is the index or key of the
-    /// `meta` and `n` is the trace index.
-    pub fn meta<V: Into<NumOrString>>(mut self, meta: V) -> Box<Self> {
-        self.meta = Some(meta.into());
-        Box::new(self)
-    }
-
-    /// Assigns extra data each datum. This may be useful when listening to hover, click and
-    /// selection events. Note that, "scatter" traces also appends customdata items in the markers
-    /// DOM elements
-    pub fn custom_data<V: Into<NumOrString> + Clone>(mut self, custom_data: Vec<V>) -> Box<Self> {
-        self.custom_data = Some(custom_data.into());
-        Box::new(self)
-    }
-
-    /// Array containing integer indices of selected points. Has an effect only for traces that
-    /// support selections. Note that an empty array means an empty selection where the
-    /// `unselected` are turned on for all points, whereas, any other non-array values means no
-    /// selection all where the `selected` and `unselected` styles have no effect.
-    pub fn selected_points(mut self, selected_points: Vec<u32>) -> Box<Self> {
-        self.selected_points = Some(selected_points);
-        Box::new(self)
-    }
-
-    /// Determines how points are displayed and joined.
-    pub fn marker(mut self, marker: Marker) -> Box<Self> {
-        self.marker = Some(marker);
-        Box::new(self)
-    }
-
-    /// Line display properties.
-    pub fn line(mut self, line: Line) -> Box<Self> {
-        self.line = Some(line);
-        Box::new(self)
-    }
-
-    /// Sets the text font.
-    pub fn text_font(mut self, text_font: Font) -> Box<Self> {
-        self.text_font = Some(text_font);
-        Box::new(self)
-    }
-
-    /// Determines whether or not markers and text nodes are clipped about the subplot axes. To show
-    /// markers and text nodes above axis lines and tick labels, make sure to set `xaxis.layer` and
-    /// `yaxis.layer` to "below traces".
-    pub fn clip_on_axis(mut self, clip_on_axis: bool) -> Box<Self> {
-        self.clip_on_axis = Some(clip_on_axis);
-        Box::new(self)
-    }
-
-    /// Determines whether or not gaps (i.e. {nan} or missing values) in the provided data arrays
-    /// are connected.
-    pub fn connect_gaps(mut self, connect_gaps: bool) -> Box<Self> {
-        self.connect_gaps = Some(connect_gaps);
-        Box::new(self)
-    }
-
-    /// Sets the area to fill with a solid color. Defaults to "none" unless this trace is stacked,
-    /// then it gets "tonexty" ("tonextx") if `orientation` is "v" ("h") Use with `fillcolor` if not
-    /// "none". "tozerox" and "tozeroy" fill to x=0 and y=0 respectively. "tonextx" and "tonexty"
-    /// fill between the endpoints of this trace and the endpoints of the trace before it,
-    /// connecting those endpoints with straight lines (to make a stacked area graph); if there is
-    /// no trace before it, they behave like "tozerox" and "tozeroy". "toself" connects the
-    /// endpoints of the trace (or each segment of the trace if it has gaps) into a closed shape.
-    /// "tonext" fills the space between two traces if one completely encloses the other
-    /// (eg consecutive contour lines), and behaves like "toself" if there is no trace before it.
-    /// "tonext" should not be used if one trace does not enclose the other. Traces in a
-    /// `stackgroup` will only fill to (or be filled to) other traces in the same group. With
-    /// multiple `stackgroup`s or some traces stacked and some not, if fill-linked traces are not
-    /// already consecutive, the later ones will be pushed down in the drawing order.
-    pub fn fill(mut self, fill: Fill) -> Box<Self> {
-        self.fill = Some(fill);
-        Box::new(self)
-    }
-
-    /// Sets the fill color. Defaults to a half-transparent variant of the line color, marker color,
-    /// or marker line color, whichever is available.
-    pub fn fill_color<C: Color>(mut self, fill_color: C) -> Box<Self> {
-        self.fill_color = Some(Box::new(fill_color));
-        Box::new(self)
-    }
-
-    /// Properties of label displayed on mouse hover.
-    pub fn hover_label(mut self, hover_label: Label) -> Box<Self> {
-        self.hover_label = Some(hover_label);
-        Box::new(self)
-    }
-
-    /// Do the hover effects highlight individual points (markers or line points) or do they
-    /// highlight filled regions? If the fill is "toself" or "tonext" and there are no markers or
-    /// text, then the default is "fills", otherwise it is "points".
-    pub fn hover_on(mut self, hover_on: HoverOn) -> Box<Self> {
-        self.hover_on = Some(hover_on);
         Box::new(self)
     }
 }

--- a/plotly/src/traces/surface.rs
+++ b/plotly/src/traces/surface.rs
@@ -11,7 +11,6 @@ use crate::{
 
 #[serde_with::skip_serializing_none]
 #[derive(Serialize, Debug, Clone, FieldSetter)]
-#[field_setter(no_box)]
 pub struct Lighting {
     ambient: Option<f64>,
     diffuse: Option<f64>,
@@ -41,7 +40,6 @@ impl Position {
 
 #[serde_with::skip_serializing_none]
 #[derive(Serialize, Debug, FieldSetter, Clone)]
-#[field_setter(no_box)]
 pub struct PlaneProject {
     x: Option<bool>,
     y: Option<bool>,
@@ -56,7 +54,6 @@ impl PlaneProject {
 
 #[serde_with::skip_serializing_none]
 #[derive(Serialize, Debug, FieldSetter, Clone)]
-#[field_setter(no_box)]
 pub struct PlaneContours {
     color: Option<Box<dyn Color>>,
     end: Option<f64>,
@@ -82,7 +79,6 @@ impl PlaneContours {
 
 #[serde_with::skip_serializing_none]
 #[derive(Serialize, Debug, FieldSetter, Clone)]
-#[field_setter(no_box)]
 pub struct SurfaceContours {
     x: Option<PlaneContours>,
     y: Option<PlaneContours>,
@@ -114,6 +110,7 @@ impl SurfaceContours {
 /// ```
 #[serde_with::skip_serializing_none]
 #[derive(Serialize, Debug, Clone, FieldSetter)]
+#[field_setter(box_self, kind = "trace")]
 pub struct Surface<X, Y, Z>
 where
     X: Serialize + Clone,

--- a/plotly/src/traces/surface.rs
+++ b/plotly/src/traces/surface.rs
@@ -1,15 +1,17 @@
 //! Surface trace
 
+use plotly_derive::FieldSetter;
 use serde::Serialize;
 
 use crate::{
-    color::{Color, ColorArray},
+    color::Color,
     common::{Calendar, ColorBar, ColorScale, Dim, HoverInfo, Label, PlotType, Visible},
-    private, Trace,
+    Trace,
 };
 
 #[serde_with::skip_serializing_none]
-#[derive(Serialize, Debug, Default, Clone)]
+#[derive(Serialize, Debug, Clone, FieldSetter)]
+#[field_setter(no_box)]
 pub struct Lighting {
     ambient: Option<f64>,
     diffuse: Option<f64>,
@@ -21,31 +23,6 @@ pub struct Lighting {
 impl Lighting {
     pub fn new() -> Self {
         Default::default()
-    }
-
-    pub fn ambient(mut self, ambient: f64) -> Self {
-        self.ambient = Some(ambient);
-        self
-    }
-
-    pub fn diffuse(mut self, diffuse: f64) -> Self {
-        self.diffuse = Some(diffuse);
-        self
-    }
-
-    pub fn fresnel(mut self, fresnel: f64) -> Self {
-        self.fresnel = Some(fresnel);
-        self
-    }
-
-    pub fn roughness(mut self, roughness: f64) -> Self {
-        self.roughness = Some(roughness);
-        self
-    }
-
-    pub fn specular(mut self, specular: f64) -> Self {
-        self.specular = Some(specular);
-        self
     }
 }
 
@@ -63,7 +40,8 @@ impl Position {
 }
 
 #[serde_with::skip_serializing_none]
-#[derive(Serialize, Debug, Default, Clone)]
+#[derive(Serialize, Debug, FieldSetter, Clone)]
+#[field_setter(no_box)]
 pub struct PlaneProject {
     x: Option<bool>,
     y: Option<bool>,
@@ -74,25 +52,11 @@ impl PlaneProject {
     pub fn new() -> Self {
         Default::default()
     }
-
-    pub fn x(mut self, x: bool) -> Self {
-        self.x = Some(x);
-        self
-    }
-
-    pub fn y(mut self, y: bool) -> Self {
-        self.y = Some(y);
-        self
-    }
-
-    pub fn z(mut self, z: bool) -> Self {
-        self.z = Some(z);
-        self
-    }
 }
 
 #[serde_with::skip_serializing_none]
-#[derive(Serialize, Debug, Default, Clone)]
+#[derive(Serialize, Debug, FieldSetter, Clone)]
+#[field_setter(no_box)]
 pub struct PlaneContours {
     color: Option<Box<dyn Color>>,
     end: Option<f64>,
@@ -114,65 +78,11 @@ impl PlaneContours {
     pub fn new() -> Self {
         Default::default()
     }
-
-    pub fn color<C: Color>(mut self, color: C) -> Self {
-        self.color = Some(Box::new(color));
-        self
-    }
-
-    pub fn highlight(mut self, highlight: bool) -> Self {
-        self.highlight = Some(highlight);
-        self
-    }
-
-    pub fn highlight_color<C: Color>(mut self, highlight_color: C) -> Self {
-        self.highlight_color = Some(Box::new(highlight_color));
-        self
-    }
-
-    pub fn highlight_width(mut self, highlight_width: usize) -> Self {
-        self.highlight_width = Some(highlight_width);
-        self
-    }
-
-    pub fn end(mut self, end: f64) -> Self {
-        self.end = Some(end);
-        self
-    }
-
-    pub fn project(mut self, project: PlaneProject) -> Self {
-        self.project = Some(project);
-        self
-    }
-
-    pub fn show(mut self, show: bool) -> Self {
-        self.show = Some(show);
-        self
-    }
-
-    pub fn size(mut self, size: usize) -> Self {
-        self.size = Some(size);
-        self
-    }
-
-    pub fn start(mut self, start: f64) -> Self {
-        self.start = Some(start);
-        self
-    }
-
-    pub fn use_colormap(mut self, use_colormap: bool) -> Self {
-        self.use_colormap = Some(use_colormap);
-        self
-    }
-
-    pub fn width(mut self, width: usize) -> Self {
-        self.width = Some(width);
-        self
-    }
 }
 
 #[serde_with::skip_serializing_none]
-#[derive(Serialize, Debug, Default, Clone)]
+#[derive(Serialize, Debug, FieldSetter, Clone)]
+#[field_setter(no_box)]
 pub struct SurfaceContours {
     x: Option<PlaneContours>,
     y: Option<PlaneContours>,
@@ -182,21 +92,6 @@ pub struct SurfaceContours {
 impl SurfaceContours {
     pub fn new() -> Self {
         Default::default()
-    }
-
-    pub fn x(mut self, x: PlaneContours) -> Self {
-        self.x = Some(x);
-        self
-    }
-
-    pub fn y(mut self, y: PlaneContours) -> Self {
-        self.y = Some(y);
-        self
-    }
-
-    pub fn z(mut self, z: PlaneContours) -> Self {
-        self.z = Some(z);
-        self
     }
 }
 
@@ -218,13 +113,14 @@ impl SurfaceContours {
 /// assert_eq!(serde_json::to_value(trace).unwrap(), expected);
 /// ```
 #[serde_with::skip_serializing_none]
-#[derive(Serialize, Debug, Clone)]
+#[derive(Serialize, Debug, Clone, FieldSetter)]
 pub struct Surface<X, Y, Z>
 where
     X: Serialize + Clone,
     Y: Serialize + Clone,
     Z: Serialize + Clone,
 {
+    #[field_setter(default = "PlotType::Surface")]
     r#type: PlotType,
     x: Option<Vec<X>>,
     y: Option<Vec<Y>>,
@@ -277,50 +173,6 @@ where
     z_calendar: Option<Calendar>,
 }
 
-impl<X, Y, Z> Default for Surface<X, Y, Z>
-where
-    X: Serialize + Clone,
-    Y: Serialize + Clone,
-    Z: Serialize + Clone,
-{
-    fn default() -> Self {
-        Self {
-            r#type: PlotType::Surface,
-            x: None,
-            y: None,
-            z: None,
-            auto_color_scale: None,
-            cauto: None,
-            cmax: None,
-            cmid: None,
-            cmin: None,
-            color_bar: None,
-            color_scale: None,
-            connect_gaps: None,
-            contours: None,
-            hide_surface: None,
-            hover_info: None,
-            hover_label: None,
-            hover_template: None,
-            hover_text: None,
-            legend_group: None,
-            light_position: None,
-            lighting: None,
-            name: None,
-            opacity: None,
-            reverse_scale: None,
-            show_legend: None,
-            show_scale: None,
-            surface_color: None,
-            text: None,
-            visible: None,
-            x_calendar: None,
-            y_calendar: None,
-            z_calendar: None,
-        }
-    }
-}
-
 impl<X, Y, Z> Surface<X, Y, Z>
 where
     X: Serialize + Clone,
@@ -332,174 +184,6 @@ where
             z: Some(z),
             ..Default::default()
         })
-    }
-
-    pub fn x(mut self, x: Vec<X>) -> Box<Self> {
-        self.x = Some(x);
-        Box::new(self)
-    }
-
-    pub fn y(mut self, y: Vec<Y>) -> Box<Self> {
-        self.y = Some(y);
-        Box::new(self)
-    }
-
-    pub fn name(mut self, name: &str) -> Box<Self> {
-        self.name = Some(name.to_string());
-        Box::new(self)
-    }
-
-    pub fn visible(mut self, visible: Visible) -> Box<Self> {
-        self.visible = Some(visible);
-        Box::new(self)
-    }
-
-    pub fn show_legend(mut self, show_legend: bool) -> Box<Self> {
-        self.show_legend = Some(show_legend);
-        Box::new(self)
-    }
-
-    pub fn legend_group(mut self, legend_group: &str) -> Box<Self> {
-        self.legend_group = Some(legend_group.to_string());
-        Box::new(self)
-    }
-
-    pub fn opacity(mut self, opacity: f64) -> Box<Self> {
-        self.opacity = Some(opacity);
-        Box::new(self)
-    }
-
-    pub fn surface_color<C: Color>(mut self, surface_color: Vec<C>) -> Box<Self> {
-        self.surface_color = Some(ColorArray(surface_color).into());
-        Box::new(self)
-    }
-
-    pub fn text(mut self, text: &str) -> Box<Self> {
-        self.text = Some(Dim::Scalar(text.to_string()));
-        Box::new(self)
-    }
-
-    pub fn text_array<S: AsRef<str>>(mut self, text: Vec<S>) -> Box<Self> {
-        let text = private::owned_string_vector(text);
-        self.text = Some(Dim::Vector(text));
-        Box::new(self)
-    }
-
-    pub fn hover_text(mut self, hover_text: &str) -> Box<Self> {
-        self.hover_text = Some(Dim::Scalar(hover_text.to_string()));
-        Box::new(self)
-    }
-
-    pub fn hover_text_array<S: AsRef<str>>(mut self, hover_text: Vec<S>) -> Box<Self> {
-        let hover_text = private::owned_string_vector(hover_text);
-        self.hover_text = Some(Dim::Vector(hover_text));
-        Box::new(self)
-    }
-
-    pub fn hover_info(mut self, hover_info: HoverInfo) -> Box<Self> {
-        self.hover_info = Some(hover_info);
-        Box::new(self)
-    }
-
-    pub fn hover_template(mut self, hover_template: &str) -> Box<Self> {
-        self.hover_template = Some(Dim::Scalar(hover_template.to_string()));
-        Box::new(self)
-    }
-
-    pub fn hover_template_array<S: AsRef<str>>(mut self, hover_template: Vec<S>) -> Box<Self> {
-        let hover_template = private::owned_string_vector(hover_template);
-        self.hover_template = Some(Dim::Vector(hover_template));
-        Box::new(self)
-    }
-
-    pub fn color_bar(mut self, color_bar: ColorBar) -> Box<Self> {
-        self.color_bar = Some(color_bar);
-        Box::new(self)
-    }
-
-    pub fn auto_color_scale(mut self, auto_color_scale: bool) -> Box<Self> {
-        self.auto_color_scale = Some(auto_color_scale);
-        Box::new(self)
-    }
-
-    pub fn color_scale(mut self, color_scale: ColorScale) -> Box<Self> {
-        self.color_scale = Some(color_scale);
-        Box::new(self)
-    }
-
-    pub fn show_scale(mut self, show_scale: bool) -> Box<Self> {
-        self.show_scale = Some(show_scale);
-        Box::new(self)
-    }
-
-    pub fn reverse_scale(mut self, reverse_scale: bool) -> Box<Self> {
-        self.reverse_scale = Some(reverse_scale);
-        Box::new(self)
-    }
-
-    pub fn cauto(mut self, cauto: bool) -> Box<Self> {
-        self.cauto = Some(cauto);
-        Box::new(self)
-    }
-
-    pub fn cmin(mut self, cmin: f64) -> Box<Self> {
-        self.cmin = Some(cmin);
-        Box::new(self)
-    }
-
-    pub fn cmax(mut self, cmax: f64) -> Box<Self> {
-        self.cmax = Some(cmax);
-        Box::new(self)
-    }
-
-    pub fn cmid(mut self, cmid: f64) -> Box<Self> {
-        self.cmid = Some(cmid);
-        Box::new(self)
-    }
-
-    pub fn connect_gaps(mut self, connect_gaps: bool) -> Box<Self> {
-        self.connect_gaps = Some(connect_gaps);
-        Box::new(self)
-    }
-
-    pub fn contours(mut self, contours: SurfaceContours) -> Box<Self> {
-        self.contours = Some(contours);
-        Box::new(self)
-    }
-
-    pub fn hide_surface(mut self, hide_surface: bool) -> Box<Self> {
-        self.hide_surface = Some(hide_surface);
-        Box::new(self)
-    }
-
-    pub fn hover_label(mut self, hover_label: Label) -> Box<Self> {
-        self.hover_label = Some(hover_label);
-        Box::new(self)
-    }
-
-    pub fn lighting(mut self, lighting: Lighting) -> Box<Self> {
-        self.lighting = Some(lighting);
-        Box::new(self)
-    }
-
-    pub fn light_position(mut self, light_position: Position) -> Box<Self> {
-        self.light_position = Some(light_position);
-        Box::new(self)
-    }
-
-    pub fn x_calendar(mut self, x_calendar: Calendar) -> Box<Self> {
-        self.x_calendar = Some(x_calendar);
-        Box::new(self)
-    }
-
-    pub fn y_calendar(mut self, y_calendar: Calendar) -> Box<Self> {
-        self.y_calendar = Some(y_calendar);
-        Box::new(self)
-    }
-
-    pub fn z_calendar(mut self, z_calendar: Calendar) -> Box<Self> {
-        self.z_calendar = Some(z_calendar);
-        Box::new(self)
     }
 }
 

--- a/plotly_derive/Cargo.toml
+++ b/plotly_derive/Cargo.toml
@@ -1,0 +1,15 @@
+[package]
+name = "plotly_derive"
+version = "0.1.0"
+edition = "2021"
+publish = false
+
+
+[dependencies]
+quote = "1.0"
+syn = "1.0"
+proc-macro2 = "1.0"
+darling = "0.14.1"
+
+[lib]
+proc-macro = true

--- a/plotly_derive/src/lib.rs
+++ b/plotly_derive/src/lib.rs
@@ -1,0 +1,325 @@
+#![recursion_limit = "256"]
+
+use darling::{ast, FromDeriveInput, FromField};
+use proc_macro2::{Ident, TokenStream};
+use quote::{quote, ToTokens, TokenStreamExt};
+use syn::{DeriveInput, GenericArgument, Generics, TypeParamBound};
+
+#[derive(Debug, FromDeriveInput)]
+#[darling(attributes(field_setter), supports(struct_named))]
+struct StructReceiver {
+    /// The struct name.
+    ident: syn::Ident,
+
+    /// The body of the struct or enum. We don't care about enum fields
+    /// because we accept only named structs. Hence the first type is null.
+    data: ast::Data<(), FieldReceiver>,
+
+    generics: Generics,
+
+    #[darling(default)]
+    no_box: bool,
+}
+
+impl ToTokens for StructReceiver {
+    fn to_tokens(&self, tokens: &mut TokenStream) {
+        let ident = &self.ident;
+
+        let (impl_generics, ty_generics, where_clause) = self.generics.split_for_impl();
+
+        let mut setter_functions = quote![];
+        let mut default_vals = quote![];
+
+        match self.data {
+            ast::Data::Struct(ref f) => {
+                for field in f.fields.iter() {
+                    let this_setter = field.setter_function(self.no_box);
+                    setter_functions = quote![
+                        #setter_functions
+                        #this_setter
+                    ];
+
+                    let this_default = field.default_value();
+                    default_vals = quote![
+                        #default_vals
+                        #this_default
+                    ];
+                }
+            }
+            _ => unreachable!(),
+        }
+
+        tokens.append_all(quote! {
+            impl #impl_generics Default for #ident #ty_generics #where_clause {
+                fn default() -> Self {
+                    Self {
+                        #default_vals
+                    }
+                }
+            }
+
+            impl #impl_generics #ident #ty_generics #where_clause {
+                #setter_functions
+            }
+        });
+    }
+}
+
+// Not using a recursive enum for simplicity
+#[derive(Clone, Copy)]
+enum FieldType {
+    NotOption,
+    OptionDimString,
+    OptionDimOther,
+    OptionVecString,
+    OptionBoxColor,
+    OptionVecBoxColor,
+    OptionString,
+    OptionNumOrString,
+    OptionNumOrStringCollection,
+    OptionOther,
+}
+
+fn _type_str_parts(field_ty: &syn::Type) -> Vec<String> {
+    let mut ty = field_ty;
+    let mut parts = Vec::new();
+    loop {
+        match ty {
+            syn::Type::Path(ref type_path) if type_path.qself == None => {
+                if let Some(segment) = type_path.path.segments.last() {
+                    parts.push(segment.ident.to_string());
+                    match &segment.arguments {
+                        syn::PathArguments::AngleBracketed(args) => match args.args.first() {
+                            Some(first) => {
+                                if let GenericArgument::Type(inner_ty) = first {
+                                    ty = inner_ty
+                                } else {
+                                    break;
+                                }
+                            }
+                            None => break,
+                        },
+                        _ => break,
+                    }
+                } else {
+                    break;
+                }
+            }
+            // Handle Box<dyn Color>
+            syn::Type::TraitObject(ref obj) => {
+                if obj.dyn_token.is_some() {
+                    if let Some(TypeParamBound::Trait(t)) = obj.bounds.first() {
+                        if let Some(segment) = t.path.segments.last() {
+                            parts.push(segment.ident.to_string());
+                        }
+                    }
+                }
+                break;
+            }
+            _ => break,
+        }
+    }
+    parts
+}
+
+impl FieldType {
+    fn infer(field_ty: &syn::Type) -> Self {
+        // Not the best implementation but works in practice
+
+        let type_str_parts = _type_str_parts(field_ty);
+        if type_str_parts.first().map_or(false, |t| t != "Option") {
+            return FieldType::NotOption;
+        }
+
+        let remaining: Vec<_> = type_str_parts.iter().skip(1).map(|x| x.as_str()).collect();
+
+        match remaining.as_slice() {
+            ["Dim", "String"] => FieldType::OptionDimString,
+            ["Dim", ..] => FieldType::OptionDimOther,
+            ["Vec", "String"] => FieldType::OptionVecString,
+            ["String"] => FieldType::OptionString,
+            ["NumOrString"] => FieldType::OptionNumOrString,
+            ["NumOrStringCollection"] => FieldType::OptionNumOrStringCollection,
+            ["Box", "Color"] => FieldType::OptionBoxColor,
+            ["Vec", "Box", "Color"] => FieldType::OptionVecBoxColor,
+            _ => FieldType::OptionOther,
+        }
+    }
+}
+
+#[allow(dead_code)]
+#[derive(Debug, FromField)]
+#[darling(attributes(field_setter), forward_attrs(doc))]
+struct FieldReceiver {
+    /// Name of the field
+    ident: Option<syn::Ident>,
+
+    /// The type of the field
+    ty: syn::Type,
+
+    attrs: Vec<syn::Attribute>,
+
+    #[darling(default)]
+    skip: bool,
+
+    #[darling(default)]
+    default: Option<String>,
+}
+
+impl FieldReceiver {
+    fn default_value(&self) -> TokenStream {
+        let field_ident = self.ident.as_ref().unwrap();
+        match FieldType::infer(&self.ty) {
+            FieldType::NotOption => {
+                // Require a default
+                assert!(
+                    self.default.is_some(),
+                    "Please provide #[field_setter(default=\"..\") for the field {}",
+                    field_ident
+                );
+                let val: proc_macro2::TokenStream = self.default.as_ref().unwrap().parse().unwrap();
+                quote![
+                    #field_ident: #val,
+                ]
+            }
+            _ => {
+                quote![
+                    #field_ident: None,
+                ]
+            }
+        }
+    }
+    fn setter_function(&self, no_box: bool) -> TokenStream {
+        if self.skip {
+            println!("{:#?}", _type_str_parts(&self.ty));
+            return quote![];
+        }
+        let field_ident = self.ident.as_ref().unwrap();
+        let field_ty = &self.ty;
+        let field_docs = self.docs();
+        let (return_ty, return_stmt) = if no_box {
+            (quote![Self], quote![self])
+        } else {
+            (quote![Box<Self>], quote![Box::new(self)])
+        };
+
+        let field_type = FieldType::infer(field_ty);
+
+        let (value_type, value_convert, array_value_convert) = match field_type {
+            FieldType::NotOption => {
+                return quote![];
+            }
+            FieldType::OptionDimString => (
+                quote![impl AsRef<str>],
+                quote![Dim::Scalar(value.as_ref().to_owned())],
+                quote![Dim::Vector(
+                    value.into_iter().map(|v| v.as_ref().to_owned()).collect()
+                )],
+            ),
+            FieldType::OptionDimOther => (
+                quote![<<#field_ty as crate::GetInner>::Inner as crate::GetInner>::Inner],
+                quote![Dim::Scalar(value)],
+                quote![Dim::Vector(value)],
+            ),
+            FieldType::OptionString => (
+                quote![impl AsRef<str>],
+                quote![value.as_ref().to_owned()],
+                quote![],
+            ),
+            FieldType::OptionOther => (
+                quote![<#field_ty as crate::GetInner>::Inner],
+                quote![value],
+                quote![],
+            ),
+            FieldType::OptionVecString => (
+                quote![Vec<impl AsRef<str>>],
+                quote![value.into_iter().map(|v| v.as_ref().to_owned()).collect()],
+                quote![],
+            ),
+            FieldType::OptionBoxColor => (
+                quote![impl crate::color::Color],
+                quote![Box::new(value)],
+                quote![],
+            ),
+            FieldType::OptionVecBoxColor => (
+                quote![Vec<impl crate::color::Color>],
+                quote![crate::color::ColorArray(value).into()],
+                quote![],
+            ),
+            FieldType::OptionNumOrString => (
+                quote![impl Into<crate::private::NumOrString>],
+                quote![value.into()],
+                quote![],
+            ),
+            FieldType::OptionNumOrStringCollection => (
+                quote![Vec<impl Into<crate::private::NumOrString> + Clone>],
+                quote![value.into()],
+                quote![],
+            ),
+        };
+
+        let setter = quote! {
+            #field_docs
+            pub fn #field_ident(mut self, value: #value_type) -> #return_ty {
+                self.#field_ident = Some(#value_convert);
+                #return_stmt
+            }
+        };
+
+        let array_setter = match field_type {
+            FieldType::OptionDimString | FieldType::OptionDimOther => {
+                let array_ident = Ident::new(
+                    &format!("{}_array", field_ident),
+                    proc_macro2::Span::call_site(),
+                );
+                quote! {
+                    #field_docs
+                    pub fn #array_ident(mut self, value: Vec<#value_type>) -> #return_ty {
+                        self.#field_ident = Some(#array_value_convert);
+                        #return_stmt
+                    }
+                }
+            }
+            _ => quote![],
+        };
+        quote![
+            #setter
+            #array_setter
+        ]
+    }
+    fn docs(&self) -> TokenStream {
+        self.attrs
+            .iter()
+            .filter(|attr| {
+                attr.path
+                    .segments
+                    .first()
+                    .map_or(false, |p| p.ident == "doc")
+            })
+            .map(|attr| {
+                quote![
+                    #attr
+                ]
+            })
+            .collect()
+    }
+}
+
+const UNSUPPORTED_ERROR: &str = r#"FieldSetter can only be derived for structs with named fields"#;
+
+#[proc_macro_derive(FieldSetter, attributes(field_setter))]
+pub fn html_template(item: proc_macro::TokenStream) -> proc_macro::TokenStream {
+    let item = syn::parse::<DeriveInput>(item).unwrap();
+    let struct_receiver = match StructReceiver::from_derive_input(&item) {
+        Ok(r) => r,
+        Err(e) => {
+            return proc_macro::TokenStream::from(
+                darling::Error::custom(format!("{}. {}", UNSUPPORTED_ERROR, e)).write_errors(),
+            )
+        }
+    };
+    quote! {
+        #struct_receiver
+    }
+    .into()
+}


### PR DESCRIPTION
_Thank you for this wonderful crate. I have personally found it much easier to make a plotly chart using this crate aided by the Rust type system as opposed to other options. Excited to contribute to this repository._

This PR introduces two changes:

## Change 1: FieldSetter derive marco
There are a number of structs defined in this crate that have private fields and public functions to set the value for each of these fields. The `FieldSetter` procedural marco, when applied on a struct, auto-derives the public setter functions for each of the fields in the struct. The setter functions have a small number of distinct signatures based on the type of the field. Types such as `Dim, String, Color, NumOrString` get a special syntax. The procedural macro is defined in the `plotly_derive` crate. I have updated the `traces` and `layout` modules to use the procedural macro (resulting in a lot of code deletions). The macro also proved two attributes
- `#[field_setter(box_self)]` - The setter functions return `Box<Self>` instead of `Self` if applied to the struct
- `#[field_setter(skip)]` - To skip generating setter function for a specific field

The procedural macro is not fully general to cover type aliasing etc, but works in practice for this crate.

### Pros
- Consistent setter API across all structs
- Minimal code required to define new structs

### Cons
- Additional dependencies
- Slightly slower compilation due to proc macro expansion

## Change 2: Support for Buttons (update menu)
I have defined the structs required to support buttons in a plotly chart (https://plotly.com/javascript/reference/layout/updatemenus/) in a new module `layout/update_menu.rs`. 

Using these structs we can add buttons with this crate. However the button API (https://plotly.com/python/dropdowns/) is not strongly-typed and needs lots of "stringy" arguments. Instead, I have added a new approach to help create buttons. There are three button methods that I have focused on:
- `restyle`: modify traces
- `relayout`: modify layout
- `update` modify traces and layout

### Restyles

First I have defined a `Restyle` marker trait. The `FieldSetter` macro defines a new enum for each struct if it is marked as `#[field_setter(kind = "trace")]`. As an example, say we are deriving FieldSetter on the (simplified) `SimpleBar` struct

```
#[serde_with::skip_serializing_none]
#[derive(Serialize, Debug, Clone, FieldSetter)]
#[field_setter(box_self, kind = "trace")]
pub struct SimpleBar
{
    name: Option<String>,
    visible: Option<Visible>,
}
```

The derived enum would look like
```
pub enum RestyleSimpleBar {
  ModifyName { name: Option<Dim<String>> },
  ModifyVisible { name: Option<Dim<Visible>> },
}
```
i.e it contains one enum variant for modifying each of the struct fields. The reason each field is wrapped with a `Dim` is that plotly provide option to modify all the traces in the plot using a scalar argument or control what to modify in each trace using a list argument. This enum implements the `Restyle` trait.

Additionally we also define helper functions for SimpleBar 
```
impl Bar {
  pub fn modify_all_name(value: impl AsRef<str>) -> RestlyeSimpleBar {
    RestlyeSimpleBar::ModifyName { name: Some(Dim::Scalar(value.as_ref().into())) }
  }
  pub fn modify_name(values: vec![impl AsRef<str>]) -> RestlyeSimpleBar {
    RestlyeSimpleBar::ModifyName { name: ... }
  }
  // .... similarly for visible
}
```

Coupled with this we have a `ButtonBuilder` struct that has a `push_restyle()` function which accepts any struct that implements `Restyle` trait. On invoking the `ButtonBuilder::build()` function, the builder sets up the Button correctly with the arguments in the right form.

So for example, if we have two bar plots and we want a button to alternate between them, we can create the button using
```
let buttons = vec![
      ButtonBuilder::new()
          .label("Chart1")
          .push_restyle(SimpleBar::modify_visible(vec![Visible::True, Visible::False]))
          .build(),
      ButtonBuilder::new()
          .label("Chart2")
          .push_restyle(SimpleBar::modify_visible(vec![Visible::False, Visible::True]))
          .build(),
  ]
```

### Relayout
Similar to `Restyle` we have a `Relayout` trait. We derive a new enum which implements `Relayout` if the struct is annotated with `#[field_setter(kind = "layout")]`. Since you only have a single layout per plot, we don't do the `Dim` wrapping here. The `ButtonBuilder` also has a `push_relayout` function.

### Examples
```
cargo r --example=buttons
```
Three plots that demonstrate the use of `UpdateMenu` to create buttons:
- Dropdown to alternate between two bar plots (restyle)
![Screen-Recording-2022-09-01-at-3 45 50-PM](https://user-images.githubusercontent.com/5753553/188025538-076b4273-5787-4f01-849f-aa76518240ff.gif)

- Heatmap with buttons to choose colorscale (restyle)
![Screen-Recording-2022-09-01-at-3 49 53-PM](https://user-images.githubusercontent.com/5753553/188025825-d3fe3631-1dfe-4a16-8855-03be8ead88ea.gif)


- Button to change barmode (relayout)
![Screen-Recording-2022-09-01-at-3 50 43-PM](https://user-images.githubusercontent.com/5753553/188025842-4c0a6679-f48c-473e-9aea-228c1412d7b4.gif)

