### PR TITLE
[#132]: Proposed Fix - "Plot `show` Method Not Working on Windows 10"

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/) a
 
 ## [0.8.4] - 2023-01-xx
 ### Fixed
-- [[#129](https://github.com/igiagkiozis/plotly/pull/129)] Fix issue for plots not showing in browser in Windows. Thanks to [@juanespj](https://github.com/juanespj) for the PR.
+- [[#129](https://github.com/igiagkiozis/plotly/pull/129)] Fix issue for plots not showing in browser in Windows. Thanks to [@juanespj](https://github.com/juanespj) and [@M-NK-Y](https://github.com/M-NK-Y) for the PRs.
 
 ## [0.8.3] - 2022-11-04
 ### Fixed

--- a/plotly/src/plot.rs
+++ b/plotly/src/plot.rs
@@ -471,9 +471,8 @@ impl Plot {
     fn show_with_default_app(temp_path: &str) {
         use std::process::Command;
         Command::new("cmd")
-            .arg("/C")
-            .arg(format!("start {}", temp_path))
-            .output()
+            .args(&["/C", "start", &format!(r#"{}"#, temp_path)])
+            .spawn()
             .expect(DEFAULT_HTML_APP_NOT_FOUND);
     }
 }


### PR DESCRIPTION
Changes `show_with_default_app` for `target_os = "windows"` to make use of `spawn` in place of `output` when attempting to open the temporary HTML file using the user's default browser. Additionally provides arguments within a shared object delegating command formatting to `std::process:Command`, which going forwards I think will be a safe bet to ensure path correctness.
