### PR TITLE
Add `LayoutScene`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,9 +3,9 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/) and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [0.8.5] - 2023-07-19
+## [0.8.5] - 2023-xx-xx
 ### Added
-- [] Added `LayoutScene`
+- [[#153](https://github.com/igiagkiozis/plotly/pull/153)] Added `LayoutScene`
 
 ## [0.8.4] - 2023-07-09
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,10 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/) and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.8.5] - 2023-07-19
+### Added
+- [] Added `LayoutScene`
+
 ## [0.8.4] - 2023-07-09
 ### Added
 - [[#143](https://github.com/igiagkiozis/plotly/pull/143)] Widen version range of `askama`.

--- a/examples/3d_charts/src/main.rs
+++ b/examples/3d_charts/src/main.rs
@@ -2,8 +2,9 @@
 
 use ndarray::Array;
 use plotly::{
-    common::{ColorScale, ColorScalePalette, Marker, MarkerSymbol, Mode, Title},
-    layout::{Axis, Layout, LayoutScene},
+    color::Rgb,
+    common::{ColorScale, ColorScalePalette, Font, Marker, MarkerSymbol, Mode, Title},
+    layout::{Axis, Camera, Layout, LayoutScene, Legend, Margin, ProjectionType},
     Mesh3D, Plot, Scatter3D, Surface,
 };
 

--- a/examples/3d_charts/src/main.rs
+++ b/examples/3d_charts/src/main.rs
@@ -29,6 +29,7 @@ fn customized_scatter3d_plot() {
     let sizelookup = z.clone();
 
     let trace = Scatter3D::new(t.clone(), y.clone(), z.iter().map(|i| -i).collect())
+        .name("Helix 1")
         .mode(Mode::Markers)
         .marker(
             Marker::new()
@@ -42,26 +43,65 @@ fn customized_scatter3d_plot() {
                 .color_scale(ColorScale::Palette(ColorScalePalette::Viridis)),
         );
 
-    let trace2 = Scatter3D::new(t, z, y).mode(Mode::Markers).marker(
-        Marker::new()
-            .size_array(
-                sizelookup
-                    .iter()
-                    .map(|i| (i.abs() * 25f64) as usize)
-                    .collect(),
-            )
-            .color_scale(ColorScale::Palette(ColorScalePalette::Viridis)),
-    );
+    let trace2 = Scatter3D::new(t, z, y)
+        .name("Helix 2")
+        .mode(Mode::Markers)
+        .marker(
+            Marker::new()
+                .size_array(
+                    sizelookup
+                        .iter()
+                        .map(|i| (i.abs() * 25f64) as usize)
+                        .collect(),
+                )
+                .color_scale(ColorScale::Palette(ColorScalePalette::Viridis)),
+        );
 
     let mut plot = Plot::new();
     plot.add_trace(trace);
     plot.add_trace(trace2);
-    let layout = Layout::new().title("Helix".into()).scene(
-        LayoutScene::new()
-            .x_axis(Axis::new().title("x (A meaningful axis name goes here)".into()))
-            .y_axis(Axis::new().title(Title::new("This is the label of the Y axis")))
-            .z_axis(Axis::new().title("z Axis".into())),
-    );
+
+    let background_color: Rgb = Rgb::new(70, 70, 70);
+    let front_color: Rgb = Rgb::new(255, 255, 255);
+
+    let layout = Layout::new()
+        .title("Helix".into())
+        .legend(Legend::new().x(0.9).y(0.9))
+        .font(Font::new().color(front_color))
+        .paper_background_color(background_color)
+        .scene(
+            LayoutScene::new()
+                .x_axis(
+                    Axis::new()
+                        .title("x (A meaningful axis name goes here)".into())
+                        .tick_angle(0f64)
+                        .grid_color(front_color)
+                        .color(front_color),
+                )
+                .y_axis(
+                    Axis::new()
+                        .title(Title::new("This is the label of the Y axis"))
+                        .tick_format(".1f")
+                        .grid_color(front_color)
+                        .color(front_color),
+                )
+                .z_axis(Axis::new().title("".into()).tick_values(vec![]))
+                .aspect_mode(plotly::layout::AspectMode::Manual)
+                .aspect_ratio((3.0, 1.0, 1.0).into())
+                .camera(
+                    Camera::new()
+                        .projection(ProjectionType::Orthographic.into())
+                        .eye((0.0, 0.0, 1.0).into())
+                        .up((0.0, 1.0, 0.0).into())
+                        .center((0.0, 0.0, 0.0).into()),
+                )
+                .drag_mode(plotly::layout::DragMode3D::Pan)
+                .hover_mode(plotly::layout::HoverMode::Closest)
+                .background_color(background_color),
+        )
+        .margin(Margin::new().left(0).right(0).top(50).bottom(0))
+        .width(1000)
+        .height(500);
     plot.set_layout(layout);
 
     plot.show();

--- a/examples/3d_charts/src/main.rs
+++ b/examples/3d_charts/src/main.rs
@@ -3,7 +3,7 @@
 use ndarray::Array;
 use plotly::{
     common::{ColorScale, ColorScalePalette, Marker, MarkerSymbol, Mode, Title},
-    layout::{Axis, Layout},
+    layout::{Axis, Layout, LayoutScene},
     Mesh3D, Plot, Scatter3D, Surface,
 };
 
@@ -56,11 +56,12 @@ fn customized_scatter3d_plot() {
     let mut plot = Plot::new();
     plot.add_trace(trace);
     plot.add_trace(trace2);
-    let layout = Layout::new()
-        .title("Helix".into())
-        .x_axis(Axis::new().title("x (A meaningful axis name goes here)".into()))
-        .y_axis(Axis::new().title(Title::new("This is the label of the Y axis")))
-        .z_axis(Axis::new().title("z Axis".into()));
+    let layout = Layout::new().title("Helix".into()).scene(
+        LayoutScene::new()
+            .x_axis(Axis::new().title("x (A meaningful axis name goes here)".into()))
+            .y_axis(Axis::new().title(Title::new("This is the label of the Y axis")))
+            .z_axis(Axis::new().title("z Axis".into())),
+    );
     plot.set_layout(layout);
 
     plot.show();

--- a/plotly/.gitignore
+++ b/plotly/.gitignore
@@ -2,3 +2,4 @@ target/
 .idea
 Cargo.lock
 gh-pages/
+.vscode

--- a/plotly/src/layout/mod.rs
+++ b/plotly/src/layout/mod.rs
@@ -1374,11 +1374,75 @@ pub enum AspectMode {
 
 #[serde_with::skip_serializing_none]
 #[derive(Serialize, Debug, Clone, FieldSetter)]
+pub struct Eye {
+    x: Option<f64>,
+    y: Option<f64>,
+    z: Option<f64>,
+}
+
+impl From<(f64, f64, f64)> for Eye {
+    fn from((x, y, z): (f64, f64, f64)) -> Self {
+        Eye {
+            x: Some(x),
+            y: Some(y),
+            z: Some(z),
+        }
+    }
+}
+
+#[serde_with::skip_serializing_none]
+#[derive(Serialize, Debug, Clone, FieldSetter)]
+pub struct Up {
+    x: Option<f64>,
+    y: Option<f64>,
+    z: Option<f64>,
+}
+
+#[derive(Serialize, Debug, Clone)]
+pub enum ProjectionType {
+    #[serde(rename = "perspective")]
+    Perspective,
+    #[serde(rename = "orthographic")]
+    Orthographic,
+}
+
+impl From<ProjectionType> for Projection {
+    fn from(projection_type: ProjectionType) -> Self {
+        Projection {
+            projection_type: Some(projection_type),
+        }
+    }
+}
+
+#[serde_with::skip_serializing_none]
+#[derive(Serialize, Debug, Clone, FieldSetter)]
+pub struct Projection {
+    #[serde(rename = "type")]
+    projection_type: Option<ProjectionType>,
+}
+
+#[serde_with::skip_serializing_none]
+#[derive(Serialize, Debug, Clone, FieldSetter)]
+pub struct Camera {
+    // center: Option<Center>,
+    eye: Option<Eye>,
+    up: Option<Up>,
+    projection: Option<Projection>,
+}
+
+impl Camera {
+    pub fn new() -> Self {
+        Default::default()
+    }
+}
+
+#[serde_with::skip_serializing_none]
+#[derive(Serialize, Debug, Clone, FieldSetter)]
 pub struct LayoutScene {
     #[serde(rename = "bgcolor")]
     background_color: Option<Box<dyn Color>>,
 
-    // camera: Camera,
+    camera: Option<Camera>,
     // domain: Domain,
     #[serde(rename = "aspectmode")]
     aspect_mode: Option<AspectMode>,

--- a/plotly/src/layout/mod.rs
+++ b/plotly/src/layout/mod.rs
@@ -1285,8 +1285,8 @@ impl Serialize for DragMode {
 
 #[derive(Debug, Clone)]
 /// Determines the mode of drag interactions.
-/// TODO: either make an outer DragMode enum with inner 2D and 3D enums or leave
-/// this as is -> Draw variants are only for 2D
+/// TODO: some DragMode variants are only valid for 2D -> either make an outer DragMode
+/// enum with inner 2D and 3D enums or leave this as is
 pub enum DragMode3D {
     Zoom,
     Pan,

--- a/plotly/src/layout/mod.rs
+++ b/plotly/src/layout/mod.rs
@@ -1285,8 +1285,8 @@ impl Serialize for DragMode {
 
 #[derive(Debug, Clone)]
 /// Determines the mode of drag interactions.
-/// TODO: some DragMode variants are only valid for 2D -> either make an outer DragMode
-/// enum with inner 2D and 3D enums or leave this as is
+/// TODO: some DragMode variants are only valid for 2D -> either make an outer
+/// DragMode enum with inner 2D and 3D enums or leave this as is
 pub enum DragMode3D {
     Zoom,
     Pan,
@@ -1475,21 +1475,16 @@ impl From<(f64, f64, f64)> for Up {
     }
 }
 
-#[derive(Serialize, Debug, Clone)]
+#[derive(Default, Serialize, Debug, Clone)]
 /// Sets the projection type. The projection type could be either "perspective"
 /// or "orthographic".
 /// Default: "perspective"
 pub enum ProjectionType {
+    #[default]
     #[serde(rename = "perspective")]
     Perspective,
     #[serde(rename = "orthographic")]
     Orthographic,
-}
-
-impl Default for ProjectionType {
-    fn default() -> Self {
-        ProjectionType::Perspective
-    }
 }
 
 impl From<ProjectionType> for Projection {

--- a/plotly/src/layout/mod.rs
+++ b/plotly/src/layout/mod.rs
@@ -1283,6 +1283,33 @@ impl Serialize for DragMode {
     }
 }
 
+#[derive(Debug, Clone)]
+/// Determines the mode of drag interactions.
+/// TODO: either make an outer DragMode enum with inner 2D and 3D enums or leave
+/// this as is -> Draw variants are only for 2D
+pub enum DragMode3D {
+    Zoom,
+    Pan,
+    Turntable,
+    Orbit,
+    False,
+}
+
+impl Serialize for DragMode3D {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        match *self {
+            Self::Zoom => serializer.serialize_str("zoom"),
+            Self::Pan => serializer.serialize_str("pan"),
+            Self::Turntable => serializer.serialize_str("turntable"),
+            Self::Orbit => serializer.serialize_str("orbit"),
+            Self::False => serializer.serialize_bool(false),
+        }
+    }
+}
+
 #[derive(Serialize, Debug, Clone)]
 #[serde(rename_all = "lowercase")]
 pub enum SelectDirection {
@@ -1590,7 +1617,7 @@ pub struct LayoutScene {
     #[serde(rename = "zaxis")]
     z_axis: Option<Axis>,
     #[serde(rename = "dragmode")]
-    drag_mode: Option<DragMode>,
+    drag_mode: Option<DragMode3D>,
     #[serde(rename = "hovermode")]
     hover_mode: Option<HoverMode>,
     annotations: Option<Vec<Annotation>>,
@@ -3236,7 +3263,7 @@ mod tests {
                 .camera(Camera::new())
                 .aspect_mode(AspectMode::Auto)
                 .hover_mode(HoverMode::Closest)
-                .drag_mode(DragMode::Turntable)
+                .drag_mode(DragMode3D::Turntable)
                 .background_color("#FFFFFF")
                 .annotations(vec![Annotation::new()]),
         );

--- a/plotly/src/layout/mod.rs
+++ b/plotly/src/layout/mod.rs
@@ -1396,8 +1396,10 @@ impl Mapbox {
 /// when one axis is more than four times the size of the two others, where in
 /// that case the results of "cube" are used.
 /// Default: "auto"
+#[derive(Default)]
 pub enum AspectMode {
     #[serde(rename = "auto")]
+    #[default]
     Auto,
     #[serde(rename = "cube")]
     Cube,
@@ -1407,11 +1409,7 @@ pub enum AspectMode {
     Manual,
 }
 
-impl Default for AspectMode {
-    fn default() -> Self {
-        AspectMode::Auto
-    }
-}
+
 
 #[serde_with::skip_serializing_none]
 #[derive(Serialize, Debug, Clone, FieldSetter)]

--- a/plotly/src/layout/mod.rs
+++ b/plotly/src/layout/mod.rs
@@ -1360,6 +1360,50 @@ impl Mapbox {
     }
 }
 
+#[derive(Serialize, Debug, Clone)]
+pub enum AspectMode {
+    #[serde(rename = "auto")]
+    Auto,
+    #[serde(rename = "cube")]
+    Cube,
+    #[serde(rename = "data")]
+    Data,
+    #[serde(rename = "manual")]
+    Manual,
+}
+
+#[serde_with::skip_serializing_none]
+#[derive(Serialize, Debug, Clone, FieldSetter)]
+pub struct LayoutScene {
+    #[serde(rename = "bgcolor")]
+    background_color: Option<Box<dyn Color>>,
+
+    // camera: Camera,
+    // domain: Domain,
+    #[serde(rename = "aspectmode")]
+    aspect_mode: Option<AspectMode>,
+    // #[serde(rename = "aspectratio")]
+    // aspect_ratio: AspectRatio
+    #[serde(rename = "xaxis")]
+    x_axis: Option<Axis>,
+    #[serde(rename = "yaxis")]
+    y_axis: Option<Axis>,
+    #[serde(rename = "zaxis")]
+    z_axis: Option<Axis>,
+
+    #[serde(rename = "dragmode")]
+    drag_mode: Option<String>,
+    #[serde(rename = "hovermode")]
+    hover_mode: Option<HoverMode>,
+    annotations: Option<Vec<Annotation>>,
+}
+
+impl LayoutScene {
+    pub fn new() -> Self {
+        Default::default()
+    }
+}
+
 #[serde_with::skip_serializing_none]
 #[derive(Serialize, Debug, Clone, FieldSetter)]
 pub struct Template {
@@ -1481,7 +1525,7 @@ pub struct LayoutTemplate {
     y_axis8: Option<Box<Axis>>,
 
     // ternary: Option<LayoutTernary>,
-    // scene: Option<LayoutScene>,
+    scene: Option<LayoutScene>,
     // polar: Option<LayoutPolar>,
     annotations: Option<Vec<Annotation>>,
     shapes: Option<Vec<Shape>>,
@@ -1665,7 +1709,7 @@ pub struct Layout {
     z_axis8: Option<Box<Axis>>,
 
     // ternary: Option<LayoutTernary>,
-    // scene: Option<LayoutScene>,
+    scene: Option<LayoutScene>,
     // polar: Option<LayoutPolar>,
     annotations: Option<Vec<Annotation>>,
     shapes: Option<Vec<Shape>>,

--- a/plotly/src/layout/mod.rs
+++ b/plotly/src/layout/mod.rs
@@ -1454,9 +1454,8 @@ pub struct LayoutScene {
     y_axis: Option<Axis>,
     #[serde(rename = "zaxis")]
     z_axis: Option<Axis>,
-
     #[serde(rename = "dragmode")]
-    drag_mode: Option<String>,
+    drag_mode: Option<DragMode>,
     #[serde(rename = "hovermode")]
     hover_mode: Option<HoverMode>,
     annotations: Option<Vec<Annotation>>,
@@ -3083,6 +3082,38 @@ mod tests {
             "sunburstcolorway": ["#654654"],
             "extendsunburstcolors": false,
             "zaxis": {},
+        });
+
+        assert_eq!(to_value(layout).unwrap(), expected);
+    }
+
+    #[test]
+    fn test_serialize_layout_scene() {
+        let layout = Layout::new().scene(
+            LayoutScene::new()
+                .x_axis(Axis::new())
+                .y_axis(Axis::new())
+                .z_axis(Axis::new())
+                .camera(Camera::new())
+                .aspect_mode(AspectMode::Auto)
+                .hover_mode(HoverMode::Closest)
+                .drag_mode(DragMode::Turntable)
+                .background_color("#FFFFFF")
+                .annotations(vec![Annotation::new()]),
+        );
+
+        let expected = json!({
+            "scene": {
+                "xaxis": {},
+                "yaxis": {},
+                "zaxis": {},
+                "camera": {},
+                "aspectmode": "auto",
+                "hovermode": "closest",
+                "dragmode": "turntable",
+                "bgcolor": "#FFFFFF",
+                "annotations": [{}],
+            }
         });
 
         assert_eq!(to_value(layout).unwrap(), expected);

--- a/plotly/src/layout/mod.rs
+++ b/plotly/src/layout/mod.rs
@@ -1285,8 +1285,6 @@ impl Serialize for DragMode {
 
 #[derive(Debug, Clone)]
 /// Determines the mode of drag interactions.
-/// TODO: some DragMode variants are only valid for 2D -> either make an outer
-/// DragMode enum with inner 2D and 3D enums or leave this as is
 pub enum DragMode3D {
     Zoom,
     Pan,
@@ -1409,8 +1407,6 @@ pub enum AspectMode {
     Manual,
 }
 
-
-
 #[serde_with::skip_serializing_none]
 #[derive(Serialize, Debug, Clone, FieldSetter)]
 /// Sets the (x, y, z) components of the 'eye' camera vector. This vector
@@ -1495,8 +1491,7 @@ impl From<ProjectionType> for Projection {
 
 #[serde_with::skip_serializing_none]
 #[derive(Serialize, Debug, Clone, FieldSetter)]
-/// Container for ProjectionType
-/// TODO: Implemented according to https://plotly.com/python/reference/layout/scene/#layout-scene-camera-projection -> Complicating it to projection { type: ..} instead of projection: .. really necessary?
+/// Container for Projection options.
 pub struct Projection {
     #[serde(rename = "type")]
     projection_type: Option<ProjectionType>,
@@ -1580,10 +1575,6 @@ impl AspectRatio {
 
 impl From<(f64, f64, f64)> for AspectRatio {
     fn from((x, y, z): (f64, f64, f64)) -> Self {
-        // assert!(x >= 0.0);
-        // assert!(y >= 0.0);
-        // assert!(z >= 0.0);
-        // TODO: panic if any of the values are negative?
         AspectRatio {
             x: Some(x),
             y: Some(y),


### PR DESCRIPTION
Hi team,

I'd like to discuss a few things. There are a few remaining TODOs that need your attention. One specific concern involves handling arguments below zero to `AspectRatio` - I'd appreciate your advice on how to approach this.

Additionally, do you think it would be a good idea to rename the struct `LayoutScene` to just `Scene` or `Scene3D`?

I also updated the `customized_scatter3d_plot()` example in the `3d_charts` section. The example now includes most of the newly implemented fields and produces a very 'customized' plot.

![newplot (2)](https://github.com/igiagkiozis/plotly/assets/94180412/edf4b8ff-327b-4670-8e6e-acddfacec1a4)


I'm open to any feedback or suggestions you may have.