### PR TITLE
Type trace axis ids

### DIFF
--- a/plotly/src/common/mod.rs
+++ b/plotly/src/common/mod.rs
@@ -893,6 +893,16 @@ pub enum Reference {
     Paper,
 }
 
+/// Axis id for a 2D cartesian x axis.
+///
+/// Use `"x"` for the primary axis, `"x2"` for the second axis, and so on.
+pub type XAxisId = String;
+
+/// Axis id for a 2D cartesian y axis.
+///
+/// Use `"y"` for the primary axis, `"y2"` for the second axis, and so on.
+pub type YAxisId = String;
+
 #[derive(Serialize, Clone, Debug)]
 pub struct Pad {
     t: usize,
@@ -1797,6 +1807,14 @@ mod tests {
     fn serialize_reference() {
         assert_eq!(to_value(Reference::Container).unwrap(), json!("container"));
         assert_eq!(to_value(Reference::Paper).unwrap(), json!("paper"));
+    }
+
+    #[test]
+    fn serialize_axis_id() {
+        assert_eq!(to_value(XAxisId::from("x")).unwrap(), json!("x"));
+        assert_eq!(to_value(XAxisId::from("x3")).unwrap(), json!("x3"));
+        assert_eq!(to_value(YAxisId::from("y")).unwrap(), json!("y"));
+        assert_eq!(to_value(YAxisId::from("y8")).unwrap(), json!("y8"));
     }
 
     #[test]

--- a/plotly/src/traces/bar.rs
+++ b/plotly/src/traces/bar.rs
@@ -6,7 +6,7 @@ use serde::Serialize;
 use crate::{
     common::{
         Calendar, ConstrainText, Dim, ErrorData, Font, HoverInfo, Label, LegendGroupTitle, Marker,
-        Orientation, PlotType, TextAnchor, TextPosition, Visible,
+        Orientation, PlotType, TextAnchor, TextPosition, Visible, XAxisId, YAxisId,
     },
     Trace,
 };
@@ -70,9 +70,9 @@ where
     #[serde(rename = "hovertemplate")]
     hover_template: Option<Dim<String>>,
     #[serde(rename = "xaxis")]
-    x_axis: Option<String>,
+    x_axis: Option<XAxisId>,
     #[serde(rename = "yaxis")]
-    y_axis: Option<String>,
+    y_axis: Option<YAxisId>,
     orientation: Option<Orientation>,
     #[serde(rename = "alignmentgroup")]
     alignment_group: Option<String>,

--- a/plotly/src/traces/box_plot.rs
+++ b/plotly/src/traces/box_plot.rs
@@ -7,7 +7,7 @@ use crate::{
     color::Color,
     common::{
         Calendar, Dim, HoverInfo, Label, LegendGroupTitle, Line, Marker, Orientation, PlotType,
-        Visible,
+        Visible, XAxisId, YAxisId,
     },
     Trace,
 };
@@ -124,9 +124,9 @@ where
     #[serde(rename = "hovertemplate")]
     hover_template: Option<Dim<String>>,
     #[serde(rename = "xaxis")]
-    x_axis: Option<String>,
+    x_axis: Option<XAxisId>,
     #[serde(rename = "yaxis")]
-    y_axis: Option<String>,
+    y_axis: Option<YAxisId>,
     orientation: Option<Orientation>,
     #[serde(rename = "alignmentgroup")]
     alignment_group: Option<String>,

--- a/plotly/src/traces/candlestick.rs
+++ b/plotly/src/traces/candlestick.rs
@@ -7,6 +7,7 @@ use crate::{
     color::NamedColor,
     common::{
         Calendar, Dim, Direction, HoverInfo, Label, LegendGroupTitle, Line, PlotType, Visible,
+        XAxisId, YAxisId,
     },
     Trace,
 };
@@ -72,9 +73,9 @@ where
     #[serde(rename = "hoverinfo")]
     hover_info: Option<HoverInfo>,
     #[serde(rename = "xaxis")]
-    x_axis: Option<String>,
+    x_axis: Option<XAxisId>,
     #[serde(rename = "yaxis")]
-    y_axis: Option<String>,
+    y_axis: Option<YAxisId>,
     line: Option<Line>,
     #[serde(rename = "whiskerwidth")]
     whisker_width: Option<f64>,

--- a/plotly/src/traces/contour.rs
+++ b/plotly/src/traces/contour.rs
@@ -7,7 +7,7 @@ use crate::{
     color::Color,
     common::{
         Calendar, ColorBar, ColorScale, Dim, Font, HoverInfo, Label, LegendGroupTitle, Line,
-        PlotType, Visible,
+        PlotType, Visible, XAxisId, YAxisId,
     },
     private, Trace,
 };
@@ -137,9 +137,9 @@ where
     #[serde(rename = "hovertemplate")]
     hover_template: Option<Dim<String>>,
     #[serde(rename = "xaxis")]
-    x_axis: Option<String>,
+    x_axis: Option<XAxisId>,
     #[serde(rename = "yaxis")]
-    y_axis: Option<String>,
+    y_axis: Option<YAxisId>,
     line: Option<Line>,
     #[serde(rename = "colorbar")]
     color_bar: Option<ColorBar>,
@@ -403,8 +403,8 @@ where
         Box::new(self)
     }
 
-    pub fn x_axis(mut self, axis: &str) -> Box<Self> {
-        self.x_axis = Some(axis.to_string());
+    pub fn x_axis(mut self, axis: impl Into<XAxisId>) -> Box<Self> {
+        self.x_axis = Some(axis.into());
         Box::new(self)
     }
 
@@ -418,8 +418,8 @@ where
         Box::new(self)
     }
 
-    pub fn y_axis(mut self, axis: &str) -> Box<Self> {
-        self.y_axis = Some(axis.to_string());
+    pub fn y_axis(mut self, axis: impl Into<YAxisId>) -> Box<Self> {
+        self.y_axis = Some(axis.into());
         Box::new(self)
     }
 
@@ -653,6 +653,29 @@ mod tests {
             "transpose": true,
             "xcalendar": "ethiopian",
             "ycalendar": "gregorian"
+        });
+
+        assert_eq!(to_value(trace).unwrap(), expected);
+    }
+
+    #[test]
+    fn serialize_contour_axis_ids() {
+        use crate::common::{XAxisId, YAxisId};
+
+        let x_axis: XAxisId = "x2".into();
+        let y_axis: YAxisId = "y12".into();
+
+        let trace = Contour::new(vec![0., 1.], vec![2., 3.], vec![4., 5.])
+            .x_axis(x_axis)
+            .y_axis(y_axis);
+
+        let expected = json!({
+            "type": "contour",
+            "x": [0.0, 1.0],
+            "y": [2.0, 3.0],
+            "z": [4.0, 5.0],
+            "xaxis": "x2",
+            "yaxis": "y12",
         });
 
         assert_eq!(to_value(trace).unwrap(), expected);

--- a/plotly/src/traces/heat_map.rs
+++ b/plotly/src/traces/heat_map.rs
@@ -6,6 +6,7 @@ use serde::Serialize;
 use crate::{
     common::{
         Calendar, ColorBar, ColorScale, Dim, HoverInfo, Label, LegendGroupTitle, PlotType, Visible,
+        XAxisId, YAxisId,
     },
     private::{NumOrString, NumOrStringCollection},
     Trace,
@@ -106,14 +107,14 @@ where
     visible: Option<Visible>,
     x: Option<Vec<X>>,
     #[serde(rename = "xaxis")]
-    x_axis: Option<String>,
+    x_axis: Option<XAxisId>,
     #[serde(rename = "xcalendar")]
     x_calendar: Option<Calendar>,
     #[serde(rename = "xgap")]
     x_gap: Option<NumOrString>,
     y: Option<Vec<Y>>,
     #[serde(rename = "yaxis")]
-    y_axis: Option<String>,
+    y_axis: Option<YAxisId>,
     #[serde(rename = "ycalendar")]
     y_calendar: Option<Calendar>,
     #[serde(rename = "ygap")]

--- a/plotly/src/traces/histogram.rs
+++ b/plotly/src/traces/histogram.rs
@@ -10,7 +10,7 @@ use crate::ndarray::ArrayTraces;
 use crate::{
     common::{
         Calendar, Dim, ErrorData, HoverInfo, Label, LegendGroupTitle, Marker, Orientation,
-        PlotType, Visible,
+        PlotType, Visible, XAxisId, YAxisId,
     },
     Trace,
 };
@@ -155,14 +155,14 @@ where
     visible: Option<Visible>,
     x: Option<Vec<H>>,
     #[serde(rename = "xaxis")]
-    x_axis: Option<String>,
+    x_axis: Option<XAxisId>,
     #[serde(rename = "xbins")]
     x_bins: Option<Bins>,
     #[serde(rename = "xcalendar")]
     x_calendar: Option<Calendar>,
     y: Option<Vec<H>>,
     #[serde(rename = "yaxis")]
-    y_axis: Option<String>,
+    y_axis: Option<YAxisId>,
     #[serde(rename = "ybins")]
     y_bins: Option<Bins>,
     #[serde(rename = "ycalendar")]

--- a/plotly/src/traces/image.rs
+++ b/plotly/src/traces/image.rs
@@ -8,7 +8,7 @@ use plotly_derive::FieldSetter;
 use serde::Serialize;
 
 use crate::color::{Rgb, Rgba};
-use crate::common::{Dim, HoverInfo, Label, LegendGroupTitle, PlotType, Visible};
+use crate::common::{Dim, HoverInfo, Label, LegendGroupTitle, PlotType, Visible, XAxisId, YAxisId};
 use crate::private::{NumOrString, NumOrStringCollection};
 use crate::Trace;
 
@@ -280,13 +280,13 @@ pub struct Image {
     /// `Layout::x_axis`. If "x2", the x coordinates
     /// refer to `Layout::x_axis2`, and so on.
     #[serde(rename = "xaxis")]
-    x_axis: Option<String>,
+    x_axis: Option<XAxisId>,
     /// Sets a reference between this trace's y coordinates and a 2D cartesian y
     /// axis. If "y" (the default value), the y coordinates refer to
     /// `Layout::y_axis`. If "y2", the y coordinates
     /// refer to `Layout::y_axis2`, and so on.
     #[serde(rename = "yaxis")]
-    y_axis: Option<String>,
+    y_axis: Option<YAxisId>,
 
     /// Color model used to map the numerical color components described in `z`
     /// into colors. If `source` is specified, this attribute will be set to

--- a/plotly/src/traces/scatter.rs
+++ b/plotly/src/traces/scatter.rs
@@ -11,7 +11,7 @@ use crate::{
     color::Color,
     common::{
         Calendar, Dim, ErrorData, Fill, Font, HoverInfo, HoverOn, Label, LegendGroupTitle, Line,
-        Marker, Mode, Orientation, PlotType, Position, Visible,
+        Marker, Mode, Orientation, PlotType, Position, Visible, XAxisId, YAxisId,
     },
     private::{NumOrString, NumOrStringCollection},
     Trace,
@@ -180,13 +180,13 @@ where
     /// `Layout::x_axis`. If "x2", the x coordinates
     /// refer to `Layout::x_axis2`, and so on.
     #[serde(rename = "xaxis")]
-    x_axis: Option<String>,
+    x_axis: Option<XAxisId>,
     /// Sets a reference between this trace's y coordinates and a 2D cartesian y
     /// axis. If "y" (the default value), the y coordinates refer to
     /// `Layout::y_axis`. If "y2", the y coordinates
     /// refer to `Layout::y_axis2`, and so on.
     #[serde(rename = "yaxis")]
-    y_axis: Option<String>,
+    y_axis: Option<YAxisId>,
     /// Only relevant when `stackgroup` is used, and only the first
     /// `orientation` found in the `stackgroup` will be used - including if
     /// `visible` is "legendonly" but not if it is `false`.
@@ -524,6 +524,28 @@ mod tests {
             "yaxis": "y_axis",
             "ycalendar": "coptic",
             "y0": 2
+        });
+
+        assert_eq!(to_value(trace).unwrap(), expected);
+    }
+
+    #[test]
+    fn serialize_scatter_axis_ids() {
+        use crate::common::{XAxisId, YAxisId};
+
+        let x_axis: XAxisId = "x2".into();
+        let y_axis: YAxisId = "y12".into();
+
+        let trace = Scatter::new(vec![0, 1], vec![2, 3])
+            .x_axis(x_axis)
+            .y_axis(y_axis);
+
+        let expected = json!({
+            "type": "scatter",
+            "x": [0, 1],
+            "y": [2, 3],
+            "xaxis": "x2",
+            "yaxis": "y12",
         });
 
         assert_eq!(to_value(trace).unwrap(), expected);

--- a/plotly_derive/src/field_setter.rs
+++ b/plotly_derive/src/field_setter.rs
@@ -341,7 +341,13 @@ impl FieldReceiver {
                 quote![value.as_ref().to_owned()],
                 quote![],
             ),
-            FieldType::OptionOther(inner_ty) => (quote![#inner_ty], quote![value], quote![]),
+            FieldType::OptionOther(inner_ty) => {
+                if matches!(field_ident.to_string().as_str(), "x_axis" | "y_axis") {
+                    (quote![impl Into<#inner_ty>], quote![value.into()], quote![])
+                } else {
+                    (quote![#inner_ty], quote![value], quote![])
+                }
+            }
             FieldType::OptionVecString => (
                 quote![Vec<impl AsRef<str>>],
                 quote![value.into_iter().map(|v| v.as_ref().to_owned()).collect()],


### PR DESCRIPTION
## Description:

Issue [plotly/plotly.py#5583](https://github.com/plotly/plotly.py/issues/5583) points out that trace `x_axis` and `y_axis` setters are not self-explanatory because users have to discover values like `"x2"` and `"y3"` from examples.

This PR keeps the existing string-based axis ids, but gives them named types:
- `XAxisId`
- `YAxisId`

The trace fields now use those named axis-id string types, and the trace setters accept `impl Into<XAxisId>` / `impl Into<YAxisId>` so existing string inputs continue to work without introducing an enum or a hardcoded axis limit.

It also adds regression tests for both code paths:
- derive-generated trace setters (`Scatter`)
- manual trace setters (`Contour`)

This PR does not include the CI fixes from #397 which have been moved there unlike earlier.

Checklist:

- [x] I have reviewed all changes in this PR myself.
- [x] I have added relevant regression test cases for this fix.
- [x] I have run formatting checks in WSL using `cargo +nightly fmt --all -- --check` and `cd examples && cargo +nightly fmt --all -- --check`.
- [x] I have run linting checks in WSL using `cargo clippy -p plotly -p plotly_derive -- -D warnings -A deprecated`.
- [x] I have run focused tests in WSL using `cargo test -p plotly axis_id --features static_export_chromedriver`.
- [x] I have run package tests in WSL using `cargo test -p plotly --features plotly_ndarray,plotly_image,static_export_chromedriver,debug`.

### The validation screenshots of the tests run, locally:

<img width="2535" height="1118" alt="image" src="https://github.com/user-attachments/assets/9892d93e-81dd-4ae0-b139-763bf27c9542" />
<img width="2517" height="1388" alt="image" src="https://github.com/user-attachments/assets/d3cfe9dc-338f-47fe-9ae7-7031cc5e2c34" />

