### PR TITLE
ci: use preinstalled browser binaries

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -38,6 +38,7 @@ jobs:
         with:
           chrome-version: 'latest'
           install-chromedriver: true
+        id: setup-chrome
       - uses: dtolnay/rust-toolchain@stable
         with:
           components: clippy

--- a/plotly_static/build.rs
+++ b/plotly_static/build.rs
@@ -174,19 +174,19 @@ fn setup_driver(config: &WebdriverDownloadConfig) -> Result<()> {
     match config.driver_name {
         CHROMEDRIVER_NAME => {
             let driver_info = ChromedriverInfo::new(webdriver_bin.clone(), browser_path);
-            runtime
-                .block_on(async { download_with_retry(&driver_info, false, true, 1).await })
-                .with_context(|| {
-                    format!("Failed to download and install {}", config.driver_name)
-                })?;
+            let dl_res =
+                runtime.block_on(async { download_with_retry(&driver_info, false, true, 1).await });
+            if let Err(e) = dl_res {
+                return Err(anyhow!("Failed to download and install chromedriver").context(e));
+            }
         }
         GECKODRIVER_NAME => {
             let driver_info = GeckodriverInfo::new(webdriver_bin.clone(), browser_path);
-            runtime
-                .block_on(async { download_with_retry(&driver_info, false, true, 1).await })
-                .with_context(|| {
-                    format!("Failed to download and install {}", config.driver_name)
-                })?;
+            let dl_res =
+                runtime.block_on(async { download_with_retry(&driver_info, false, true, 1).await });
+            if let Err(e) = dl_res {
+                return Err(anyhow!("Failed to download and install geckodriver").context(e));
+            }
         }
         _ => return Err(anyhow!("Unsupported driver type: {}", config.driver_name)),
     }


### PR DESCRIPTION
## Description:

Maintainer requested that the CI fixes be split out from #392 into a separate PR.

This PR keeps only the CI/browser setup changes needed for the static export workflow:
- add a `setup-chrome` step id in the clippy job so later steps can reliably consume action outputs.
- adjust `plotly_static` webdriver download error handling so it fits the preinstalled browser/driver flow used in CI.

This keeps PR #397 scoped to CI fixes only.

Checklist:

- [x] I have reviewed all changes in this PR myself.
- [x] This PR does not include the axis-id/API changes from #392.
- [x] I have run formatting checks in WSL using `cargo +nightly fmt --all -- --check` and `cd examples && cargo +nightly fmt --all -- --check`.
- [x] I have run linting checks in WSL using `cargo clippy -p plotly_static --features chromedriver,webdriver_download -- -D warnings -A deprecated` and `cargo clippy -p plotly_static --features geckodriver,webdriver_download -- -D warnings -A deprecated`.
- [x] I have run focused local verification in WSL.

### The verification screenshots of the tests run, locally:

<img width="2269" height="171" alt="image" src="https://github.com/user-attachments/assets/d92d872b-8752-4917-867f-3e3dfe2b33c7" />

<img width="2536" height="1184" alt="image" src="https://github.com/user-attachments/assets/d2db7880-bfb2-423a-b6c8-374b3029c399" />

<img width="2300" height="1299" alt="image" src="https://github.com/user-attachments/assets/86413c27-7626-454a-8b36-763d845b0912" />


