### PR TITLE
ci: harden windows static export readiness

### DIFF
--- a/plotly_static/src/lib.rs
+++ b/plotly_static/src/lib.rs
@@ -1059,7 +1059,7 @@ impl AsyncStaticExporter {
         client.goto(&url).await?;
 
         #[cfg(target_os = "windows")]
-        Self::wait_for_document_ready(&client, std::time::Duration::from_secs(10)).await?;
+        Self::wait_for_document_ready(&client, std::time::Duration::from_secs(20)).await?;
 
         // Wait for Plotly container element
         #[cfg(target_os = "windows")]
@@ -1200,13 +1200,13 @@ impl AsyncStaticExporter {
             if has_el.as_bool().unwrap_or(false) {
                 return Ok(());
             }
+            if start.elapsed() > timeout {
+                return Err(anyhow!(
+                    "Timeout waiting for #plotly-html-element to appear in DOM"
+                ));
+            }
+            tokio::time::sleep(std::time::Duration::from_millis(50)).await;
         }
-        if start.elapsed() > timeout {
-            return Err(anyhow!(
-                "Timeout waiting for #plotly-html-element to appear in DOM"
-            ));
-        }
-        tokio::time::sleep(std::time::Duration::from_millis(50)).await;
     }
 
     #[cfg(target_os = "windows")]


### PR DESCRIPTION
## Description:

A flaky `windows-latest` Chrome CI run timed out waiting for `document.readyState` during `plot::tests::image_to_svg_string` even though the page finished loading immediately afterward.

This PR slightly hardens the Windows-only static export readiness path by widening the Windows-only `document.readyState` wait and fixing the `#plotly-html-element` timeout loop so the timeout path behaves as intended.

## Checklist:

- [x] I have run `cargo +nightly fmt --all -- --check` in WSL.
- [x] I have run `cargo test -p plotly plot::tests::image_to_svg_string --features plotly_ndarray,plotly_image,static_export_chromedriver,debug -- --nocapture` in WSL.