### PR TITLE
Add Treemap and Sunburst trace types; upgrade plotly.js from 3.0.1 to 3.6.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,10 @@ https://github.com/plotly/plotly.rs/pull/350
 - [[#NNN](https://github.com/plotly/plotly.rs/pull/NNN)] Add `Treemap` trace type, with `Tiling`/`PathBar` helpers, a dedicated `treemap::Marker` (`pad`/`corner_radius`/`depth_fade`), and `treemapcolorway`/`extendtreemapcolors` layout options
 - [[#NNN](https://github.com/plotly/plotly.rs/pull/NNN)] Add `Sunburst` trace type
 
+### Changed
+
+- [[#407](https://github.com/plotly/plotly.rs/issues/407)] Upgrade bundled plotly.js from 3.0.1 to 3.6.0
+
 ## [0.14.1] - 2026-02-15
 
 ### Fixed  

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,13 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/) a
 
 https://github.com/plotly/plotly.rs/pull/350
 
+## [Unreleased]
+
+### Added
+
+- [[#NNN](https://github.com/plotly/plotly.rs/pull/NNN)] Add `Treemap` trace type, with `Tiling`/`PathBar` helpers, a dedicated `treemap::Marker` (`pad`/`corner_radius`/`depth_fade`), and `treemapcolorway`/`extendtreemapcolors` layout options
+- [[#NNN](https://github.com/plotly/plotly.rs/pull/NNN)] Add `Sunburst` trace type
+
 ## [0.14.1] - 2026-02-15
 
 ### Fixed  

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,15 @@ https://github.com/plotly/plotly.rs/pull/350
 
 - [[#NNN](https://github.com/plotly/plotly.rs/pull/NNN)] Add `Treemap` trace type, with `Tiling`/`PathBar` helpers, a dedicated `treemap::Marker` (`pad`/`corner_radius`/`depth_fade`), and `treemapcolorway`/`extendtreemapcolors` layout options
 - [[#NNN](https://github.com/plotly/plotly.rs/pull/NNN)] Add `Sunburst` trace type
+- [[#407](https://github.com/plotly/plotly.rs/issues/407)] Expose plotly.js 3.1–3.6 attributes:
+  - `Layout`: `hoversort`, `hoveranywhere`, `clickanywhere`
+  - `Axis`: `zerolinelayer` (`ZeroLineLayer`), `minorloglabels`, `modebardisable` (`ModeBarDisable`), `ticklabelposition` (`TickLabelPosition`), `unifiedhovertitle` (`UnifiedHoverTitle`), and `ExponentFormat::SIExtended`
+  - `Legend`: `maxheight`
+  - `Configuration`: `displayNotifier`
+  - `common::Label` (hover labels): `showarrow`
+  - `common::Pattern`: `path` (arbitrary SVG path fill)
+  - `Candlestick`/`Ohlc`: `hovertemplate`
+  - `hovertemplatefallback`/`texttemplatefallback` across applicable traces
 
 ### Changed
 

--- a/docs/book/src/SUMMARY.md
+++ b/docs/book/src/SUMMARY.md
@@ -16,6 +16,8 @@
         - [Bar Charts](./recipes/basic_charts/bar_charts.md)
         - [Pie Charts](./recipes/basic_charts/pie_charts.md)
         - [Sankey Diagrams](./recipes/basic_charts/sankey_diagrams.md)
+        - [Treemap Charts](./recipes/basic_charts/treemap_charts.md)
+        - [Sunburst Charts](./recipes/basic_charts/sunburst_charts.md)
     - [Statistical Charts](./recipes/statistical_charts.md)
         - [Error Bars](./recipes/statistical_charts/error_bars.md)
         - [Box Plots](./recipes/statistical_charts/box_plots.md)

--- a/docs/book/src/recipes/basic_charts.md
+++ b/docs/book/src/recipes/basic_charts.md
@@ -9,3 +9,5 @@ Line Charts | [![Line Charts](./img/line_shape_options_for_interpolation.png)](.
 Bar Charts | [![Bar Charts](./img/bar_chart_with_error_bars.png)](./basic_charts/scatter_plots.md)
 Pie Charts | [![Pie Charts](./img/pie_charts.png)](./basic_charts/pie_charts.md)
 Sankey Diagrams | [![Sankey Diagrams](./img/basic_sankey.png)](./basic_charts/sankey_diagrams.md)
+Treemap Charts | [Treemap Charts](./basic_charts/treemap_charts.md)
+Sunburst Charts | [Sunburst Charts](./basic_charts/sunburst_charts.md)

--- a/docs/book/src/recipes/basic_charts/sunburst_charts.md
+++ b/docs/book/src/recipes/basic_charts/sunburst_charts.md
@@ -1,0 +1,27 @@
+# Sunburst Charts
+
+The following imports have been used to produce the plots below:
+
+```rust,no_run
+use plotly::common::Orientation;
+use plotly::sunburst::Leaf;
+use plotly::treemap::BranchValues;
+use plotly::{Plot, Sunburst};
+```
+
+The `to_inline_html` method is used to produce the html plot displayed in this page.
+
+## Basic Sunburst
+```rust,no_run
+{{#include ../../../../../examples/basic_charts/src/main.rs:basic_sunburst}}
+```
+
+{{#include ../../../../../examples/basic_charts/output/inline_basic_sunburst.html}}
+
+
+## Styled Sunburst with Branch Values and Leaf Opacity
+```rust,no_run
+{{#include ../../../../../examples/basic_charts/src/main.rs:styled_sunburst}}
+```
+
+{{#include ../../../../../examples/basic_charts/output/inline_styled_sunburst.html}}

--- a/docs/book/src/recipes/basic_charts/treemap_charts.md
+++ b/docs/book/src/recipes/basic_charts/treemap_charts.md
@@ -1,0 +1,25 @@
+# Treemap Charts
+
+The following imports have been used to produce the plots below:
+
+```rust,no_run
+use plotly::treemap::{BranchValues, Packing, PathBar, Side, Tiling};
+use plotly::{Plot, Treemap};
+```
+
+The `to_inline_html` method is used to produce the html plot displayed in this page.
+
+## Basic Treemap
+```rust,no_run
+{{#include ../../../../../examples/basic_charts/src/main.rs:basic_treemap}}
+```
+
+{{#include ../../../../../examples/basic_charts/output/inline_basic_treemap.html}}
+
+
+## Styled Treemap with Tiling and Path Bar
+```rust,no_run
+{{#include ../../../../../examples/basic_charts/src/main.rs:styled_treemap}}
+```
+
+{{#include ../../../../../examples/basic_charts/output/inline_styled_treemap.html}}

--- a/docs/book/theme/header.hbs
+++ b/docs/book/theme/header.hbs
@@ -1,1 +1,1 @@
-<script src="https://cdn.plot.ly/plotly-3.0.1.min.js"></script>
+<script src="https://cdn.plot.ly/plotly-3.6.0.min.js"></script>

--- a/examples/basic_charts/src/main.rs
+++ b/examples/basic_charts/src/main.rs
@@ -13,7 +13,7 @@ use plotly::{
         TicksDirection, TraceOrder,
     },
     sankey::{Line as SankeyLine, Link, Node},
-    sunburst::Leaf,
+    sunburst::{InsideTextOrientation, Leaf},
     traces::table::{
         Align as TableAlign, Cells, Fill as TableFill, Font as TableFont, Header, Line as TableLine,
     },
@@ -1135,7 +1135,7 @@ fn styled_sunburst(show: bool, file_name: &str) {
         .values(vec![8.0, 3.0, 5.0, 3.0, 5.0])
         .branch_values(BranchValues::Total)
         .leaf(Leaf::new().opacity(0.7))
-        .inside_text_orientation(Orientation::Radial);
+        .inside_text_orientation(InsideTextOrientation::Radial);
 
     let mut plot = Plot::new();
     plot.add_trace(trace);

--- a/examples/basic_charts/src/main.rs
+++ b/examples/basic_charts/src/main.rs
@@ -13,10 +13,12 @@ use plotly::{
         TicksDirection, TraceOrder,
     },
     sankey::{Line as SankeyLine, Link, Node},
+    sunburst::Leaf,
     traces::table::{
         Align as TableAlign, Cells, Fill as TableFill, Font as TableFont, Header, Line as TableLine,
     },
-    Bar, Pie, Plot, Sankey, Scatter, ScatterPolar, Table,
+    treemap::{BranchValues, Packing, PathBar, Side, Tiling},
+    Bar, Pie, Plot, Sankey, Scatter, ScatterPolar, Sunburst, Table, Treemap,
 };
 use plotly_utils::write_example_to_html;
 use rand_distr::{Distribution, Normal, Uniform};
@@ -1043,6 +1045,103 @@ fn grouped_donout_pie_charts(show: bool, file_name: &str) {
 }
 // ANCHOR_END: grouped_donout_pie_charts
 
+// ANCHOR: basic_treemap
+fn basic_treemap(show: bool, file_name: &str) {
+    let labels = vec![
+        "Eve", "Cain", "Seth", "Enos", "Noam", "Abel", "Awan", "Enoch", "Azura",
+    ];
+    let parents = vec![
+        "", "Eve", "Eve", "Seth", "Seth", "Eve", "Eve", "Awan", "Eve",
+    ];
+    let trace = Treemap::new(labels, parents)
+        .values(vec![10.0, 14.0, 12.0, 10.0, 2.0, 6.0, 6.0, 4.0, 4.0])
+        .text_info("label+value");
+
+    let mut plot = Plot::new();
+    plot.add_trace(trace);
+
+    let path = write_example_to_html(&plot, file_name);
+    if show {
+        plot.show_html(path);
+    }
+}
+// ANCHOR_END: basic_treemap
+
+// ANCHOR: styled_treemap
+fn styled_treemap(show: bool, file_name: &str) {
+    let labels = vec![
+        "Total",
+        "Tech",
+        "Health",
+        "Finance",
+        "Software",
+        "Hardware",
+        "Pharma",
+        "Devices",
+        "Banking",
+        "Insurance",
+    ];
+    let parents = vec![
+        "", "Total", "Total", "Total", "Tech", "Tech", "Health", "Health", "Finance", "Finance",
+    ];
+    let trace = Treemap::new(labels, parents)
+        .values(vec![0.0, 0.0, 0.0, 0.0, 40.0, 30.0, 25.0, 15.0, 20.0, 18.0])
+        .branch_values(BranchValues::Remainder)
+        .tiling(Tiling::new().packing(Packing::Binary).pad(2.0))
+        .path_bar(PathBar::new().visible(true).side(Side::Top))
+        .text_info("label+value+percent parent");
+
+    let mut plot = Plot::new();
+    plot.add_trace(trace);
+
+    let path = write_example_to_html(&plot, file_name);
+    if show {
+        plot.show_html(path);
+    }
+}
+// ANCHOR_END: styled_treemap
+
+// ANCHOR: basic_sunburst
+fn basic_sunburst(show: bool, file_name: &str) {
+    let labels = vec![
+        "Eve", "Cain", "Seth", "Enos", "Noam", "Abel", "Awan", "Enoch", "Azura",
+    ];
+    let parents = vec![
+        "", "Eve", "Eve", "Seth", "Seth", "Eve", "Eve", "Awan", "Eve",
+    ];
+    let trace = Sunburst::new(labels, parents)
+        .values(vec![10.0, 14.0, 12.0, 10.0, 2.0, 6.0, 6.0, 4.0, 4.0]);
+
+    let mut plot = Plot::new();
+    plot.add_trace(trace);
+
+    let path = write_example_to_html(&plot, file_name);
+    if show {
+        plot.show_html(path);
+    }
+}
+// ANCHOR_END: basic_sunburst
+
+// ANCHOR: styled_sunburst
+fn styled_sunburst(show: bool, file_name: &str) {
+    let labels = vec!["Root", "Branch A", "Branch B", "Leaf A1", "Leaf B1"];
+    let parents = vec!["", "Root", "Root", "Branch A", "Branch B"];
+    let trace = Sunburst::new(labels, parents)
+        .values(vec![8.0, 3.0, 5.0, 3.0, 5.0])
+        .branch_values(BranchValues::Total)
+        .leaf(Leaf::new().opacity(0.7))
+        .inside_text_orientation(Orientation::Radial);
+
+    let mut plot = Plot::new();
+    plot.add_trace(trace);
+
+    let path = write_example_to_html(&plot, file_name);
+    if show {
+        plot.show_html(path);
+    }
+}
+// ANCHOR_END: styled_sunburst
+
 // ANCHOR: set_lower_or_upper_bound_on_axis
 fn set_lower_or_upper_bound_on_axis(show: bool, file_name: &str) {
     use std::fs::File;
@@ -1199,6 +1298,14 @@ fn main() {
     pie_chart_text_control(false, "pie_chart_text_control");
 
     grouped_donout_pie_charts(false, "grouped_donout_pie_charts");
+
+    // Treemap Charts
+    basic_treemap(false, "basic_treemap");
+    styled_treemap(false, "styled_treemap");
+
+    // Sunburst Charts
+    basic_sunburst(false, "basic_sunburst");
+    styled_sunburst(false, "styled_sunburst");
 
     // Set Lower or Upper Bound on Axis
     set_lower_or_upper_bound_on_axis(false, "set_lower_or_upper_bound_on_axis");

--- a/examples/basic_charts/src/main.rs
+++ b/examples/basic_charts/src/main.rs
@@ -17,7 +17,7 @@ use plotly::{
     traces::table::{
         Align as TableAlign, Cells, Fill as TableFill, Font as TableFont, Header, Line as TableLine,
     },
-    treemap::{BranchValues, Packing, PathBar, Side, Tiling},
+    treemap::{BranchValues, Marker as TreemapMarker, Packing, PathBar, Side, Tiling},
     Bar, Pie, Plot, Sankey, Scatter, ScatterPolar, Sunburst, Table, Treemap,
 };
 use plotly_utils::write_example_to_html;
@@ -1087,6 +1087,11 @@ fn styled_treemap(show: bool, file_name: &str) {
     let trace = Treemap::new(labels, parents)
         .values(vec![0.0, 0.0, 0.0, 0.0, 40.0, 30.0, 25.0, 15.0, 20.0, 18.0])
         .branch_values(BranchValues::Remainder)
+        .marker(
+            TreemapMarker::new()
+                .corner_radius(5.0)
+                .line(Line::new().width(1.0).color(NamedColor::White)),
+        )
         .tiling(Tiling::new().packing(Packing::Binary).pad(2.0))
         .path_bar(PathBar::new().visible(true).side(Side::Top))
         .text_info("label+value+percent parent");

--- a/plotly/src/common/mod.rs
+++ b/plotly/src/common/mod.rs
@@ -614,6 +614,8 @@ pub enum ExponentFormat {
     SI,
     #[serde(rename = "B")]
     B,
+    #[serde(rename = "SI extended")]
+    SIExtended,
 }
 
 #[derive(Serialize, Clone, Debug)]
@@ -794,6 +796,9 @@ pub enum PatternFillMode {
 #[derive(Serialize, Clone, Debug, FieldSetter)]
 pub struct Pattern {
     shape: Option<Dim<PatternShape>>,
+    /// An arbitrary SVG path string to use as the pattern fill, as an
+    /// alternative to one of the preset `shape` values.
+    path: Option<String>,
     #[serde(rename = "fillmode")]
     fill_mode: Option<PatternFillMode>,
     #[serde(rename = "bgcolor")]
@@ -979,6 +984,10 @@ pub struct Label {
     align: Option<String>,
     #[serde(rename = "namelength")]
     name_length: Option<Dim<i32>>,
+    /// Determines whether or not the triangular caret pointing to the data
+    /// point is shown on the hover label box.
+    #[serde(rename = "showarrow")]
+    show_arrow: Option<bool>,
 }
 
 impl Label {
@@ -1624,6 +1633,10 @@ mod tests {
         assert_eq!(to_value(ExponentFormat::Power).unwrap(), json!("power"));
         assert_eq!(to_value(ExponentFormat::SI).unwrap(), json!("SI"));
         assert_eq!(to_value(ExponentFormat::B).unwrap(), json!("B"));
+        assert_eq!(
+            to_value(ExponentFormat::SIExtended).unwrap(),
+            json!("SI extended")
+        );
     }
 
     #[test]
@@ -1705,10 +1718,12 @@ mod tests {
             .foreground_color_array(vec![NamedColor::Red, NamedColor::Green])
             .foreground_opacity(0.9)
             .size_array(vec![10.0, 20.0])
-            .solidity_array(vec![0.1, 0.2]);
+            .solidity_array(vec![0.1, 0.2])
+            .path("M0,0 L10,10");
 
         let expected = json!({
             "shape": ["-", "|"],
+            "path": "M0,0 L10,10",
             "fillmode": "overlay",
             "bgcolor": ["black", "blue"],
             "fgcolor": ["red", "green"],
@@ -1889,13 +1904,15 @@ mod tests {
             .font(Font::new())
             .align("something")
             .name_length_array(vec![5, 10])
-            .name_length(6);
+            .name_length(6)
+            .show_arrow(false);
         let expected = json!({
             "bgcolor": "#FFFFFF",
             "bordercolor": "#000000",
             "font": {},
             "align": "something",
             "namelength": 6,
+            "showarrow": false,
         });
 
         assert_eq!(to_value(label).unwrap(), expected);

--- a/plotly/src/common/mod.rs
+++ b/plotly/src/common/mod.rs
@@ -798,7 +798,7 @@ pub struct Pattern {
     shape: Option<Dim<PatternShape>>,
     /// An arbitrary SVG path string to use as the pattern fill, as an
     /// alternative to one of the preset `shape` values.
-    path: Option<String>,
+    path: Option<Dim<String>>,
     #[serde(rename = "fillmode")]
     fill_mode: Option<PatternFillMode>,
     #[serde(rename = "bgcolor")]
@@ -1719,11 +1719,11 @@ mod tests {
             .foreground_opacity(0.9)
             .size_array(vec![10.0, 20.0])
             .solidity_array(vec![0.1, 0.2])
-            .path("M0,0 L10,10");
+            .path_array(vec!["M0,0 L10,10", "M5,5 L15,15"]);
 
         let expected = json!({
             "shape": ["-", "|"],
-            "path": "M0,0 L10,10",
+            "path": ["M0,0 L10,10", "M5,5 L15,15"],
             "fillmode": "overlay",
             "bgcolor": ["black", "blue"],
             "fgcolor": ["red", "green"],
@@ -1733,6 +1733,18 @@ mod tests {
         });
 
         assert_eq!(to_value(pattern).unwrap(), expected);
+    }
+
+    #[test]
+    fn serialize_pattern_path() {
+        let pattern = Pattern::new().path("M0,0 L10,10");
+        assert_eq!(to_value(pattern).unwrap(), json!({"path": "M0,0 L10,10"}));
+
+        let pattern = Pattern::new().path_array(vec!["M0,0 L10,10", "M5,5 L15,15"]);
+        assert_eq!(
+            to_value(pattern).unwrap(),
+            json!({"path": ["M0,0 L10,10", "M5,5 L15,15"]})
+        );
     }
 
     #[test]

--- a/plotly/src/common/mod.rs
+++ b/plotly/src/common/mod.rs
@@ -230,6 +230,8 @@ pub enum PlotType {
     DensityMapbox,
     Table,
     Pie,
+    Treemap,
+    Sunburst,
 }
 
 #[derive(Serialize, Clone, Debug)]

--- a/plotly/src/configuration.rs
+++ b/plotly/src/configuration.rs
@@ -185,6 +185,7 @@ pub struct Configuration {
     plot_gl_pixel_ratio: Option<PlotGLPixelRatio>,
     show_send_to_cloud: Option<bool>,
     queue_length: Option<usize>,
+    display_notifier: Option<bool>,
 }
 
 impl Configuration {
@@ -420,6 +421,13 @@ impl Configuration {
         self
     }
 
+    /// Determines whether the notifier is displayed in the top right area of
+    /// the viewport.
+    pub fn display_notifier(mut self, display_notifier: bool) -> Self {
+        self.display_notifier = Some(display_notifier);
+        self
+    }
+
     /// Sets which localization to use. When using this setting, make sure that
     /// the appropriate locale is present in the HTML file. For example, to
     /// use the "fr" locale, <script src="https://cdn.plot.ly/plotly-locale-fr-latest.js"></script> must be present.
@@ -552,6 +560,7 @@ mod tests {
             .topojson_url("topojson_url")
             .mapbox_access_token("123")
             .queue_length(100)
+            .display_notifier(true)
             .locale("en");
 
         let expected = json!({
@@ -583,6 +592,7 @@ mod tests {
             "topojsonURL": "topojson_url",
             "mapboxAccessToken": "123",
             "queueLength": 100,
+            "displayNotifier": true,
             "locale": "en"
         });
 

--- a/plotly/src/layout/axis.rs
+++ b/plotly/src/layout/axis.rs
@@ -6,7 +6,7 @@ use crate::common::{
     Anchor, AxisSide, Calendar, ColorBar, ColorScale, DashType, ExponentFormat, Font,
     TickFormatStop, TickMode, Title,
 };
-use crate::layout::RangeBreak;
+use crate::layout::{MinorLogLabels, RangeBreak};
 use crate::private::{NumOrString, NumOrStringCollection};
 
 #[derive(Serialize, Clone, Debug, PartialEq)]
@@ -441,6 +441,8 @@ pub struct Axis {
     ticks: Option<TicksDirection>,
     #[serde(rename = "tickson")]
     ticks_on: Option<TicksPosition>,
+    #[serde(rename = "ticklabelposition")]
+    tick_label_position: Option<TickLabelPosition>,
     mirror: Option<bool>,
     #[serde(rename = "ticklen")]
     tick_length: Option<usize>,
@@ -480,6 +482,8 @@ pub struct Axis {
     show_exponent: Option<ArrayShow>,
     #[serde(rename = "exponentformat")]
     exponent_format: Option<ExponentFormat>,
+    #[serde(rename = "minorloglabels")]
+    minor_log_labels: Option<MinorLogLabels>,
     #[serde(rename = "separatethousands")]
     separate_thousands: Option<bool>,
     #[serde(rename = "tickformat")]
@@ -506,6 +510,8 @@ pub struct Axis {
     zero_line_color: Option<Box<dyn Color>>,
     #[serde(rename = "zerolinewidth")]
     zero_line_width: Option<usize>,
+    #[serde(rename = "zerolinelayer")]
+    zero_line_layer: Option<ZeroLineLayer>,
     #[serde(rename = "showdividers")]
     show_dividers: Option<bool>,
     #[serde(rename = "dividercolor")]
@@ -515,6 +521,8 @@ pub struct Axis {
     anchor: Option<String>,
     side: Option<AxisSide>,
     overlaying: Option<String>,
+    #[serde(rename = "modebardisable")]
+    mode_bar_disable: Option<ModeBarDisable>,
     #[field_setter(skip)]
     domain: Option<Vec<f64>>,
     position: Option<f64>,
@@ -523,6 +531,73 @@ pub struct Axis {
     #[serde(rename = "rangeselector")]
     range_selector: Option<RangeSelector>,
     calendar: Option<Calendar>,
+    #[serde(rename = "unifiedhovertitle")]
+    unified_hover_title: Option<UnifiedHoverTitle>,
+}
+
+/// Determines whether the zero line is drawn above or below the traces of
+/// this cartesian axis.
+#[derive(Serialize, Debug, Clone, PartialEq)]
+pub enum ZeroLineLayer {
+    #[serde(rename = "above traces")]
+    AboveTraces,
+    #[serde(rename = "below traces")]
+    BelowTraces,
+}
+
+/// Determines the location of tick labels with respect to the ticks of a
+/// cartesian axis.
+#[derive(Serialize, Debug, Clone, PartialEq)]
+pub enum TickLabelPosition {
+    #[serde(rename = "outside")]
+    Outside,
+    #[serde(rename = "inside")]
+    Inside,
+    #[serde(rename = "outside top")]
+    OutsideTop,
+    #[serde(rename = "inside top")]
+    InsideTop,
+    #[serde(rename = "outside left")]
+    OutsideLeft,
+    #[serde(rename = "inside left")]
+    InsideLeft,
+    #[serde(rename = "outside right")]
+    OutsideRight,
+    #[serde(rename = "inside right")]
+    InsideRight,
+    #[serde(rename = "outside bottom")]
+    OutsideBottom,
+    #[serde(rename = "inside bottom")]
+    InsideBottom,
+}
+
+/// Determines which modebar buttons are disabled for this cartesian axis,
+/// giving fine control over which buttons affect which axes.
+#[derive(Serialize, Debug, Clone, PartialEq)]
+pub enum ModeBarDisable {
+    #[serde(rename = "none")]
+    None,
+    #[serde(rename = "autoscale")]
+    Autoscale,
+    #[serde(rename = "zoominout")]
+    ZoomInOut,
+    #[serde(rename = "autoscale+zoominout")]
+    AutoscaleAndZoomInOut,
+}
+
+/// Formats the title shown in unified hover labels for this cartesian axis.
+#[serde_with::skip_serializing_none]
+#[derive(Serialize, Debug, Clone, FieldSetter)]
+pub struct UnifiedHoverTitle {
+    /// Template string used for rendering the unified hover title. Variables
+    /// are inserted using `%{variable}`, e.g. `%{x}`.
+    text: Option<String>,
+}
+
+impl UnifiedHoverTitle {
+    pub fn new() -> Self {
+        Default::default()
+    }
 }
 
 impl Axis {
@@ -1008,6 +1083,53 @@ mod tests {
         // Backward compatible range() setter version with both ends
         let axis = Axis::new().range(vec!["2020-01-01", "2020-01-02"]);
         let expected = json!({ "range": ["2020-01-01", "2020-01-02"] });
+        assert_eq!(to_value(axis).unwrap(), expected);
+    }
+
+    #[test]
+    #[rustfmt::skip]
+    fn serialize_zero_line_layer() {
+        assert_eq!(to_value(ZeroLineLayer::AboveTraces).unwrap(), json!("above traces"));
+        assert_eq!(to_value(ZeroLineLayer::BelowTraces).unwrap(), json!("below traces"));
+    }
+
+    #[test]
+    #[rustfmt::skip]
+    fn serialize_tick_label_position() {
+        assert_eq!(to_value(TickLabelPosition::Outside).unwrap(), json!("outside"));
+        assert_eq!(to_value(TickLabelPosition::Inside).unwrap(), json!("inside"));
+        assert_eq!(to_value(TickLabelPosition::OutsideTop).unwrap(), json!("outside top"));
+        assert_eq!(to_value(TickLabelPosition::InsideBottom).unwrap(), json!("inside bottom"));
+    }
+
+    #[test]
+    #[rustfmt::skip]
+    fn serialize_mode_bar_disable() {
+        assert_eq!(to_value(ModeBarDisable::None).unwrap(), json!("none"));
+        assert_eq!(to_value(ModeBarDisable::Autoscale).unwrap(), json!("autoscale"));
+        assert_eq!(to_value(ModeBarDisable::ZoomInOut).unwrap(), json!("zoominout"));
+        assert_eq!(to_value(ModeBarDisable::AutoscaleAndZoomInOut).unwrap(), json!("autoscale+zoominout"));
+    }
+
+    #[test]
+    fn serialize_axis_new_3x_attributes() {
+        let axis = Axis::new()
+            .zero_line_layer(ZeroLineLayer::AboveTraces)
+            .minor_log_labels(MinorLogLabels::Complete)
+            .mode_bar_disable(ModeBarDisable::AutoscaleAndZoomInOut)
+            .tick_label_position(TickLabelPosition::Inside)
+            .exponent_format(ExponentFormat::SIExtended)
+            .unified_hover_title(UnifiedHoverTitle::new().text("%{x}"));
+
+        let expected = json!({
+            "zerolinelayer": "above traces",
+            "minorloglabels": "complete",
+            "modebardisable": "autoscale+zoominout",
+            "ticklabelposition": "inside",
+            "exponentformat": "SI extended",
+            "unifiedhovertitle": {"text": "%{x}"},
+        });
+
         assert_eq!(to_value(axis).unwrap(), expected);
     }
 }

--- a/plotly/src/layout/legend.rs
+++ b/plotly/src/layout/legend.rs
@@ -82,6 +82,10 @@ pub struct Legend {
     group_click: Option<GroupClick>,
     #[serde(rename = "itemwidth")]
     item_width: Option<usize>,
+    /// Sets the max height (in px) of a horizontal legend, or the max height
+    /// ratio (from 0 to 1) of a vertical legend.
+    #[serde(rename = "maxheight")]
+    max_height: Option<f64>,
 }
 
 impl Legend {
@@ -146,7 +150,8 @@ mod tests {
             .valign(VAlign::Middle)
             .title("title")
             .group_click(GroupClick::ToggleItem)
-            .item_width(50);
+            .item_width(50)
+            .max_height(200.0);
 
         let expected = json!({
             "bgcolor": "#123123",
@@ -166,7 +171,8 @@ mod tests {
             "valign": "middle",
             "title": {"text": "title"},
             "groupclick": "toggleitem",
-            "itemwidth": 50
+            "itemwidth": 50,
+            "maxheight": 200.0
         });
 
         assert_eq!(to_value(legend).unwrap(), expected)

--- a/plotly/src/layout/mod.rs
+++ b/plotly/src/layout/mod.rs
@@ -377,6 +377,10 @@ pub struct LayoutFields {
     sunburst_colorway: Option<Vec<Box<dyn Color>>>,
     #[serde(rename = "extendsunburstcolors")]
     extend_sunburst_colors: Option<bool>,
+    #[serde(rename = "treemapcolorway")]
+    treemap_colorway: Option<Vec<Box<dyn Color>>>,
+    #[serde(rename = "extendtreemapcolors")]
+    extend_treemap_colors: Option<bool>,
     mapbox: Option<Mapbox>,
     #[serde(rename = "updatemenus")]
     update_menus: Option<Vec<UpdateMenu>>,
@@ -545,6 +549,8 @@ mod tests {
             .extend_pie_colors(true)
             .sunburst_colorway(vec!["#654654"])
             .extend_sunburst_colors(false)
+            .treemap_colorway(vec!["#321321"])
+            .extend_treemap_colors(true)
             .mapbox(Mapbox::new())
             .update_menus(vec![UpdateMenu::new()])
             .sliders(vec![Slider::new()]);
@@ -620,6 +626,8 @@ mod tests {
             "extendpiecolors": true,
             "sunburstcolorway": ["#654654"],
             "extendsunburstcolors": false,
+            "treemapcolorway": ["#321321"],
+            "extendtreemapcolors": true,
             "mapbox": {},
             "updatemenus": [{}],
             "sliders": [{}],
@@ -704,6 +712,8 @@ mod tests {
             .extend_pie_colors(true)
             .sunburst_colorway(vec!["#654654"])
             .extend_sunburst_colors(false)
+            .treemap_colorway(vec!["#321321"])
+            .extend_treemap_colors(true)
             .z_axis(Axis::new())
             .scene(LayoutScene::new());
 
@@ -771,6 +781,8 @@ mod tests {
             "extendpiecolors": true,
             "sunburstcolorway": ["#654654"],
             "extendsunburstcolors": false,
+            "treemapcolorway": ["#321321"],
+            "extendtreemapcolors": true,
             "zaxis": {},
             "scene": {}
         });

--- a/plotly/src/layout/mod.rs
+++ b/plotly/src/layout/mod.rs
@@ -33,8 +33,9 @@ pub use self::animation::{
 pub use self::annotation::{Annotation, ArrowSide, ClickToShow};
 pub use self::axis::{
     ArrayShow, Axis, AxisConstrain, AxisRange, AxisType, CategoryOrder, ColorAxis,
-    ConstrainDirection, RangeMode, RangeSelector, RangeSlider, RangeSliderYAxis, SelectorButton,
-    SelectorStep, SliderRangeMode, SpikeMode, SpikeSnap, StepMode, TicksDirection, TicksPosition,
+    ConstrainDirection, ModeBarDisable, RangeMode, RangeSelector, RangeSlider, RangeSliderYAxis,
+    SelectorButton, SelectorStep, SliderRangeMode, SpikeMode, SpikeSnap, StepMode,
+    TickLabelPosition, TicksDirection, TicksPosition, UnifiedHoverTitle, ZeroLineLayer,
 };
 pub use self::geo::LayoutGeo;
 pub use self::grid::{GridDomain, GridPattern, GridXSide, GridYSide, LayoutGrid, RowOrder};
@@ -50,8 +51,8 @@ pub use self::polar::{
 };
 pub use self::rangebreaks::RangeBreak;
 pub use self::scene::{
-    AspectRatio, Camera, CameraCenter, DragMode, DragMode3D, Eye, HoverMode, LayoutScene,
-    Projection, ProjectionType, Rotation, Up,
+    AspectRatio, Camera, CameraCenter, DragMode, DragMode3D, Eye, HoverMode, HoverSort,
+    LayoutScene, Projection, ProjectionType, Rotation, Up,
 };
 pub use self::shape::{
     ActiveShape, DrawDirection, FillRule, NewShape, Shape, ShapeLayer, ShapeLine, ShapeSizeMode,
@@ -283,6 +284,12 @@ pub struct LayoutFields {
     spike_distance: Option<i32>,
     #[serde(rename = "hoverlabel")]
     hover_label: Option<Label>,
+    #[serde(rename = "hoversort")]
+    hover_sort: Option<HoverSort>,
+    #[serde(rename = "hoveranywhere")]
+    hover_anywhere: Option<bool>,
+    #[serde(rename = "clickanywhere")]
+    click_anywhere: Option<bool>,
     grid: Option<LayoutGrid>,
     calendar: Option<Calendar>,
     #[serde(rename = "xaxis")]
@@ -785,6 +792,22 @@ mod tests {
             "extendtreemapcolors": true,
             "zaxis": {},
             "scene": {}
+        });
+
+        assert_eq!(to_value(layout).unwrap(), expected);
+    }
+
+    #[test]
+    fn serialize_layout_hover_attributes() {
+        let layout = Layout::new()
+            .hover_sort(HoverSort::ValueDescending)
+            .hover_anywhere(true)
+            .click_anywhere(false);
+
+        let expected = json!({
+            "hoversort": "value descending",
+            "hoveranywhere": true,
+            "clickanywhere": false,
         });
 
         assert_eq!(to_value(layout).unwrap(), expected);

--- a/plotly/src/layout/scene.rs
+++ b/plotly/src/layout/scene.rs
@@ -457,6 +457,17 @@ impl Serialize for HoverMode {
     }
 }
 
+/// Determines the order in which items in a unified hover label are sorted.
+#[derive(Serialize, Debug, Clone, PartialEq)]
+pub enum HoverSort {
+    #[serde(rename = "trace")]
+    Trace,
+    #[serde(rename = "value descending")]
+    ValueDescending,
+    #[serde(rename = "value ascending")]
+    ValueAscending,
+}
+
 #[serde_with::skip_serializing_none]
 #[derive(Serialize, Debug, Clone, FieldSetter)]
 /// 3D scene layout

--- a/plotly/src/lib.rs
+++ b/plotly/src/lib.rs
@@ -61,12 +61,13 @@ pub use plot::{Plot, Trace, Traces};
 // Also provide easy access to modules which contain additional trace-specific types
 pub use traces::{
     box_plot, contour, heat_map, histogram, image, mesh3d, sankey, scatter, scatter3d,
-    scatter_mapbox, surface,
+    scatter_mapbox, sunburst, surface, treemap,
 };
 // Bring the different trace types into the top-level scope
 pub use traces::{
     Bar, BoxPlot, Candlestick, Contour, DensityMapbox, HeatMap, Histogram, Image, Mesh3D, Ohlc,
-    Pie, Sankey, Scatter, Scatter3D, ScatterGeo, ScatterMapbox, ScatterPolar, Surface, Table,
+    Pie, Sankey, Scatter, Scatter3D, ScatterGeo, ScatterMapbox, ScatterPolar, Sunburst, Surface,
+    Table, Treemap,
 };
 
 pub trait Restyle: serde::Serialize {}

--- a/plotly/src/plot.rs
+++ b/plotly/src/plot.rs
@@ -757,7 +757,7 @@ impl Plot {
     /// This function provides HTML script tags that load JavaScript libraries
     /// from external CDN sources, requiring an internet connection to
     /// function. The referenced sources include:
-    /// - Plotly.js library from CDN (version 3.0.1)
+    /// - Plotly.js library from CDN (version 3.6.0)
     /// - MathJax tex-svg from jsDelivr CDN (version 3.2.2)
     ///
     /// This is the default behavior when the `plotly_embed_js` feature is
@@ -767,7 +767,7 @@ impl Plot {
         // Note that since 'tex-mml-chtml' conflicts with 'tex-svg' when generating
         // Latex Titles we no longer include it.
         r##"<script src="https://cdn.jsdelivr.net/npm/mathjax@3.2.2/es5/tex-svg.js"></script>
-        <script src="https://cdn.plot.ly/plotly-3.0.1.min.js"></script>
+        <script src="https://cdn.plot.ly/plotly-3.6.0.min.js"></script>
         "##
         .to_string()
     }

--- a/plotly/src/traces/bar.rs
+++ b/plotly/src/traces/bar.rs
@@ -63,12 +63,16 @@ where
     text_position: Option<Dim<TextPosition>>,
     #[serde(rename = "texttemplate")]
     text_template: Option<Dim<String>>,
+    #[serde(rename = "texttemplatefallback")]
+    text_template_fallback: Option<Dim<String>>,
     #[serde(rename = "hovertext")]
     hover_text: Option<Dim<String>>,
     #[serde(rename = "hoverinfo")]
     hover_info: Option<HoverInfo>,
     #[serde(rename = "hovertemplate")]
     hover_template: Option<Dim<String>>,
+    #[serde(rename = "hovertemplatefallback")]
+    hover_template_fallback: Option<Dim<String>>,
     #[serde(rename = "xaxis")]
     x_axis: Option<XAxisId>,
     #[serde(rename = "yaxis")]

--- a/plotly/src/traces/box_plot.rs
+++ b/plotly/src/traces/box_plot.rs
@@ -123,6 +123,8 @@ where
     hover_info: Option<HoverInfo>,
     #[serde(rename = "hovertemplate")]
     hover_template: Option<Dim<String>>,
+    #[serde(rename = "hovertemplatefallback")]
+    hover_template_fallback: Option<Dim<String>>,
     #[serde(rename = "xaxis")]
     x_axis: Option<XAxisId>,
     #[serde(rename = "yaxis")]

--- a/plotly/src/traces/candlestick.rs
+++ b/plotly/src/traces/candlestick.rs
@@ -72,6 +72,10 @@ where
     hover_text: Option<Dim<String>>,
     #[serde(rename = "hoverinfo")]
     hover_info: Option<HoverInfo>,
+    #[serde(rename = "hovertemplate")]
+    hover_template: Option<Dim<String>>,
+    #[serde(rename = "hovertemplatefallback")]
+    hover_template_fallback: Option<Dim<String>>,
     #[serde(rename = "xaxis")]
     x_axis: Option<XAxisId>,
     #[serde(rename = "yaxis")]
@@ -152,6 +156,8 @@ mod tests {
         .hover_text_array(vec!["hover", "text"])
         .hover_text("hover text")
         .hover_info(HoverInfo::Skip)
+        .hover_template("%{close}")
+        .hover_template_fallback("n/a")
         .x_axis("x1")
         .y_axis("y1")
         .line(Line::new())
@@ -177,6 +183,8 @@ mod tests {
             "text": "text here",
             "hovertext": "hover text",
             "hoverinfo": "skip",
+            "hovertemplate": "%{close}",
+            "hovertemplatefallback": "n/a",
             "xaxis": "x1",
             "yaxis": "y1",
             "line": {},

--- a/plotly/src/traces/contour.rs
+++ b/plotly/src/traces/contour.rs
@@ -136,6 +136,8 @@ where
     hover_info: Option<HoverInfo>,
     #[serde(rename = "hovertemplate")]
     hover_template: Option<Dim<String>>,
+    #[serde(rename = "hovertemplatefallback")]
+    hover_template_fallback: Option<Dim<String>>,
     #[serde(rename = "xaxis")]
     x_axis: Option<XAxisId>,
     #[serde(rename = "yaxis")]
@@ -203,6 +205,7 @@ where
             hover_text: None,
             hover_info: None,
             hover_template: None,
+            hover_template_fallback: None,
             x_axis: None,
             y_axis: None,
             line: None,

--- a/plotly/src/traces/heat_map.rs
+++ b/plotly/src/traces/heat_map.rs
@@ -86,6 +86,8 @@ where
     hover_on_gaps: Option<bool>,
     #[serde(rename = "hovertemplate")]
     hover_template: Option<Dim<String>>,
+    #[serde(rename = "hovertemplatefallback")]
+    hover_template_fallback: Option<Dim<String>>,
     #[serde(rename = "hovertext")]
     #[field_setter(with_matrix)]
     hover_text: Option<Dim<String>>,

--- a/plotly/src/traces/histogram.rs
+++ b/plotly/src/traces/histogram.rs
@@ -133,6 +133,8 @@ where
     hover_label: Option<Label>,
     #[serde(rename = "hovertemplate")]
     hover_template: Option<Dim<String>>,
+    #[serde(rename = "hovertemplatefallback")]
+    hover_template_fallback: Option<Dim<String>>,
     #[serde(rename = "hovertext")]
     hover_text: Option<Dim<String>>,
     #[serde(rename = "legendgroup")]

--- a/plotly/src/traces/image.rs
+++ b/plotly/src/traces/image.rs
@@ -258,6 +258,8 @@ pub struct Image {
     /// completely, use an empty tag `<extra></extra>`.
     #[serde(rename = "hovertemplate")]
     hover_template: Option<Dim<String>>,
+    #[serde(rename = "hovertemplatefallback")]
+    hover_template_fallback: Option<Dim<String>>,
 
     /// Assigns extra meta information associated with this trace that can be
     /// used in various text attributes. Attributes such as trace `name`,

--- a/plotly/src/traces/mesh3d.rs
+++ b/plotly/src/traces/mesh3d.rs
@@ -203,6 +203,8 @@ where
     /// completely, use an empty tag `<extra></extra>`.
     #[serde(rename = "hovertemplate")]
     hover_template: Option<Dim<String>>,
+    #[serde(rename = "hovertemplatefallback")]
+    hover_template_fallback: Option<Dim<String>>,
     /// Sets the hover text formatting rulefor `x` using d3 formatting
     /// mini-languages which are very similar to those in Python. For numbers, see: <https://github.com/d3/d3-format/tree/v1.4.5#d3-format>. And for dates
     /// see: <https://github.com/d3/d3-time-format/tree/v2.2.3#locale_format>. We add two items to d3's date

--- a/plotly/src/traces/mod.rs
+++ b/plotly/src/traces/mod.rs
@@ -17,8 +17,10 @@ pub mod scatter3d;
 pub mod scatter_geo;
 pub mod scatter_mapbox;
 mod scatter_polar;
+pub mod sunburst;
 pub mod surface;
 pub mod table;
+pub mod treemap;
 
 pub use bar::Bar;
 pub use box_plot::BoxPlot;
@@ -36,7 +38,9 @@ pub use scatter3d::Scatter3D;
 pub use scatter_geo::ScatterGeo;
 pub use scatter_mapbox::ScatterMapbox;
 pub use scatter_polar::ScatterPolar;
+pub use sunburst::Sunburst;
 pub use surface::Surface;
 pub use table::Table;
+pub use treemap::Treemap;
 
 pub use self::image::Image;

--- a/plotly/src/traces/ohlc.rs
+++ b/plotly/src/traces/ohlc.rs
@@ -57,6 +57,10 @@ where
     hover_label: Option<Label>,
     #[serde(rename = "hovertext")]
     hover_text: Option<Dim<String>>,
+    #[serde(rename = "hovertemplate")]
+    hover_template: Option<Dim<String>>,
+    #[serde(rename = "hovertemplatefallback")]
+    hover_template_fallback: Option<Dim<String>>,
     increasing: Option<Direction>,
     #[serde(rename = "legendgroup")]
     legend_group: Option<String>,

--- a/plotly/src/traces/pie.rs
+++ b/plotly/src/traces/pie.rs
@@ -113,6 +113,8 @@ where
     /// box completely, use an empty tag <extra></extra>.
     #[serde(rename = "hovertemplate")]
     hover_template: Option<Dim<String>>,
+    #[serde(rename = "hovertemplatefallback")]
+    hover_template_fallback: Option<Dim<String>>,
     /// Sets hover text elements associated with each sector. If a single
     /// string, the same string appears for all data points. If an array of
     /// string, the items are mapped in order of this trace’s sectors. To be
@@ -217,6 +219,8 @@ where
     /// access to variables label, color, value, percent and text.
     #[serde(rename = "texttemplate")]
     text_template: Option<Dim<String>>,
+    #[serde(rename = "texttemplatefallback")]
+    text_template_fallback: Option<Dim<String>>,
     /// Controls persistence of some user-driven changes to the trace:
     /// constraintrange in parcoords traces, as well as some editable: true
     /// modifications such as name and colorbar.title. Defaults to

--- a/plotly/src/traces/scatter.rs
+++ b/plotly/src/traces/scatter.rs
@@ -128,6 +128,8 @@ where
     /// per-point (the ones that are `arrayOk: true`) are available.
     #[serde(rename = "texttemplate")]
     text_template: Option<Dim<String>>,
+    #[serde(rename = "texttemplatefallback")]
+    text_template_fallback: Option<Dim<String>>,
     /// Sets hover text elements associated with each (x,y) pair. If a single
     /// string, the same string appears over all the data points. If an
     /// array of string, the items are mapped in order to the this trace's
@@ -159,6 +161,8 @@ where
     /// completely, use an empty tag `<extra></extra>`.
     #[serde(rename = "hovertemplate")]
     hover_template: Option<Dim<String>>,
+    #[serde(rename = "hovertemplatefallback")]
+    hover_template_fallback: Option<Dim<String>>,
     /// Assigns extra meta information associated with this trace that can be
     /// used in various text attributes. Attributes such as trace `name`,
     /// graph, axis and colorbar `title.text`, annotation `text`
@@ -452,6 +456,7 @@ mod tests {
             .hover_text_array(vec!["hover_text"])
             .hover_template("hover_template")
             .hover_template_array(vec!["hover_template"])
+            .hover_template_fallback("hover_template_fallback")
             .ids(vec!["1"])
             .legend_group("legend_group")
             .legend_group_title("Legend Group Title")
@@ -472,6 +477,7 @@ mod tests {
             .text_position_array(vec![Position::MiddleLeft])
             .text_template("text_template")
             .text_template_array(vec!["text_template"])
+            .text_template_fallback("text_template_fallback")
             .visible(Visible::True)
             .x_axis("x_axis")
             .x_calendar(Calendar::Chinese)
@@ -500,6 +506,7 @@ mod tests {
             "hoveron": "points",
             "hovertext": ["hover_text"],
             "hovertemplate": ["hover_template"],
+            "hovertemplatefallback": "hover_template_fallback",
             "ids": ["1"],
             "legendgroup": "legend_group",
             "legendgrouptitle": {"text": "Legend Group Title"},
@@ -517,6 +524,7 @@ mod tests {
             "textfont": {},
             "textposition": ["middle left"],
             "texttemplate": ["text_template"],
+            "texttemplatefallback": "text_template_fallback",
             "visible": true,
             "xaxis": "x_axis",
             "xcalendar": "chinese",

--- a/plotly/src/traces/scatter3d.rs
+++ b/plotly/src/traces/scatter3d.rs
@@ -154,6 +154,8 @@ where
     /// per-point (the ones that are `arrayOk: true`) are available.
     #[serde(rename = "texttemplate")]
     text_template: Option<Dim<String>>,
+    #[serde(rename = "texttemplatefallback")]
+    text_template_fallback: Option<Dim<String>>,
     /// Sets hover text elements associated with each (x, y, z) triplet. The
     /// same text will be associated with all data points. To be seen, the
     /// trace `hover_info` must contain a "Text" flag.
@@ -182,6 +184,8 @@ where
     /// completely, use an empty tag `<extra></extra>`.
     #[serde(rename = "hovertemplate")]
     hover_template: Option<Dim<String>>,
+    #[serde(rename = "hovertemplatefallback")]
+    hover_template_fallback: Option<Dim<String>>,
     /// Sets the hover text formatting rulefor `x` using d3 formatting
     /// mini-languages which are very similar to those in Python. For numbers, see: <https://github.com/d3/d3-format/tree/v1.4.5#d3-format>. And for
     /// dates see: <https://github.com/d3/d3-time-format/tree/v2.2.3#locale_format>. We add two items to d3's

--- a/plotly/src/traces/scatter_geo.rs
+++ b/plotly/src/traces/scatter_geo.rs
@@ -130,6 +130,8 @@ where
     /// per-point (the ones that are `arrayOk: true`) are available.
     #[serde(rename = "texttemplate")]
     text_template: Option<Dim<String>>,
+    #[serde(rename = "texttemplatefallback")]
+    text_template_fallback: Option<Dim<String>>,
     /// Sets hover text elements associated with each (x,y) pair. If a single
     /// string, the same string appears over all the data points. If an
     /// array of string, the items are mapped in order to the this trace's
@@ -161,6 +163,8 @@ where
     /// completely, use an empty tag `<extra></extra>`.
     #[serde(rename = "hovertemplate")]
     hover_template: Option<Dim<String>>,
+    #[serde(rename = "hovertemplatefallback")]
+    hover_template_fallback: Option<Dim<String>>,
 
     /// Assigns extra meta information associated with this trace that can be
     /// used in various text attributes. Attributes such as trace `name`,

--- a/plotly/src/traces/scatter_mapbox.rs
+++ b/plotly/src/traces/scatter_mapbox.rs
@@ -130,6 +130,8 @@ where
     /// per-point (the ones that are `arrayOk: true`) are available.
     #[serde(rename = "texttemplate")]
     text_template: Option<Dim<String>>,
+    #[serde(rename = "texttemplatefallback")]
+    text_template_fallback: Option<Dim<String>>,
     /// Sets hover text elements associated with each (x,y) pair. If a single
     /// string, the same string appears over all the data points. If an
     /// array of string, the items are mapped in order to the this trace's
@@ -161,6 +163,8 @@ where
     /// completely, use an empty tag `<extra></extra>`.
     #[serde(rename = "hovertemplate")]
     hover_template: Option<Dim<String>>,
+    #[serde(rename = "hovertemplatefallback")]
+    hover_template_fallback: Option<Dim<String>>,
 
     /// Assigns extra meta information associated with this trace that can be
     /// used in various text attributes. Attributes such as trace `name`,

--- a/plotly/src/traces/scatter_polar.rs
+++ b/plotly/src/traces/scatter_polar.rs
@@ -115,6 +115,8 @@ where
     /// per-point (the ones that are `arrayOk: true`) are available.
     #[serde(rename = "texttemplate")]
     text_template: Option<Dim<String>>,
+    #[serde(rename = "texttemplatefallback")]
+    text_template_fallback: Option<Dim<String>>,
     /// Sets hover text elements associated with each (x,y) pair. If a single
     /// string, the same string appears over all the data points. If an
     /// array of string, the items are mapped in order to the this trace's
@@ -146,6 +148,8 @@ where
     /// completely, use an empty tag `<extra></extra>`.
     #[serde(rename = "hovertemplate")]
     hover_template: Option<Dim<String>>,
+    #[serde(rename = "hovertemplatefallback")]
+    hover_template_fallback: Option<Dim<String>>,
     /// Assigns extra meta information associated with this trace that can be
     /// used in various text attributes. Attributes such as trace `name`,
     /// graph, axis and colorbar `title.text`, annotation `text`

--- a/plotly/src/traces/sunburst.rs
+++ b/plotly/src/traces/sunburst.rs
@@ -116,6 +116,8 @@ where
     /// points.
     #[serde(rename = "texttemplate")]
     text_template: Option<Dim<String>>,
+    #[serde(rename = "texttemplatefallback")]
+    text_template_fallback: Option<Dim<String>>,
     /// Sets the font used for `text_info`.
     #[serde(rename = "textfont")]
     text_font: Option<Font>,
@@ -140,6 +142,8 @@ where
     /// hover box.
     #[serde(rename = "hovertemplate")]
     hover_template: Option<Dim<String>>,
+    #[serde(rename = "hovertemplatefallback")]
+    hover_template_fallback: Option<Dim<String>>,
     /// Assigns extra meta information associated with this trace that can be
     /// used in various text attributes.
     meta: Option<NumOrString>,

--- a/plotly/src/traces/sunburst.rs
+++ b/plotly/src/traces/sunburst.rs
@@ -6,9 +6,24 @@ use serde::Serialize;
 use crate::private::{NumOrString, NumOrStringCollection};
 use crate::traces::treemap::BranchValues;
 use crate::{
-    common::{Dim, Domain, Font, HoverInfo, Label, Marker, Orientation, PlotType},
+    common::{Dim, Domain, Font, HoverInfo, Label, Marker, PlotType},
     Trace,
 };
+
+/// Controls the orientation of the text inside the sectors of a [`Sunburst`].
+///
+/// Unlike the general [`crate::common::Orientation`] (which serializes to the
+/// single-letter codes `h`/`v` used by bars, boxes and legends), Plotly's
+/// `insidetextorientation` attribute expects the full words `horizontal`,
+/// `radial`, `tangential` or `auto`.
+#[derive(Serialize, Clone, Debug)]
+#[serde(rename_all = "lowercase")]
+pub enum InsideTextOrientation {
+    Horizontal,
+    Radial,
+    Tangential,
+    Auto,
+}
 
 /// Configures the appearance of the leaf nodes of a [`Sunburst`].
 #[serde_with::skip_serializing_none]
@@ -129,7 +144,7 @@ where
     outside_text_font: Option<Font>,
     /// Controls the orientation of the text inside chart sectors.
     #[serde(rename = "insidetextorientation")]
-    inside_text_orientation: Option<Orientation>,
+    inside_text_orientation: Option<InsideTextOrientation>,
     /// Determines which trace information appears on hover.
     #[serde(rename = "hoverinfo")]
     hover_info: Option<HoverInfo>,
@@ -218,7 +233,7 @@ mod tests {
             .text_font(Font::new())
             .inside_text_font(Font::new())
             .outside_text_font(Font::new())
-            .inside_text_orientation(Orientation::Radial)
+            .inside_text_orientation(InsideTextOrientation::Radial)
             .hover_info(HoverInfo::All)
             .hover_label(Label::new())
             .hover_template("%{label}: %{value}")
@@ -247,7 +262,7 @@ mod tests {
             "textfont": {},
             "insidetextfont": {},
             "outsidetextfont": {},
-            "insidetextorientation": "r",
+            "insidetextorientation": "radial",
             "hoverinfo": "all",
             "hoverlabel": {},
             "hovertemplate": "%{label}: %{value}",

--- a/plotly/src/traces/sunburst.rs
+++ b/plotly/src/traces/sunburst.rs
@@ -1,0 +1,257 @@
+//! Sunburst trace
+
+use plotly_derive::FieldSetter;
+use serde::Serialize;
+
+use crate::private::{NumOrString, NumOrStringCollection};
+use crate::traces::treemap::BranchValues;
+use crate::{
+    common::{Dim, Domain, Font, HoverInfo, Label, Marker, Orientation, PlotType},
+    Trace,
+};
+
+/// Configures the appearance of the leaf nodes of a [`Sunburst`].
+#[serde_with::skip_serializing_none]
+#[derive(Serialize, Clone, Debug, FieldSetter)]
+pub struct Leaf {
+    /// Sets the opacity of the leaves. With colorscale it is defaulted to `1`;
+    /// otherwise it is defaulted to `0.7`.
+    opacity: Option<f64>,
+}
+
+impl Leaf {
+    pub fn new() -> Self {
+        Default::default()
+    }
+}
+
+/// Construct a Sunburst trace.
+///
+/// Sunburst charts visualize hierarchical data spanning outwards radially from
+/// the root to the leaves. The hierarchy is defined via the `labels` and
+/// `parents` fields (the root is the item whose parent is an empty string).
+///
+/// # Examples
+///
+/// ```
+/// use plotly::Sunburst;
+///
+/// let trace = Sunburst::new(
+///     vec!["Eve", "Cain", "Seth"],
+///     vec!["", "Eve", "Eve"],
+/// )
+/// .values(vec![10, 14, 12]);
+///
+/// let expected = serde_json::json!({
+///     "type": "sunburst",
+///     "labels": ["Eve", "Cain", "Seth"],
+///     "parents": ["", "Eve", "Eve"],
+///     "values": [10, 14, 12],
+/// });
+///
+/// assert_eq!(serde_json::to_value(trace).unwrap(), expected);
+/// ```
+#[serde_with::skip_serializing_none]
+#[derive(Serialize, Clone, Debug, FieldSetter)]
+#[field_setter(box_self, kind = "trace")]
+pub struct Sunburst<V>
+where
+    V: Serialize + Clone,
+{
+    #[field_setter(default = "PlotType::Sunburst")]
+    r#type: PlotType,
+    /// Sets the trace name. The trace name appears as the legend item and on
+    /// hover.
+    name: Option<String>,
+    /// Determines whether or not this trace is visible.
+    visible: Option<bool>,
+    /// Sets the opacity of the trace.
+    opacity: Option<f64>,
+    /// Assigns id labels to each datum. These ids are for object constancy of
+    /// data points during animation.
+    ids: Option<Vec<String>>,
+    /// Sets the labels of each of the sectors.
+    labels: Option<Vec<String>>,
+    /// Sets the parent sectors for each of the sectors. Empty string items
+    /// `""` are understood to reference the root node in the hierarchy.
+    parents: Option<Vec<String>>,
+    /// Sets the values associated with each of the sectors. Use with
+    /// `branch_values` to determine how the values are summed.
+    values: Option<Vec<V>>,
+    /// Determines how the items in `values` are summed. When set to
+    /// `Remainder`, the value of a parent is the sum of its `values` plus those
+    /// of its children. When set to `Total`, the value of a parent is the total
+    /// of its children.
+    #[serde(rename = "branchvalues")]
+    branch_values: Option<BranchValues>,
+    /// Determines default for `values` when it is not provided, by inferring a
+    /// `count`, i.e. the number of `"branches"` or `"leaves"`.
+    count: Option<String>,
+    /// Sets the level from which this trace hierarchy is rendered. Set `level`
+    /// to `""` to start from the root node in the hierarchy.
+    level: Option<NumOrString>,
+    /// Sets the number of rendered sectors from any given `level`. Set
+    /// `max_depth` to `-1` to render all the levels in the hierarchy.
+    #[serde(rename = "maxdepth")]
+    max_depth: Option<i32>,
+    /// Sets the domain within which this trace is drawn.
+    domain: Option<Domain>,
+    marker: Option<Marker>,
+    /// Sets the styling of the leaves of the sunburst.
+    leaf: Option<Leaf>,
+    /// Rotates the whole diagram counterclockwise by some angle. By default the
+    /// first slice starts at 3 o'clock. The 'rotation' property is a number
+    /// between -360 and 360.
+    rotation: Option<f64>,
+    /// Determines whether or not the sectors are reordered from largest to
+    /// smallest.
+    sort: Option<bool>,
+    /// Sets text elements associated with each sector. If trace `text_info`
+    /// contains a `"text"` flag, these elements will be seen on the chart.
+    text: Option<Dim<String>>,
+    /// Determines which trace information appears on the graph.
+    #[serde(rename = "textinfo")]
+    text_info: Option<String>,
+    /// Template string used for rendering the information text that appears on
+    /// points.
+    #[serde(rename = "texttemplate")]
+    text_template: Option<Dim<String>>,
+    /// Sets the font used for `text_info`.
+    #[serde(rename = "textfont")]
+    text_font: Option<Font>,
+    /// Sets the font used for `text_info` lying inside the sector.
+    #[serde(rename = "insidetextfont")]
+    inside_text_font: Option<Font>,
+    /// Sets the font used for `text_info` lying outside the sector.
+    #[serde(rename = "outsidetextfont")]
+    outside_text_font: Option<Font>,
+    /// Controls the orientation of the text inside chart sectors.
+    #[serde(rename = "insidetextorientation")]
+    inside_text_orientation: Option<Orientation>,
+    /// Determines which trace information appears on hover.
+    #[serde(rename = "hoverinfo")]
+    hover_info: Option<HoverInfo>,
+    #[serde(rename = "hoverlabel")]
+    hover_label: Option<Label>,
+    /// Sets hover text elements associated with each sector.
+    #[serde(rename = "hovertext")]
+    hover_text: Option<Dim<String>>,
+    /// Template string used for rendering the information that appears on the
+    /// hover box.
+    #[serde(rename = "hovertemplate")]
+    hover_template: Option<Dim<String>>,
+    /// Assigns extra meta information associated with this trace that can be
+    /// used in various text attributes.
+    meta: Option<NumOrString>,
+    /// Assigns extra data to each datum that can be used in hover, click and
+    /// selection events.
+    #[serde(rename = "customdata")]
+    custom_data: Option<NumOrStringCollection>,
+    /// Assign an id to this trace. Use this to provide object constancy between
+    /// traces during animations and transitions.
+    uid: Option<String>,
+}
+
+impl<V> Sunburst<V>
+where
+    V: Serialize + Clone + 'static,
+{
+    /// Build a new Sunburst trace from its `labels` and `parents`.
+    ///
+    /// The root sector is the one whose parent is an empty string `""`.
+    pub fn new<L, P>(labels: Vec<L>, parents: Vec<P>) -> Box<Self>
+    where
+        L: Into<String>,
+        P: Into<String>,
+    {
+        Box::new(Self {
+            labels: Some(labels.into_iter().map(Into::into).collect()),
+            parents: Some(parents.into_iter().map(Into::into).collect()),
+            ..Default::default()
+        })
+    }
+}
+
+impl<V> Trace for Sunburst<V>
+where
+    V: Serialize + Clone,
+{
+    fn to_json(&self) -> String {
+        serde_json::to_string(self).unwrap()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use serde_json::{json, to_value};
+
+    use super::*;
+
+    #[test]
+    fn serialize_leaf() {
+        let leaf = Leaf::new().opacity(0.7);
+        assert_eq!(to_value(leaf).unwrap(), json!({ "opacity": 0.7 }));
+    }
+
+    #[test]
+    fn serialize_sunburst() {
+        let trace = Sunburst::new(vec!["Eve", "Cain", "Seth"], vec!["", "Eve", "Eve"])
+            .values(vec![10, 14, 12])
+            .branch_values(BranchValues::Remainder)
+            .count("leaves")
+            .level("Eve")
+            .max_depth(2)
+            .name("family")
+            .visible(true)
+            .opacity(0.8)
+            .ids(vec!["eve", "cain", "seth"])
+            .domain(Domain::new())
+            .marker(Marker::new())
+            .leaf(Leaf::new().opacity(0.6))
+            .rotation(45.0)
+            .sort(true)
+            .text_info("label+value")
+            .text_font(Font::new())
+            .inside_text_font(Font::new())
+            .outside_text_font(Font::new())
+            .inside_text_orientation(Orientation::Radial)
+            .hover_info(HoverInfo::All)
+            .hover_label(Label::new())
+            .hover_template("%{label}: %{value}")
+            .meta("meta")
+            .custom_data(vec!["custom_data"])
+            .uid("uid-1");
+        let expected = json!({
+            "type": "sunburst",
+            "labels": ["Eve", "Cain", "Seth"],
+            "parents": ["", "Eve", "Eve"],
+            "values": [10, 14, 12],
+            "branchvalues": "remainder",
+            "count": "leaves",
+            "level": "Eve",
+            "maxdepth": 2,
+            "name": "family",
+            "visible": true,
+            "opacity": 0.8,
+            "ids": ["eve", "cain", "seth"],
+            "domain": {},
+            "marker": {},
+            "leaf": {"opacity": 0.6},
+            "rotation": 45.0,
+            "sort": true,
+            "textinfo": "label+value",
+            "textfont": {},
+            "insidetextfont": {},
+            "outsidetextfont": {},
+            "insidetextorientation": "r",
+            "hoverinfo": "all",
+            "hoverlabel": {},
+            "hovertemplate": "%{label}: %{value}",
+            "meta": "meta",
+            "customdata": ["custom_data"],
+            "uid": "uid-1",
+        });
+
+        assert_eq!(to_value(trace).unwrap(), expected);
+    }
+}

--- a/plotly/src/traces/surface.rs
+++ b/plotly/src/traces/surface.rs
@@ -145,6 +145,8 @@ where
     hover_label: Option<Label>,
     #[serde(rename = "hovertemplate")]
     hover_template: Option<Dim<String>>,
+    #[serde(rename = "hovertemplatefallback")]
+    hover_template_fallback: Option<Dim<String>>,
     #[serde(rename = "hovertext")]
     hover_text: Option<Dim<String>>,
     #[serde(rename = "legendgroup")]

--- a/plotly/src/traces/treemap.rs
+++ b/plotly/src/traces/treemap.rs
@@ -304,6 +304,8 @@ where
     /// points.
     #[serde(rename = "texttemplate")]
     text_template: Option<Dim<String>>,
+    #[serde(rename = "texttemplatefallback")]
+    text_template_fallback: Option<Dim<String>>,
     /// Sets the font used for `text_info`.
     #[serde(rename = "textfont")]
     text_font: Option<Font>,
@@ -328,6 +330,8 @@ where
     /// hover box.
     #[serde(rename = "hovertemplate")]
     hover_template: Option<Dim<String>>,
+    #[serde(rename = "hovertemplatefallback")]
+    hover_template_fallback: Option<Dim<String>>,
     /// Assigns extra meta information associated with this trace that can be
     /// used in various text attributes.
     meta: Option<NumOrString>,

--- a/plotly/src/traces/treemap.rs
+++ b/plotly/src/traces/treemap.rs
@@ -1,0 +1,375 @@
+//! Treemap trace
+
+use plotly_derive::FieldSetter;
+use serde::Serialize;
+
+use crate::private::{NumOrString, NumOrStringCollection};
+use crate::{
+    common::{Dim, Domain, Font, HoverInfo, Label, Marker, PlotType, Position},
+    Trace,
+};
+
+/// Determines how the items in `values` are summed up the hierarchy.
+///
+/// When set to `Remainder`, the value of a parent sector is the sum of its
+/// `values` plus the values of its child sectors. When set to `Total`, the
+/// value of a parent sector is taken to be the total of its child sectors.
+#[derive(Serialize, Clone, Debug)]
+#[serde(rename_all = "lowercase")]
+pub enum BranchValues {
+    Remainder,
+    Total,
+}
+
+/// Determines the tiling algorithm used to lay out the rectangles.
+#[derive(Serialize, Clone, Debug)]
+#[serde(rename_all = "kebab-case")]
+pub enum Packing {
+    Squarify,
+    Binary,
+    Dice,
+    Slice,
+    SliceDice,
+    DiceSlice,
+}
+
+/// Determines on which side of the the treemap the `pathbar` should be
+/// presented.
+#[derive(Serialize, Clone, Debug)]
+#[serde(rename_all = "lowercase")]
+pub enum Side {
+    Top,
+    Bottom,
+}
+
+/// Configures the tiling behaviour of a [`Treemap`].
+#[serde_with::skip_serializing_none]
+#[derive(Serialize, Clone, Debug, FieldSetter)]
+pub struct Tiling {
+    /// Determines the tiling algorithm used to lay out the rectangles.
+    packing: Option<Packing>,
+    /// When using `Packing::Squarify`, this option determines the aspect ratio
+    /// targeted for each tile. The default value of `1` produces tiles that
+    /// are as square as possible.
+    #[serde(rename = "squarifyratio")]
+    squarify_ratio: Option<f64>,
+    /// Determines if the positions obtained from solver are flipped on each
+    /// axis. Valid combinations of `"x"` and `"y"` (e.g. `"x"`, `"y"`,
+    /// `"x+y"`).
+    flip: Option<String>,
+    /// Sets the inner padding (in px) between sectors.
+    pad: Option<f64>,
+}
+
+impl Tiling {
+    pub fn new() -> Self {
+        Default::default()
+    }
+}
+
+/// Configures the `pathbar` (the breadcrumb header) of a [`Treemap`].
+#[serde_with::skip_serializing_none]
+#[derive(Serialize, Clone, Debug, FieldSetter)]
+pub struct PathBar {
+    /// Determines if the path bar is drawn.
+    visible: Option<bool>,
+    /// Determines on which side of the treemap the path bar is presented.
+    side: Option<Side>,
+    /// Determines which shape is used to draw the edges between the path bar's
+    /// sectors. One of `">"`, `"<"`, `"|"`, `"/"` or `"\\"`.
+    #[serde(rename = "edgeshape")]
+    edge_shape: Option<String>,
+    /// Sets the thickness of the path bar (in px).
+    thickness: Option<usize>,
+    /// Sets the font used inside the path bar.
+    #[serde(rename = "textfont")]
+    text_font: Option<Font>,
+}
+
+impl PathBar {
+    pub fn new() -> Self {
+        Default::default()
+    }
+}
+
+/// Construct a Treemap trace.
+///
+/// Treemap charts visualize hierarchical data using nested rectangles. The
+/// hierarchy is defined via the `labels` and `parents` fields (the root is the
+/// item whose parent is an empty string).
+///
+/// # Examples
+///
+/// ```
+/// use plotly::Treemap;
+///
+/// let trace = Treemap::new(
+///     vec!["Eve", "Cain", "Seth"],
+///     vec!["", "Eve", "Eve"],
+/// )
+/// .values(vec![10, 14, 12]);
+///
+/// let expected = serde_json::json!({
+///     "type": "treemap",
+///     "labels": ["Eve", "Cain", "Seth"],
+///     "parents": ["", "Eve", "Eve"],
+///     "values": [10, 14, 12],
+/// });
+///
+/// assert_eq!(serde_json::to_value(trace).unwrap(), expected);
+/// ```
+///
+/// Note: the treemap-specific `marker.pad`, `marker.cornerradius` and
+/// `marker.depthfade` attributes are not yet exposed; the shared
+/// [`Marker`](crate::common::Marker) is reused, providing colors, color scales,
+/// color bars and outline styling.
+#[serde_with::skip_serializing_none]
+#[derive(Serialize, Clone, Debug, FieldSetter)]
+#[field_setter(box_self, kind = "trace")]
+pub struct Treemap<V>
+where
+    V: Serialize + Clone,
+{
+    #[field_setter(default = "PlotType::Treemap")]
+    r#type: PlotType,
+    /// Sets the trace name. The trace name appears as the legend item and on
+    /// hover.
+    name: Option<String>,
+    /// Determines whether or not this trace is visible.
+    visible: Option<bool>,
+    /// Sets the opacity of the trace.
+    opacity: Option<f64>,
+    /// Assigns id labels to each datum. These ids are for object constancy of
+    /// data points during animation.
+    ids: Option<Vec<String>>,
+    /// Sets the labels of each of the sectors.
+    labels: Option<Vec<String>>,
+    /// Sets the parent sectors for each of the sectors. Empty string items
+    /// `""` are understood to reference the root node in the hierarchy.
+    parents: Option<Vec<String>>,
+    /// Sets the values associated with each of the sectors. Use with
+    /// `branch_values` to determine how the values are summed.
+    values: Option<Vec<V>>,
+    /// Determines how the items in `values` are summed. When set to
+    /// `Remainder`, the value of a parent is the sum of its `values` plus those
+    /// of its children. When set to `Total`, the value of a parent is the total
+    /// of its children.
+    #[serde(rename = "branchvalues")]
+    branch_values: Option<BranchValues>,
+    /// Determines default for `values` when it is not provided, by inferring a
+    /// `count`, i.e. the number of `"branches"` or `"leaves"`.
+    count: Option<String>,
+    /// Sets the level from which this trace hierarchy is rendered. Set `level`
+    /// to `""` to start from the root node in the hierarchy.
+    level: Option<NumOrString>,
+    /// Sets the number of rendered sectors from any given `level`. Set
+    /// `max_depth` to `-1` to render all the levels in the hierarchy.
+    #[serde(rename = "maxdepth")]
+    max_depth: Option<i32>,
+    /// Sets the domain within which this trace is drawn.
+    domain: Option<Domain>,
+    marker: Option<Marker>,
+    /// Sets the tiling behaviour of the treemap.
+    tiling: Option<Tiling>,
+    /// Sets the path bar (breadcrumb header) of the treemap.
+    #[serde(rename = "pathbar")]
+    path_bar: Option<PathBar>,
+    /// Determines whether or not the sectors are reordered from largest to
+    /// smallest.
+    sort: Option<bool>,
+    /// Sets text elements associated with each sector. If trace `text_info`
+    /// contains a `"text"` flag, these elements will be seen on the chart.
+    text: Option<Dim<String>>,
+    /// Determines which trace information appears on the graph.
+    #[serde(rename = "textinfo")]
+    text_info: Option<String>,
+    /// Template string used for rendering the information text that appears on
+    /// points.
+    #[serde(rename = "texttemplate")]
+    text_template: Option<Dim<String>>,
+    /// Sets the font used for `text_info`.
+    #[serde(rename = "textfont")]
+    text_font: Option<Font>,
+    /// Sets the positions of the `text` elements.
+    #[serde(rename = "textposition")]
+    text_position: Option<Position>,
+    /// Sets the font used for `text_info` lying inside the sector.
+    #[serde(rename = "insidetextfont")]
+    inside_text_font: Option<Font>,
+    /// Sets the font used for `text_info` lying outside the sector.
+    #[serde(rename = "outsidetextfont")]
+    outside_text_font: Option<Font>,
+    /// Determines which trace information appears on hover.
+    #[serde(rename = "hoverinfo")]
+    hover_info: Option<HoverInfo>,
+    #[serde(rename = "hoverlabel")]
+    hover_label: Option<Label>,
+    /// Sets hover text elements associated with each sector.
+    #[serde(rename = "hovertext")]
+    hover_text: Option<Dim<String>>,
+    /// Template string used for rendering the information that appears on the
+    /// hover box.
+    #[serde(rename = "hovertemplate")]
+    hover_template: Option<Dim<String>>,
+    /// Assigns extra meta information associated with this trace that can be
+    /// used in various text attributes.
+    meta: Option<NumOrString>,
+    /// Assigns extra data to each datum that can be used in hover, click and
+    /// selection events.
+    #[serde(rename = "customdata")]
+    custom_data: Option<NumOrStringCollection>,
+    /// Assign an id to this trace. Use this to provide object constancy between
+    /// traces during animations and transitions.
+    uid: Option<String>,
+}
+
+impl<V> Treemap<V>
+where
+    V: Serialize + Clone + 'static,
+{
+    /// Build a new Treemap trace from its `labels` and `parents`.
+    ///
+    /// The root sector is the one whose parent is an empty string `""`.
+    pub fn new<L, P>(labels: Vec<L>, parents: Vec<P>) -> Box<Self>
+    where
+        L: Into<String>,
+        P: Into<String>,
+    {
+        Box::new(Self {
+            labels: Some(labels.into_iter().map(Into::into).collect()),
+            parents: Some(parents.into_iter().map(Into::into).collect()),
+            ..Default::default()
+        })
+    }
+}
+
+impl<V> Trace for Treemap<V>
+where
+    V: Serialize + Clone,
+{
+    fn to_json(&self) -> String {
+        serde_json::to_string(self).unwrap()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use serde_json::{json, to_value};
+
+    use super::*;
+
+    #[test]
+    fn serialize_branch_values() {
+        assert_eq!(
+            to_value(BranchValues::Remainder).unwrap(),
+            json!("remainder")
+        );
+        assert_eq!(to_value(BranchValues::Total).unwrap(), json!("total"));
+    }
+
+    #[test]
+    fn serialize_packing() {
+        assert_eq!(to_value(Packing::Squarify).unwrap(), json!("squarify"));
+        assert_eq!(to_value(Packing::Binary).unwrap(), json!("binary"));
+        assert_eq!(to_value(Packing::Dice).unwrap(), json!("dice"));
+        assert_eq!(to_value(Packing::Slice).unwrap(), json!("slice"));
+        assert_eq!(to_value(Packing::SliceDice).unwrap(), json!("slice-dice"));
+        assert_eq!(to_value(Packing::DiceSlice).unwrap(), json!("dice-slice"));
+    }
+
+    #[test]
+    fn serialize_tiling() {
+        let tiling = Tiling::new()
+            .packing(Packing::SliceDice)
+            .squarify_ratio(1.5)
+            .flip("x+y")
+            .pad(2.0);
+        let expected = json!({
+            "packing": "slice-dice",
+            "squarifyratio": 1.5,
+            "flip": "x+y",
+            "pad": 2.0,
+        });
+        assert_eq!(to_value(tiling).unwrap(), expected);
+    }
+
+    #[test]
+    fn serialize_path_bar() {
+        let path_bar = PathBar::new()
+            .visible(true)
+            .side(Side::Top)
+            .edge_shape(">")
+            .thickness(20)
+            .text_font(Font::new());
+        let expected = json!({
+            "visible": true,
+            "side": "top",
+            "edgeshape": ">",
+            "thickness": 20,
+            "textfont": {},
+        });
+        assert_eq!(to_value(path_bar).unwrap(), expected);
+    }
+
+    #[test]
+    fn serialize_treemap() {
+        let trace = Treemap::new(vec!["Eve", "Cain", "Seth"], vec!["", "Eve", "Eve"])
+            .values(vec![10, 14, 12])
+            .branch_values(BranchValues::Total)
+            .count("leaves")
+            .level("Eve")
+            .max_depth(3)
+            .name("family")
+            .visible(true)
+            .opacity(0.8)
+            .ids(vec!["eve", "cain", "seth"])
+            .domain(Domain::new())
+            .marker(Marker::new())
+            .tiling(Tiling::new().packing(Packing::Squarify))
+            .path_bar(PathBar::new().visible(true).side(Side::Top))
+            .sort(true)
+            .text_info("label+value")
+            .text_font(Font::new())
+            .text_position(Position::TopCenter)
+            .inside_text_font(Font::new())
+            .outside_text_font(Font::new())
+            .hover_info(HoverInfo::All)
+            .hover_label(Label::new())
+            .hover_template("%{label}: %{value}")
+            .meta("meta")
+            .custom_data(vec!["custom_data"])
+            .uid("uid-1");
+        let expected = json!({
+            "type": "treemap",
+            "labels": ["Eve", "Cain", "Seth"],
+            "parents": ["", "Eve", "Eve"],
+            "values": [10, 14, 12],
+            "branchvalues": "total",
+            "count": "leaves",
+            "level": "Eve",
+            "maxdepth": 3,
+            "name": "family",
+            "visible": true,
+            "opacity": 0.8,
+            "ids": ["eve", "cain", "seth"],
+            "domain": {},
+            "marker": {},
+            "tiling": {"packing": "squarify"},
+            "pathbar": {"visible": true, "side": "top"},
+            "sort": true,
+            "textinfo": "label+value",
+            "textfont": {},
+            "textposition": "top center",
+            "insidetextfont": {},
+            "outsidetextfont": {},
+            "hoverinfo": "all",
+            "hoverlabel": {},
+            "hovertemplate": "%{label}: %{value}",
+            "meta": "meta",
+            "customdata": ["custom_data"],
+            "uid": "uid-1",
+        });
+
+        assert_eq!(to_value(trace).unwrap(), expected);
+    }
+}

--- a/plotly/src/traces/treemap.rs
+++ b/plotly/src/traces/treemap.rs
@@ -3,9 +3,13 @@
 use plotly_derive::FieldSetter;
 use serde::Serialize;
 
+use crate::color::{Color, ColorArray};
 use crate::private::{NumOrString, NumOrStringCollection};
 use crate::{
-    common::{Dim, Domain, Font, HoverInfo, Label, Marker, PlotType, Position},
+    common::{
+        ColorBar, ColorScale, Dim, Domain, Font, HoverInfo, Label, Line, Pattern, PlotType,
+        Position,
+    },
     Trace,
 };
 
@@ -92,6 +96,120 @@ impl PathBar {
     }
 }
 
+/// Sets the inner padding (in px) of the treemap tiles.
+#[serde_with::skip_serializing_none]
+#[derive(Serialize, Clone, Debug, FieldSetter)]
+pub struct Pad {
+    /// Sets the padding form the top (in px).
+    #[serde(rename = "t")]
+    top: Option<f64>,
+    /// Sets the padding form the left (in px).
+    #[serde(rename = "l")]
+    left: Option<f64>,
+    /// Sets the padding form the right (in px).
+    #[serde(rename = "r")]
+    right: Option<f64>,
+    /// Sets the padding form the bottom (in px).
+    #[serde(rename = "b")]
+    bottom: Option<f64>,
+}
+
+impl Pad {
+    pub fn new() -> Self {
+        Default::default()
+    }
+}
+
+/// Determines if the sector colors are faded towards the background color of
+/// the chart as a function of depth.
+///
+/// Serializes to the values understood by Plotly.js: `Enabled` -> `true`,
+/// `Disabled` -> `false`, `Reversed` -> `"reversed"`.
+#[derive(Clone, Debug)]
+pub enum DepthFade {
+    Enabled,
+    Disabled,
+    Reversed,
+}
+
+impl Serialize for DepthFade {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        match self {
+            DepthFade::Enabled => serializer.serialize_bool(true),
+            DepthFade::Disabled => serializer.serialize_bool(false),
+            DepthFade::Reversed => serializer.serialize_str("reversed"),
+        }
+    }
+}
+
+/// Configures the appearance of the sectors of a [`Treemap`].
+///
+/// This is a treemap-specific marker: in addition to the shared
+/// color/colorscale machinery it exposes `pad`, `corner_radius` and
+/// `depth_fade`, which the common [`Marker`](crate::common::Marker) does not.
+#[serde_with::skip_serializing_none]
+#[derive(Serialize, Clone, Debug, FieldSetter)]
+pub struct Marker {
+    /// Sets the color of each sector of the treemap. If not specified, the
+    /// default trace color set is used to pick the sector colors.
+    #[field_setter(skip)]
+    colors: Option<Vec<Box<dyn Color>>>,
+    /// Determines whether the colorscale is a default palette (`true`) or the
+    /// palette determined by `cmin` and `cmax`.
+    cauto: Option<bool>,
+    /// Sets the lower bound of the color domain.
+    cmin: Option<f64>,
+    /// Sets the upper bound of the color domain.
+    cmax: Option<f64>,
+    /// Sets the mid-point of the color domain by scaling `cmin` and/or `cmax`
+    /// to be equidistant to this point.
+    cmid: Option<f64>,
+    /// Sets the colorscale.
+    #[serde(rename = "colorscale")]
+    color_scale: Option<ColorScale>,
+    /// Determines whether the colorscale is picked using the sign of the input
+    /// `colors`.
+    #[serde(rename = "autocolorscale")]
+    auto_color_scale: Option<bool>,
+    /// Reverses the color mapping if `true`.
+    #[serde(rename = "reversescale")]
+    reverse_scale: Option<bool>,
+    /// Determines whether or not a colorbar is displayed.
+    #[serde(rename = "showscale")]
+    show_scale: Option<bool>,
+    /// Sets the colorbar.
+    #[serde(rename = "colorbar")]
+    color_bar: Option<ColorBar>,
+    /// Sets the outline of the sectors.
+    line: Option<Line>,
+    /// Sets the pattern within the sectors.
+    pattern: Option<Pattern>,
+    /// Sets the inner padding (in px) of the tiles.
+    pad: Option<Pad>,
+    /// Sets the maximum rounding of the corners (in px) of the tiles.
+    #[serde(rename = "cornerradius")]
+    corner_radius: Option<f64>,
+    /// Determines if the sector colors are faded towards the background color
+    /// of the chart as a function of depth.
+    #[serde(rename = "depthfade")]
+    depth_fade: Option<DepthFade>,
+}
+
+impl Marker {
+    pub fn new() -> Self {
+        Default::default()
+    }
+
+    /// Sets the color of each sector of the treemap.
+    pub fn colors<C: Color>(mut self, colors: Vec<C>) -> Self {
+        self.colors = Some(ColorArray(colors).into());
+        self
+    }
+}
+
 /// Construct a Treemap trace.
 ///
 /// Treemap charts visualize hierarchical data using nested rectangles. The
@@ -119,10 +237,9 @@ impl PathBar {
 /// assert_eq!(serde_json::to_value(trace).unwrap(), expected);
 /// ```
 ///
-/// Note: the treemap-specific `marker.pad`, `marker.cornerradius` and
-/// `marker.depthfade` attributes are not yet exposed; the shared
-/// [`Marker`](crate::common::Marker) is reused, providing colors, color scales,
-/// color bars and outline styling.
+/// Treemap styling uses the treemap-specific [`Marker`], which exposes the
+/// `pad`, `corner_radius` and `depth_fade` attributes in addition to the shared
+/// color/colorscale/line machinery.
 #[serde_with::skip_serializing_none]
 #[derive(Serialize, Clone, Debug, FieldSetter)]
 #[field_setter(box_self, kind = "trace")]
@@ -309,6 +426,39 @@ mod tests {
             "textfont": {},
         });
         assert_eq!(to_value(path_bar).unwrap(), expected);
+    }
+
+    #[test]
+    fn serialize_depth_fade() {
+        assert_eq!(to_value(DepthFade::Enabled).unwrap(), json!(true));
+        assert_eq!(to_value(DepthFade::Disabled).unwrap(), json!(false));
+        assert_eq!(to_value(DepthFade::Reversed).unwrap(), json!("reversed"));
+    }
+
+    #[test]
+    fn serialize_marker() {
+        let marker = Marker::new()
+            .colors(vec!["#1f77b4", "#ff7f0e"])
+            .show_scale(true)
+            .cmin(0.0)
+            .cmax(10.0)
+            .line(Line::new().width(2.0))
+            .pattern(Pattern::new())
+            .pad(Pad::new().top(1.0).left(2.0).right(3.0).bottom(4.0))
+            .corner_radius(5.0)
+            .depth_fade(DepthFade::Reversed);
+        let expected = json!({
+            "colors": ["#1f77b4", "#ff7f0e"],
+            "showscale": true,
+            "cmin": 0.0,
+            "cmax": 10.0,
+            "line": {"width": 2.0},
+            "pattern": {},
+            "pad": {"t": 1.0, "l": 2.0, "r": 3.0, "b": 4.0},
+            "cornerradius": 5.0,
+            "depthfade": "reversed",
+        });
+        assert_eq!(to_value(marker).unwrap(), expected);
     }
 
     #[test]

--- a/plotly/templates/jupyter_notebook_plot.html
+++ b/plotly/templates/jupyter_notebook_plot.html
@@ -1,7 +1,7 @@
 <div>
     <div id="{{ plot_div_id }}" class="plotly-graph-div" style="height:100%; width:100%;"></div>
     <script type="text/javascript">
-        require(['https://cdn.plot.ly/plotly-3.0.1.min.js'], function(Plotly) {
+        require(['https://cdn.plot.ly/plotly-3.6.0.min.js'], function(Plotly) {
             Plotly.newPlot(
                 "{{ plot_div_id }}",
                 {{ plot| tojson | safe }}

--- a/plotly_static/src/template.rs
+++ b/plotly_static/src/template.rs
@@ -271,7 +271,7 @@ fn offline_js_sources() -> String {
 fn online_js_cdn() -> String {
     // tex-mml-chtml conflicts with tex-svg when generating Latex Titles
     r##"
-    <script src="https://cdn.plot.ly/plotly-3.0.1.min.js"></script>
+    <script src="https://cdn.plot.ly/plotly-3.6.0.min.js"></script>
     <script src="https://cdn.jsdelivr.net/npm/mathjax@3.2.2/es5/tex-svg.js"></script>
     <script src="https://cdnjs.cloudflare.com/ajax/libs/html2pdf.js/0.10.1/html2pdf.bundle.min.js"></script>
     "##


### PR DESCRIPTION
Adds two hierarchical trace types — `Treemap` and `Sunburst` — to the `plotly` crate, upgrades the bundled Plotly.js, and exposes the new attributes that came with it. The trace types follow the existing `Pie` pattern and share Plotly's `labels`/`parents`/`ids`/`values` data model.

## What's added

### Trace types
- **`Treemap<V>`**: hierarchy fields (`branch_values`, `count`, `level`, `max_depth`), `domain`, full text/hover set, `Tiling` (`Packing`) and `PathBar` (`Side`) helper structs, and a dedicated `treemap::Marker` exposing the treemap-only `pad`, `corner_radius`, and `depth_fade` attributes (on top of the shared color/colorscale/colorbar/line/pattern machinery).
- **`Sunburst<V>`**: same hierarchy/text/hover set plus `Leaf`, `rotation`, and `inside_text_orientation`.
- New `PlotType::Treemap` / `PlotType::Sunburst` variants and top-level re-exports; new `treemapcolorway` / `extendtreemapcolors` layout options.

### Bundled Plotly.js upgrade (#407)
- Upgraded the vendored/CDN Plotly.js from **3.0.1 → 3.6.0** (latest). Replaced the three vendored `plotly.min.js` copies (`plotly/resource`, `plotly_static/resource`, `docs/book`) and the pinned CDN version strings in `plot.rs`, the Jupyter template, `plotly_static/template.rs`, and the book header.

### New 3.1–3.6 attributes exposed
Additive bindings for the user-facing attributes added across Plotly.js 3.1.0 → 3.6.0, following the existing `Option<T>` + `FieldSetter` pattern:
- **`Layout`**: `hoversort` (`HoverSort`), `hoveranywhere`, `clickanywhere`
- **`Axis`**: `zerolinelayer` (`ZeroLineLayer`), `minorloglabels`, `modebardisable` (`ModeBarDisable`), `ticklabelposition` (`TickLabelPosition`), `unifiedhovertitle` (`UnifiedHoverTitle`), and `ExponentFormat::SIExtended`
- **`Legend`**: `maxheight`
- **`Configuration`**: `displayNotifier`
- **`common::Label`** (hover labels): `showarrow`
- **`common::Pattern`**: `path` (arbitrary SVG path fill, `arrayOk`)
- **`Candlestick`/`Ohlc`**: `hovertemplate`
- `hovertemplatefallback` / `texttemplatefallback` across applicable traces

### Tests & docs
- Unit tests + doctests for the new trace types and attributes, four `basic_charts` examples, and book pages.

## Compatibility note
Because `FieldSetter`/`layout_structs` generate a per-field variant in the `Restyle*`/`RelayoutLayout` enums, adding any field is a semver-breaking change (`cargo-semver-checks` flags `enum_variant_added`). Combined with the new `PlotType` and `ExponentFormat` variants, this targets the next breaking release (**0.15.0**).

I used Claude Code Opus 4.8 and reviewed the code and tested it with my project - [qsv](https://github.com/dathere/qsv).

See https://github.com/dathere/qsv/wiki/Visualization

Closes #405
Closes #407
